### PR TITLE
fix: Error throw for `\` or `/` in playlist name

### DIFF
--- a/src/api/playlists/[id].ts
+++ b/src/api/playlists/[id].ts
@@ -133,7 +133,7 @@ export const useUpdatePlaylist = (playlistName: string) => {
             latest: { type: "playlist", id: newName, name: newName },
           },
         });
-        router.replace(`/playlist/${newName}`);
+        router.replace(`/playlist/${encodeURIComponent(newName)}`);
       } else {
         resynchronizeFn({
           action: "update",

--- a/src/app/(app)/(current)/album/[id].tsx
+++ b/src/app/(app)/(current)/album/[id].tsx
@@ -58,7 +58,7 @@ export default function CurrentAlbumScreen() {
           title={data.name}
           SubtitleComponent={
             <Link
-              href={`/artist/${data.artistName}`}
+              href={`/artist/${encodeURIComponent(data.artistName)}`}
               numberOfLines={1}
               className="self-start font-geistMonoLight text-xs text-accent50"
             >

--- a/src/app/(app)/(home)/artist.tsx
+++ b/src/app/(app)/(home)/artist.tsx
@@ -33,7 +33,9 @@ export default function ArtistScreen() {
           ) : (
             <View className="mb-2">
               <ActionButton
-                onPress={() => router.navigate(`/artist/${item.name}`)}
+                onPress={() =>
+                  router.navigate(`/artist/${encodeURIComponent(item.name)}`)
+                }
                 textContent={item.textContent}
                 icon={{ Element: <ArrowRight size={24} /> }}
               />

--- a/src/db/utils/formatters.ts
+++ b/src/db/utils/formatters.ts
@@ -72,7 +72,7 @@ export function formatForMediaCard({ type, data }: FnArgs) {
         ? `/album/${data.id}`
         : type === "playlist" && data.name === SpecialPlaylists.tracks
           ? "/track"
-          : `/${type}/${data.name}`,
+          : `/${type}/${encodeURIComponent(data.name)}`,
     title: data.name,
     subtitle: type === "album" ? data.artistName : trackStr,
     extra: type === "album" ? `| ${trackStr}` : null,

--- a/src/features/modal/modals/TrackModal.tsx
+++ b/src/features/modal/modals/TrackModal.tsx
@@ -95,7 +95,7 @@ export function TrackModal({ id, origin }: Props) {
 
           {origin !== "artist" && (
             <Link
-              href={`/artist/${data.artistName}`}
+              href={`/artist/${encodeURIComponent(data.artistName)}`}
               content="View Artist"
               icon="ArtistOutline"
             />
@@ -181,7 +181,7 @@ function ViewPlaylist() {
       href={
         currentPlaylist === SpecialPlaylists.tracks
           ? "/track"
-          : `/playlist/${currentPlaylist}`
+          : `/playlist/${encodeURIComponent(currentPlaylist)}`
       }
       content="View Playlist"
       icon="ListOutline"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

While thinking of potentially redesigning the `album` schema such that we no longer need an `id` field as we can just rely on `${artist name}/${album name}` as the key, I wondered if having either back or forward slashes as part of a Playlist or Artist name would break anything. They in fact, led to an "invalid route" error being thrown.

# How

<!--
How did you build this feature or fix this bug and why?
-->

The solution ended up being running `encodeURIComponent()` on the parameter that gets inserted into the href of an Artist or Playlist link.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Testing whether we can create a playlist with `\` or `/` and navigate to it. In addition, see if we can add & remove tracks from this playlist.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
