### PR TITLE
fix: Adjust header to match design in `<AnimatedHeader />`

### DIFF
--- a/src/app/(app)/(current)/_layout.tsx
+++ b/src/app/(app)/(current)/_layout.tsx
@@ -1,15 +1,14 @@
 import { Stack } from "expo-router";
 
-import { BackButton } from "@/components/navigation/back";
+import { CustomHeader } from "@/components/navigation/header";
 
 export default function CurrentLayout() {
   return (
     <Stack
       screenOptions={{
         animation: "fade",
+        header: CustomHeader,
         headerTitle: "",
-        // @ts-expect-error (TS2322) — Props shouldn't be conflicting.
-        headerLeft: BackButton,
       }}
     >
       <Stack.Screen name="playlist/[id]" />

--- a/src/app/(app)/(current)/album/[id].tsx
+++ b/src/app/(app)/(current)/album/[id].tsx
@@ -40,7 +40,10 @@ export default function CurrentAlbumScreen() {
       <Stack.Screen
         options={{
           headerRight: () => (
-            <Pressable onPress={() => mutateGuard(toggleFavoriteFn, undefined)}>
+            <Pressable
+              onPress={() => mutateGuard(toggleFavoriteFn, undefined)}
+              className="p-3 active:opacity-75"
+            >
               <Ionicons
                 name={isToggled ? "heart" : "heart-outline"}
                 size={24}

--- a/src/app/(app)/(current)/playlist/[id].tsx
+++ b/src/app/(app)/(current)/playlist/[id].tsx
@@ -38,6 +38,7 @@ export default function CurrentPlaylistScreen() {
               onPress={() =>
                 openModal({ entity: "playlist", scope: "view", id })
               }
+              className="p-3 active:opacity-75"
             >
               <EllipsisVertical size={24} />
             </Pressable>

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -4,7 +4,8 @@ import { Pressable, View } from "react-native";
 
 import { useHasNewUpdate } from "@/hooks/useHasNewUpdate";
 
-import { Colors, FontFamily } from "@/constants/Styles";
+import { Colors } from "@/constants/Styles";
+import { CustomHeader } from "@/components/navigation/header";
 import { MiniPlayer } from "@/features/playback/components/mini-player";
 
 /** @description Contains content that doesn't take up the full-screen. */
@@ -18,18 +19,20 @@ export default function MainLayout() {
           name="(home)"
           options={{
             title: "MUSIC",
-            headerTitleStyle: { fontFamily: FontFamily.ndot57, fontSize: 32 },
+            header: CustomHeader,
             headerRight: () => (
               <Link href="/setting" asChild>
-                <Pressable className="active:opacity-75">
-                  <Ionicons
-                    name="settings-outline"
-                    size={24}
-                    color={Colors.foreground50}
-                  />
-                  {newUpdate && (
-                    <View className="absolute right-0 top-0 size-2 rounded-full bg-accent500" />
-                  )}
+                <Pressable className="p-3 active:opacity-75">
+                  <View>
+                    <Ionicons
+                      name="settings-outline"
+                      size={24}
+                      color={Colors.foreground50}
+                    />
+                    {newUpdate && (
+                      <View className="absolute right-0 top-0 size-2 rounded-full bg-accent500" />
+                    )}
+                  </View>
                 </Pressable>
               </Link>
             ),

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,13 +1,17 @@
 import { Stack } from "expo-router";
+import { useSetAtom } from "jotai";
+import { Pressable } from "react-native";
 import TrackPlayer from "react-native-track-player";
 
+import { EllipsisVertical } from "@/assets/svgs/EllipsisVertical";
 import { useLoadAssets } from "@/hooks/useLoadAssets";
+import { modalAtom } from "@/features/modal/store";
 
 import "@/assets/global.css";
 import { PlaybackService } from "@/constants/PlaybackService";
 import { AppProvider } from "@/components/app-provider";
-import { Header } from "@/components/navigation/header";
 import { AnimatedBootSplash } from "@/components/navigation/animated-boot-splash";
+import { CurrentTrackHeader } from "@/components/navigation/header";
 import { AppModals } from "@/features/modal";
 
 export {
@@ -29,6 +33,8 @@ export default function RootLayout() {
 }
 
 function RootLayoutNav() {
+  const openModal = useSetAtom(modalAtom);
+
   return (
     <AppProvider>
       <Stack screenOptions={{ headerShown: false }}>
@@ -38,8 +44,17 @@ function RootLayoutNav() {
           options={{
             headerShown: true,
             animation: "slide_from_bottom",
-            header: Header,
+            header: CurrentTrackHeader,
             headerTitle: "",
+            headerRight: () => (
+              <Pressable
+                accessibilityLabel="View track settings."
+                onPress={() => openModal({ entity: "track", scope: "current" })}
+                className="p-3 active:opacity-75"
+              >
+                <EllipsisVertical size={24} />
+              </Pressable>
+            ),
           }}
         />
         <Stack.Screen name="setting" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This aims to fix the issue with tap target size in the header warned by the Play Console (ie: they should be at least `48px` in size). In addition, we want to match the design changes seen when we changed the `<AnimatedHeader />` implementation:
- Tap target size of the back button is `48px`.
- Padding values on sides where we have a button is `4px`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

On the screens that uses the default header provided by React Navigation, we added `header: CustomHeader`, where `CustomHeader` is the custom header component that mimics the one used in `<AnimatedHeader />`.

For tap target size, we added the `p-3` class to the pressables placed in the `headerRight` option, which adds `12px` around a `24px` icon, giving it a size of `48px`. We also added an opacity effect when pressed if they weren't present.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Go through the screens that renders a header from React Navigation and use Google Accessibility Scanner to verify the tap target size in the header is at least `48px`. In addition, visually compare the position of the buttons to see if they're in the right space (ie: back button location matches the one in `<AnimatedHeader />` seen in the setting pages).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
