### PR TITLE
ci: Fixed Manual `.aab` Build Workflow

### DIFF
--- a/.github/workflows/playstore-review.yml
+++ b/.github/workflows/playstore-review.yml
@@ -11,7 +11,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 25
+          fetch-tags: true
 
+      - name: Check available tags
+        run: git tag
+      
       - name: Save Commit Tag as Environment Variable & Display it
         run: |
           COMMIT_TAG=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This fixes a draft of the workflow currently in the `main` branch, where we fail to find the latest tag (or any tag) with `git describe --tags --abbrev=0`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adding `fetch-tags: true` wasn't enough for `actions/checkout@v4` — we expected this would fetch all tags per documentation as it claimed "Whether to fetch tags, even if fetch-depth > 0.".

We needed to add a larger `fetch-depth` (defaults to `fetch-depth: 1`) to be able to get the latest tags. It seems `fetch-tags: true` & `fetch-depth: x` gets only the tags found in the `x` latest commits instead of all tags.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [ ] This diff will work correctly for `pnpm android:prod`.
