### PR TITLE
chore: Micro-animations & UI/UX Adjustments & Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@boterop/react-native-background-timer": "^2.5.1",
     "@expo/vector-icons": "^14.0.2",
-    "@gorhom/bottom-sheet": "5.0.0-alpha.10",
+    "@gorhom/bottom-sheet": "5.0.0-alpha.9",
     "@miblanchard/react-native-slider": "^2.6.0",
     "@missingcore/audio-metadata": "^1.2.0",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^14.0.2
     version: 14.0.2
   '@gorhom/bottom-sheet':
-    specifier: 5.0.0-alpha.10
-    version: 5.0.0-alpha.10(@types/react@18.2.79)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native@0.74.2)(react@18.2.0)
+    specifier: 5.0.0-alpha.9
+    version: 5.0.0-alpha.9(@types/react@18.2.79)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native@0.74.2)(react@18.2.0)
   '@miblanchard/react-native-slider':
     specifier: ^2.6.0
     version: 2.6.0(react-native@0.74.2)(react@18.2.0)
@@ -2650,8 +2650,8 @@ packages:
       js-yaml: 4.1.0
     dev: false
 
-  /@gorhom/bottom-sheet@5.0.0-alpha.10(@types/react@18.2.79)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native@0.74.2)(react@18.2.0):
-    resolution: {integrity: sha512-FjiNf2VtmCEWC4T6/1CHjNYHlgqq+eQAGp0jCSDm87nEWtzmvg6vhspttpRNqGCxj40//Z03BGw/JZR+AYhP0w==}
+  /@gorhom/bottom-sheet@5.0.0-alpha.9(@types/react@18.2.79)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native@0.74.2)(react@18.2.0):
+    resolution: {integrity: sha512-s44MvF5QO40nmiK8lycrGAZM8M8t+nbiH98kXTiqwxU8BQNAm3XiOTlvg56Z+gnpiRv+wvkbmsO9tDkVzLfDGQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-native': '*'

--- a/src/app/(app)/(current)/album/[id].tsx
+++ b/src/app/(app)/(current)/album/[id].tsx
@@ -1,6 +1,6 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { Link, Stack, useLocalSearchParams } from "expo-router";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { useAlbumForCurrentPage } from "@/api/albums/[id]";
 import { useToggleFavorite } from "@/api/favorites/[id]";
@@ -8,6 +8,7 @@ import { useToggleFavorite } from "@/api/favorites/[id]";
 import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
 import { MediaScreenHeader } from "@/components/media/screen-header";
+import { StyledPressable } from "@/components/ui/pressable";
 import { Description } from "@/components/ui/text";
 import { TrackList } from "@/features/track/components/track-list";
 
@@ -40,16 +41,18 @@ export default function CurrentAlbumScreen() {
       <Stack.Screen
         options={{
           headerRight: () => (
-            <Pressable
+            <StyledPressable
               onPress={() => mutateGuard(toggleFavoriteFn, undefined)}
-              className="p-3 active:opacity-75"
+              forIcon
             >
-              <Ionicons
-                name={isToggled ? "heart" : "heart-outline"}
-                size={24}
-                color={Colors.foreground50}
-              />
-            </Pressable>
+              <View className="pointer-events-none">
+                <Ionicons
+                  name={isToggled ? "heart" : "heart-outline"}
+                  size={24}
+                  color={Colors.foreground50}
+                />
+              </View>
+            </StyledPressable>
           ),
         }}
       />

--- a/src/app/(app)/(current)/album/[id].tsx
+++ b/src/app/(app)/(current)/album/[id].tsx
@@ -1,11 +1,10 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
 import { Link, Stack, useLocalSearchParams } from "expo-router";
 import { View } from "react-native";
 
+import { Ionicons } from "@/components/icons";
 import { useAlbumForCurrentPage } from "@/api/albums/[id]";
 import { useToggleFavorite } from "@/api/favorites/[id]";
 
-import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
 import { MediaScreenHeader } from "@/components/media/screen-header";
 import { StyledPressable } from "@/components/ui/pressable";
@@ -45,13 +44,7 @@ export default function CurrentAlbumScreen() {
               onPress={() => mutateGuard(toggleFavoriteFn, undefined)}
               forIcon
             >
-              <View className="pointer-events-none">
-                <Ionicons
-                  name={isToggled ? "heart" : "heart-outline"}
-                  size={24}
-                  color={Colors.foreground50}
-                />
-              </View>
+              <Ionicons name={isToggled ? "heart" : "heart-outline"} />
             </StyledPressable>
           ),
         }}

--- a/src/app/(app)/(current)/playlist/[id].tsx
+++ b/src/app/(app)/(current)/playlist/[id].tsx
@@ -1,7 +1,7 @@
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useSetAtom } from "jotai";
 import { useMemo } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { EllipsisVertical } from "@/assets/svgs/EllipsisVertical";
 import { useFavoriteTracksForCurrentPage } from "@/api/favorites";
@@ -11,6 +11,7 @@ import { SpecialPlaylists } from "@/features/playback/constants";
 
 import { MediaScreenHeader } from "@/components/media/screen-header";
 import type { MediaList } from "@/components/media/types";
+import { StyledPressable } from "@/components/ui/pressable";
 import { Description } from "@/components/ui/text";
 import { TrackList } from "@/features/track/components/track-list";
 
@@ -33,15 +34,15 @@ export default function CurrentPlaylistScreen() {
       <Stack.Screen
         options={{
           headerRight: () => (
-            <Pressable
+            <StyledPressable
               accessibilityLabel="View playlist settings."
               onPress={() =>
                 openModal({ entity: "playlist", scope: "view", id })
               }
-              className="p-3 active:opacity-75"
+              forIcon
             >
               <EllipsisVertical size={24} />
-            </Pressable>
+            </StyledPressable>
           ),
         }}
       />

--- a/src/app/(app)/(home)/playlist.tsx
+++ b/src/app/(app)/(home)/playlist.tsx
@@ -2,7 +2,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import { FlashList } from "@shopify/flash-list";
 import { useSetAtom } from "jotai";
 import { useMemo } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { DashedBorder } from "@/assets/svgs/DashedBorder";
 import { usePlaylistsForMediaCard } from "@/api/playlists";
@@ -11,6 +11,7 @@ import { modalAtom } from "@/features/modal/store";
 
 import { Colors } from "@/constants/Styles";
 import { MediaCard, PlaceholderContent } from "@/components/media/card";
+import { StyledPressable } from "@/components/ui/pressable";
 
 /** @description Screen for `/playlist` route. */
 export default function PlaylistScreen() {
@@ -49,13 +50,19 @@ function CreatePlaylistButton({ colWidth }: { colWidth: number }) {
   const openModal = useSetAtom(modalAtom);
 
   return (
-    <Pressable
-      onPress={() => openModal({ entity: "playlist", scope: "new" })}
+    <View
       style={{ width: colWidth, height: colWidth }}
-      className="items-center justify-center rounded-lg active:bg-surface800"
+      className="overflow-hidden rounded-lg"
     >
-      <DashedBorder size={colWidth} />
-      <Ionicons name="add-outline" size={36} color={Colors.foreground100} />
-    </Pressable>
+      <StyledPressable
+        onPress={() => openModal({ entity: "playlist", scope: "new" })}
+        className="flex-1 items-center justify-center"
+      >
+        <DashedBorder size={colWidth} />
+        <View className="pointer-events-none">
+          <Ionicons name="add-outline" size={36} color={Colors.foreground50} />
+        </View>
+      </StyledPressable>
+    </View>
   );
 }

--- a/src/app/(app)/(home)/playlist.tsx
+++ b/src/app/(app)/(home)/playlist.tsx
@@ -1,15 +1,14 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
 import { FlashList } from "@shopify/flash-list";
 import { useSetAtom } from "jotai";
 import { useMemo } from "react";
 import { View } from "react-native";
 
 import { DashedBorder } from "@/assets/svgs/DashedBorder";
+import { Ionicons } from "@/components/icons";
 import { usePlaylistsForMediaCard } from "@/api/playlists";
 import { useGetColumn } from "@/hooks/layout";
 import { modalAtom } from "@/features/modal/store";
 
-import { Colors } from "@/constants/Styles";
 import { MediaCard, PlaceholderContent } from "@/components/media/card";
 import { StyledPressable } from "@/components/ui/pressable";
 
@@ -59,9 +58,7 @@ function CreatePlaylistButton({ colWidth }: { colWidth: number }) {
         className="flex-1 items-center justify-center"
       >
         <DashedBorder size={colWidth} />
-        <View className="pointer-events-none">
-          <Ionicons name="add-outline" size={36} color={Colors.foreground50} />
-        </View>
+        <Ionicons name="add-outline" size={36} />
       </StyledPressable>
     </View>
   );

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,11 +1,12 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { Link, Stack } from "expo-router";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { useHasNewUpdate } from "@/hooks/useHasNewUpdate";
 
 import { Colors } from "@/constants/Styles";
 import { CustomHeader } from "@/components/navigation/header";
+import { StyledPressable } from "@/components/ui/pressable";
 import { MiniPlayer } from "@/features/playback/components/mini-player";
 
 /** @description Contains content that doesn't take up the full-screen. */
@@ -22,8 +23,8 @@ export default function MainLayout() {
             header: CustomHeader,
             headerRight: () => (
               <Link href="/setting" asChild>
-                <Pressable className="p-3 active:opacity-75">
-                  <View>
+                <StyledPressable forIcon>
+                  <View className="pointer-events-none">
                     <Ionicons
                       name="settings-outline"
                       size={24}
@@ -33,7 +34,7 @@ export default function MainLayout() {
                       <View className="absolute right-0 top-0 size-2 rounded-full bg-accent500" />
                     )}
                   </View>
-                </Pressable>
+                </StyledPressable>
               </Link>
             ),
           }}

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,10 +1,9 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
 import { Link, Stack } from "expo-router";
 import { View } from "react-native";
 
+import { Ionicons } from "@/components/icons";
 import { useHasNewUpdate } from "@/hooks/useHasNewUpdate";
 
-import { Colors } from "@/constants/Styles";
 import { CustomHeader } from "@/components/navigation/header";
 import { StyledPressable } from "@/components/ui/pressable";
 import { MiniPlayer } from "@/features/playback/components/mini-player";
@@ -24,12 +23,8 @@ export default function MainLayout() {
             headerRight: () => (
               <Link href="/setting" asChild>
                 <StyledPressable forIcon>
-                  <View className="pointer-events-none">
-                    <Ionicons
-                      name="settings-outline"
-                      size={24}
-                      color={Colors.foreground50}
-                    />
+                  <View>
+                    <Ionicons name="settings-outline" />
                     {newUpdate && (
                       <View className="absolute right-0 top-0 size-2 rounded-full bg-accent500" />
                     )}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,6 +1,5 @@
 import { Stack } from "expo-router";
 import { useSetAtom } from "jotai";
-import { Pressable } from "react-native";
 import TrackPlayer from "react-native-track-player";
 
 import { EllipsisVertical } from "@/assets/svgs/EllipsisVertical";
@@ -12,6 +11,7 @@ import { PlaybackService } from "@/constants/PlaybackService";
 import { AppProvider } from "@/components/app-provider";
 import { AnimatedBootSplash } from "@/components/navigation/animated-boot-splash";
 import { CurrentTrackHeader } from "@/components/navigation/header";
+import { StyledPressable } from "@/components/ui/pressable";
 import { AppModals } from "@/features/modal";
 
 export {
@@ -47,13 +47,13 @@ function RootLayoutNav() {
             header: CurrentTrackHeader,
             headerTitle: "",
             headerRight: () => (
-              <Pressable
+              <StyledPressable
                 accessibilityLabel="View track settings."
                 onPress={() => openModal({ entity: "track", scope: "current" })}
-                className="p-3 active:opacity-75"
+                forIcon
               >
                 <EllipsisVertical size={24} />
-              </Pressable>
+              </StyledPressable>
             ),
           }}
         />

--- a/src/app/setting/index.tsx
+++ b/src/app/setting/index.tsx
@@ -134,7 +134,6 @@ function UpdateChecker() {
               color={Colors.foreground50}
             />
           }
-          wrapperClassName="p-2"
         >
           APK
         </Button>
@@ -149,7 +148,6 @@ function UpdateChecker() {
               color={Colors.foreground50}
             />
           }
-          wrapperClassName="p-2"
         >
           Play Store
         </Button>

--- a/src/app/setting/index.tsx
+++ b/src/app/setting/index.tsx
@@ -1,7 +1,7 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
 import { StyleSheet, Text, View } from "react-native";
 import Markdown from "react-native-markdown-display";
 
+import { Ionicons } from "@/components/icons";
 import { useHasNewUpdate } from "@/hooks/useHasNewUpdate";
 
 import { APP_VERSION, GITHUB_LINK, PLAYSTORE_LINK } from "@/constants/Config";
@@ -127,13 +127,7 @@ function UpdateChecker() {
           interaction="external-link"
           href={`${GITHUB_LINK}/releases/tag/${release.version}`}
           theme="neutral-dark"
-          Icon={
-            <Ionicons
-              name="logo-github"
-              size={20}
-              color={Colors.foreground50}
-            />
-          }
+          Icon={<Ionicons name="logo-github" size={20} />}
         >
           APK
         </Button>
@@ -141,13 +135,7 @@ function UpdateChecker() {
           interaction="external-link"
           href={PLAYSTORE_LINK}
           theme="neutral-dark"
-          Icon={
-            <Ionicons
-              name="logo-google-playstore"
-              size={20}
-              color={Colors.foreground50}
-            />
-          }
+          Icon={<Ionicons name="logo-google-playstore" size={20} />}
         >
           Play Store
         </Button>

--- a/src/app/setting/third-party/index.tsx
+++ b/src/app/setting/third-party/index.tsx
@@ -1,6 +1,6 @@
 import { FlashList } from "@shopify/flash-list";
 import { Link } from "expo-router";
-import { Pressable, Text, View } from "react-native";
+import { Text, View } from "react-native";
 
 import LicensesList from "@/assets/licenses.json";
 import { ArrowRight } from "@/assets/svgs/ArrowRight";
@@ -9,6 +9,7 @@ import { Colors } from "@/constants/Styles";
 import { cn } from "@/lib/style";
 import { AnimatedHeader } from "@/components/navigation/animated-header";
 import { NavLinkLabel } from "@/components/navigation/nav-link";
+import { StyledPressable } from "@/components/ui/pressable";
 import { Description } from "@/components/ui/text";
 
 /** @description Screen for `/setting/third-party` route. */
@@ -30,9 +31,9 @@ export default function ThirdPartyScreen() {
               href={`/setting/third-party/${encodeURIComponent(item.name)}`}
               asChild
             >
-              <Pressable
+              <StyledPressable
                 className={cn(
-                  "flex-row items-center justify-between gap-2 pl-4 active:opacity-75",
+                  "flex-row items-center justify-between gap-2 pl-4",
                   { "mb-1": index !== Object.values(LicensesList).length - 1 },
                 )}
               >
@@ -45,10 +46,10 @@ export default function ThirdPartyScreen() {
                     <Text className="text-surface400">({item.version})</Text>
                   </Text>
                 </View>
-                <View className="p-3">
+                <View className="pointer-events-none p-3">
                   <ArrowRight size={24} color={Colors.surface400} />
                 </View>
-              </Pressable>
+              </StyledPressable>
             </Link>
           )}
           showsVerticalScrollIndicator={false}

--- a/src/app/setting/third-party/index.tsx
+++ b/src/app/setting/third-party/index.tsx
@@ -46,7 +46,7 @@ export default function ThirdPartyScreen() {
                     <Text className="text-surface400">({item.version})</Text>
                   </Text>
                 </View>
-                <View className="pointer-events-none p-3">
+                <View className="p-3">
                   <ArrowRight size={24} color={Colors.surface400} />
                 </View>
               </StyledPressable>

--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -17,7 +17,7 @@
   },
   "@gorhom/bottom-sheet": {
     "name": "@gorhom/bottom-sheet",
-    "version": "5.0.0-alpha.10",
+    "version": "5.0.0-alpha.9",
     "copyright": "Copyright (c) 2020 Mo Gorhom",
     "source": "https://github.com/gorhom/react-native-bottom-sheet",
     "license": "MIT",

--- a/src/assets/svgs/ArrowRight.tsx
+++ b/src/assets/svgs/ArrowRight.tsx
@@ -1,4 +1,5 @@
 import { cssInterop } from "nativewind";
+import { View } from "react-native";
 import Svg, { Path } from "react-native-svg";
 
 import { Colors } from "@/constants/Styles";
@@ -16,16 +17,18 @@ export function ArrowRight({
   className?: string;
 }) {
   return (
-    <WrappedSvg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke={color}
-      strokeWidth="1.25"
-      className={className}
-    >
-      <Path d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-    </WrappedSvg>
+    <View className="pointer-events-none">
+      <WrappedSvg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={color}
+        strokeWidth="1.25"
+        className={className}
+      >
+        <Path d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+      </WrappedSvg>
+    </View>
   );
 }

--- a/src/assets/svgs/EllipsisVertical.tsx
+++ b/src/assets/svgs/EllipsisVertical.tsx
@@ -1,3 +1,4 @@
+import { View } from "react-native";
 import Svg, { Circle } from "react-native-svg";
 
 import { Colors } from "@/constants/Styles";
@@ -11,10 +12,12 @@ export function EllipsisVertical({
   color?: string;
 }) {
   return (
-    <Svg width={size} height={size} viewBox="0 0 512 512" fill={color}>
-      <Circle cx="256" cy="76" r="36" />
-      <Circle cx="256" cy="256" r="36" />
-      <Circle cx="256" cy="436" r="36" />
-    </Svg>
+    <View className="pointer-events-none">
+      <Svg width={size} height={size} viewBox="0 0 512 512" fill={color}>
+        <Circle cx="256" cy="76" r="36" />
+        <Circle cx="256" cy="256" r="36" />
+        <Circle cx="256" cy="436" r="36" />
+      </Svg>
+    </View>
   );
 }

--- a/src/components/form/action-button.tsx
+++ b/src/components/form/action-button.tsx
@@ -1,5 +1,5 @@
 import type { PressableProps } from "react-native";
-import { Pressable, View } from "react-native";
+import { Platform, View } from "react-native";
 
 import { EllipsisVertical } from "@/assets/svgs/EllipsisVertical";
 
@@ -35,12 +35,17 @@ export function ActionButton(props: ActionButton.Props) {
   const icon = props.icon?.Element ?? <EllipsisVertical size={24} />;
 
   return (
-    <Pressable
+    <StyledPressable
       onPress={props.onPress}
+      // Prevent ripple effect from occuring if `onPress` is undefined.
+      disabled={!props.onPress}
       className={cn(
-        "h-[58px] flex-row items-center rounded p-1",
-        "border border-surface500 active:bg-surface800",
-        { "px-2": !props.Image, "pr-0": !props.withoutIcon },
+        "h-[58px] flex-row items-center rounded border border-surface500 p-1",
+        {
+          "px-2": !props.Image,
+          "pr-0": !props.withoutIcon,
+          "active:bg-surface700 active:opacity-100": Platform.OS !== "android",
+        },
         props.className,
       )}
     >
@@ -56,11 +61,11 @@ export function ActionButton(props: ActionButton.Props) {
           forIcon
           className="shrink-0"
         >
-          <View className="pointer-events-none">{icon}</View>
+          {icon}
         </StyledPressable>
       ) : (
         <View className="shrink-0 p-3">{icon}</View>
       )}
-    </Pressable>
+    </StyledPressable>
   );
 }

--- a/src/components/form/action-button.tsx
+++ b/src/components/form/action-button.tsx
@@ -35,37 +35,40 @@ export function ActionButton(props: ActionButton.Props) {
   const icon = props.icon?.Element ?? <EllipsisVertical size={24} />;
 
   return (
-    <StyledPressable
-      onPress={props.onPress}
-      // Prevent ripple effect from occuring if `onPress` is undefined.
-      disabled={!props.onPress}
-      className={cn(
-        "h-[58px] flex-row items-center rounded border border-surface500 p-1",
-        {
-          "px-2": !props.Image,
-          "pr-0": !props.withoutIcon,
-          "active:bg-surface700 active:opacity-100": Platform.OS !== "android",
-        },
-        props.className,
-      )}
-    >
-      <View className="shrink flex-row items-center gap-2">
-        {props.Image}
-        <TextStack content={props.textContent} wrapperClassName="flex-1" />
-        {props.AsideContent}
-      </View>
-      {props.withoutIcon ? null : props.icon?.onPress ? (
-        <StyledPressable
-          accessibilityLabel={props.icon.label}
-          onPress={props.icon.onPress}
-          forIcon
-          className="shrink-0"
-        >
-          {icon}
-        </StyledPressable>
-      ) : (
-        <View className="shrink-0 p-3">{icon}</View>
-      )}
-    </StyledPressable>
+    <View className="overflow-hidden rounded border border-surface500">
+      <StyledPressable
+        onPress={props.onPress}
+        // Prevent ripple effect from occuring if `onPress` is undefined.
+        disabled={!props.onPress}
+        className={cn(
+          "h-[58px] flex-row items-center p-1",
+          {
+            "px-2": !props.Image,
+            "pr-0": !props.withoutIcon,
+            "active:bg-surface700 active:opacity-100":
+              Platform.OS !== "android",
+          },
+          props.className,
+        )}
+      >
+        <View className="pointer-events-none shrink flex-row items-center gap-2">
+          {props.Image}
+          <TextStack content={props.textContent} wrapperClassName="flex-1" />
+          {props.AsideContent}
+        </View>
+        {props.withoutIcon ? null : props.icon?.onPress ? (
+          <StyledPressable
+            accessibilityLabel={props.icon.label}
+            onPress={props.icon.onPress}
+            forIcon
+            className="shrink-0"
+          >
+            {icon}
+          </StyledPressable>
+        ) : (
+          <View className="shrink-0 p-3">{icon}</View>
+        )}
+      </StyledPressable>
+    </View>
   );
 }

--- a/src/components/form/action-button.tsx
+++ b/src/components/form/action-button.tsx
@@ -37,25 +37,27 @@ export function ActionButton(props: ActionButton.Props) {
     <Pressable
       onPress={props.onPress}
       className={cn(
-        "h-[58px] flex-row items-center gap-2 rounded p-1",
+        "h-[58px] flex-row items-center rounded p-1",
         "border border-surface500 active:bg-surface800",
-        { "px-2": !props.Image },
+        { "px-2": !props.Image, "pr-0": !props.withoutIcon },
         props.className,
       )}
     >
-      {props.Image}
-      <TextStack content={props.textContent} wrapperClassName="flex-1" />
-      {props.AsideContent}
+      <View className="shrink flex-row items-center gap-2">
+        {props.Image}
+        <TextStack content={props.textContent} wrapperClassName="flex-1" />
+        {props.AsideContent}
+      </View>
       {props.withoutIcon ? null : props.icon?.onPress ? (
         <Pressable
           accessibilityLabel={props.icon.label}
           onPress={props.icon.onPress}
-          className="shrink-0"
+          className="shrink-0 p-3 active:opacity-75"
         >
           {icon}
         </Pressable>
       ) : (
-        <View className="shrink-0">{icon}</View>
+        <View className="shrink-0 p-3">{icon}</View>
       )}
     </Pressable>
   );

--- a/src/components/form/action-button.tsx
+++ b/src/components/form/action-button.tsx
@@ -5,6 +5,7 @@ import { EllipsisVertical } from "@/assets/svgs/EllipsisVertical";
 
 import { cn } from "@/lib/style";
 import type { Maybe } from "@/utils/types";
+import { StyledPressable } from "../ui/pressable";
 import { TextStack } from "../ui/text";
 
 export namespace ActionButton {
@@ -49,13 +50,14 @@ export function ActionButton(props: ActionButton.Props) {
         {props.AsideContent}
       </View>
       {props.withoutIcon ? null : props.icon?.onPress ? (
-        <Pressable
+        <StyledPressable
           accessibilityLabel={props.icon.label}
           onPress={props.icon.onPress}
-          className="shrink-0 p-3 active:opacity-75"
+          forIcon
+          className="shrink-0"
         >
-          {icon}
-        </Pressable>
+          <View className="pointer-events-none">{icon}</View>
+        </StyledPressable>
       ) : (
         <View className="shrink-0 p-3">{icon}</View>
       )}

--- a/src/components/form/button.tsx
+++ b/src/components/form/button.tsx
@@ -12,7 +12,7 @@ import { ExternalLink } from "../navigation/external-link";
 const button = cva({
   base: [
     `[--txt-clr:#F0F2F2]`,
-    "items-center rounded-full border px-2 py-1",
+    "items-center rounded-full border p-2",
     "active:opacity-75 disabled:opacity-25",
   ],
   variants: {

--- a/src/components/form/checkbox-field.tsx
+++ b/src/components/form/checkbox-field.tsx
@@ -1,6 +1,5 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
+import { Ionicons } from "../icons";
 
-import { Colors } from "@/constants/Styles";
 import { ActionButton } from "./action-button";
 
 export namespace CheckboxField {
@@ -18,14 +17,9 @@ export function CheckboxField({ checked, ...props }: CheckboxField.Props) {
       {...props}
       icon={{
         Element: (
-          <Ionicons
-            name={checked ? "checkmark-circle" : "ellipse-outline"}
-            size={24}
-            color={Colors.foreground50}
-          />
+          <Ionicons name={checked ? "checkmark-circle" : "ellipse-outline"} />
         ),
       }}
-      className="active:bg-surface700"
     />
   );
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,35 @@
+import _Ionicons from "@expo/vector-icons/Ionicons";
+import _MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { View } from "react-native";
+
+import { Colors } from "@/constants/Styles";
+
+type IconProps<IconNames extends string> = {
+  name: IconNames;
+  size?: number;
+  color?: string;
+};
+
+export function Ionicons({
+  name,
+  size = 24,
+  color = Colors.foreground50,
+}: IconProps<React.ComponentProps<typeof _Ionicons>["name"]>) {
+  return (
+    <View className="pointer-events-none">
+      <_Ionicons {...{ name, size, color }} />
+    </View>
+  );
+}
+
+export function MaterialIcons({
+  name,
+  size = 24,
+  color = Colors.foreground50,
+}: IconProps<React.ComponentProps<typeof _MaterialIcons>["name"]>) {
+  return (
+    <View className="pointer-events-none">
+      <_MaterialIcons {...{ name, size, color }} />
+    </View>
+  );
+}

--- a/src/components/media/screen-header.tsx
+++ b/src/components/media/screen-header.tsx
@@ -49,7 +49,7 @@ export function MediaScreenHeader(props: {
         <View className="flex-row items-center">
           <RepeatButton />
           <ShuffleButton />
-          <PlayButton trackSource={props.trackSource} className="ml-2" />
+          <PlayButton trackSource={props.trackSource} className="ml-1" />
         </View>
       </View>
     </View>

--- a/src/components/navigation/animated-header.tsx
+++ b/src/components/navigation/animated-header.tsx
@@ -77,7 +77,7 @@ export function AnimatedHeader({ title, children }: AnimatedHeaderProps) {
               }}
             >
               <View className="flex h-14 flex-row items-center gap-4 p-1 pr-4">
-                <BackButton unstyled className="p-3" />
+                <BackButton />
                 <Animated.Text
                   numberOfLines={1}
                   style={animatedStyles}

--- a/src/components/navigation/back.tsx
+++ b/src/components/navigation/back.tsx
@@ -1,10 +1,9 @@
 import { router } from "expo-router";
 import { useEffect } from "react";
-import { Pressable } from "react-native";
 
 import { ArrowRight } from "@/assets/svgs/ArrowRight";
 
-import { cn } from "@/lib/style";
+import { StyledPressable } from "../ui/pressable";
 
 /** @description Navigate back when rendered. */
 export function Back() {
@@ -16,18 +15,15 @@ export function Back() {
 }
 
 /** @description Custom back button to replace the one used by React Navigation. */
-export function BackButton(props: { unstyled?: boolean; className?: string }) {
+export function BackButton(props: { className?: string }) {
   return (
-    <Pressable
+    <StyledPressable
       accessibilityLabel="Go back."
       onPress={() => router.back()}
-      className={cn(
-        "active:opacity-75",
-        { "mr-8": !props.unstyled },
-        props.className,
-      )}
+      forIcon
+      className={props.className}
     >
       <ArrowRight size={24} className="rotate-180" />
-    </Pressable>
+    </StyledPressable>
   );
 }

--- a/src/components/navigation/header.tsx
+++ b/src/components/navigation/header.tsx
@@ -75,7 +75,7 @@ export function ReusableHeaderBase({
   const title = getHeaderTitle(options, route.name);
   const navigation = useNavigation();
 
-  const canGoBack = navigation.canGoBack();
+  const canGoBack = navigation.canGoBack() && title !== "MUSIC";
 
   return (
     <SafeContainer className="bg-canvas">

--- a/src/components/navigation/header.tsx
+++ b/src/components/navigation/header.tsx
@@ -85,7 +85,7 @@ export function ReusableHeaderBase({
           "pr-4": !options.headerRight,
         })}
       >
-        {canGoBack && <BackButton unstyled className="p-3" />}
+        {canGoBack && <BackButton />}
         <TitleWrapper>{title}</TitleWrapper>
         {!!options.headerRight && options.headerRight({ canGoBack })}
       </View>

--- a/src/components/navigation/nav-link.tsx
+++ b/src/components/navigation/nav-link.tsx
@@ -1,5 +1,5 @@
 import { Link } from "expo-router";
-import { Pressable, Text, View } from "react-native";
+import { Text, View } from "react-native";
 
 import { ArrowRight } from "@/assets/svgs/ArrowRight";
 import { OpenInNewOutline } from "@/assets/svgs/MaterialSymbol";
@@ -7,6 +7,7 @@ import { OpenInNewOutline } from "@/assets/svgs/MaterialSymbol";
 import { Colors } from "@/constants/Styles";
 import { cn } from "@/lib/style";
 import { ExternalLink } from "./external-link";
+import { StyledPressable } from "../ui/pressable";
 
 export namespace NavLink {
   export type Props = { href: string; label: string; external?: boolean };
@@ -23,12 +24,12 @@ export function NavLink(props: NavLink.Props) {
 
   return (
     <LinkType href={href} asChild>
-      <Pressable className="flex-row items-center justify-between gap-2 pl-4 active:opacity-75">
+      <StyledPressable className="flex-row items-center justify-between gap-2 pl-4">
         <NavLinkLabel className="py-1">{label}</NavLinkLabel>
-        <View className="p-3">
+        <View className="pointer-events-none p-3">
           <NavIcon size={24} color={Colors.surface400} />
         </View>
-      </Pressable>
+      </StyledPressable>
     </LinkType>
   );
 }

--- a/src/components/ui/pressable.tsx
+++ b/src/components/ui/pressable.tsx
@@ -1,0 +1,44 @@
+import { forwardRef } from "react";
+import type { PressableProps, View } from "react-native";
+import { Platform, Pressable } from "react-native";
+
+import { Colors } from "@/constants/Styles";
+import { cn } from "@/lib/style";
+
+// eslint-disable-next-line import/export
+export namespace StyledPressable {
+  export type Props = PressableProps & {
+    forIcon?: boolean;
+  };
+}
+
+/** @description Pre-styled `<Pressable />` with `android_ripple`. */
+// eslint-disable-next-line @typescript-eslint/no-redeclare, import/export
+export const StyledPressable = forwardRef<View, StyledPressable.Props>(
+  function StyledPressable(
+    { forIcon, android_ripple, className, ...props },
+    ref,
+  ) {
+    return (
+      <Pressable
+        ref={ref}
+        {...props}
+        android_ripple={{
+          color: Colors.surface700,
+          // Radius is 75% (ie: 18px for 24px icon).
+          ...(forIcon ? { radius: 18 } : {}),
+          ...android_ripple,
+        }}
+        className={cn(
+          {
+            // Icons are generally 24px; adding `p-3` of padding will give
+            // it the 48px size.
+            "p-3": forIcon,
+            "active:opacity-75": Platform.OS !== "android",
+          },
+          className,
+        )}
+      />
+    );
+  },
+);

--- a/src/features/modal/components/form-button.tsx
+++ b/src/features/modal/components/form-button.tsx
@@ -18,7 +18,7 @@ export function ModalFormButton({
         if (onPress) setTimeout(() => onPress(e), 250);
         close();
       }}
-      wrapperClassName={cn("px-4 py-1.5", wrapperClassName)}
+      wrapperClassName={cn("px-4 py-2", wrapperClassName)}
     />
   );
 }

--- a/src/features/modal/modals/playlist-delete.tsx
+++ b/src/features/modal/modals/playlist-delete.tsx
@@ -15,8 +15,8 @@ export function PlaylistDeleteModal({ id }: { id: string }) {
   return (
     <ModalBase detached>
       <BottomSheetScrollView className="px-4">
-        <Heading as="h1">Delete Playlist</Heading>
-        <Heading as="h4" asLine className="mb-8 text-accent50">
+        <Heading as="h2">Delete Playlist</Heading>
+        <Heading as="h4" asLine className="mb-6 text-accent50">
           {id}
         </Heading>
 

--- a/src/features/modal/modals/playlist-name.tsx
+++ b/src/features/modal/modals/playlist-name.tsx
@@ -1,4 +1,3 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
 import {
   BottomSheetScrollView,
   BottomSheetTextInput,
@@ -6,6 +5,7 @@ import {
 import { useMemo, useState } from "react";
 import { Text, View } from "react-native";
 
+import { Ionicons } from "@/components/icons";
 import { useCreatePlaylist, usePlaylistsForModal } from "@/api/playlists";
 import { useUpdatePlaylist } from "@/api/playlists/[id]";
 

--- a/src/features/modal/modals/playlist-name.tsx
+++ b/src/features/modal/modals/playlist-name.tsx
@@ -50,7 +50,7 @@ export function PlaylistNameModal({ id, scope }: Props) {
         keyboardShouldPersistTaps="handled"
         className="px-4"
       >
-        <Heading as="h1" className="mb-8">
+        <Heading as="h2" className="mb-6">
           {scope === "new" ? "Create a Playlist" : "Rename Playlist"}
         </Heading>
 
@@ -62,8 +62,8 @@ export function PlaylistNameModal({ id, scope }: Props) {
           placeholder="Playlist Name"
           placeholderTextColor={Colors.surface400}
           className={cn(
-            "mb-2 border-b border-b-foreground100 px-2 py-1",
-            "font-geistMonoLight text-lg text-foreground100",
+            "mb-2 border-b border-b-foreground100 p-1",
+            "font-geistMonoLight text-base text-foreground100",
           )}
         />
         <View className="mb-8 flex-row gap-2">
@@ -106,10 +106,10 @@ type RequirementProps = { satisfied: boolean; description: string };
 /** @description Displays a requirement. */
 function Requirement({ satisfied, description }: RequirementProps) {
   return (
-    <View className="flex-row items-center gap-2">
+    <View className="flex-row items-center gap-1">
       <Ionicons
         name={satisfied ? "checkmark-circle" : "close-circle-outline"}
-        size={24}
+        size={20}
         color={satisfied ? Colors.foreground100 : Colors.surface500}
       />
       <Text

--- a/src/features/modal/modals/playlist.tsx
+++ b/src/features/modal/modals/playlist.tsx
@@ -29,7 +29,7 @@ export function PlaylistModal({ id }: { id: string }) {
   return (
     <ModalBase detached>
       <BottomSheetScrollView>
-        <Heading as="h1" asLine className="mb-8 px-4">
+        <Heading as="h2" asLine className="mb-6 px-4">
           {data.name}
         </Heading>
 

--- a/src/features/modal/modals/track-to-playlist.tsx
+++ b/src/features/modal/modals/track-to-playlist.tsx
@@ -29,7 +29,7 @@ export function TrackToPlaylistModal({ id }: { id: string }) {
     <ModalBase
       footerComponent={(props) => <ModalFooter trackId={id} {...props} />}
     >
-      <Heading as="h1" className="p-4 pt-0">
+      <Heading as="h2" className="p-4 pt-0">
         Add Track to Playlist
       </Heading>
       <BottomSheetScrollView

--- a/src/features/modal/modals/track.tsx
+++ b/src/features/modal/modals/track.tsx
@@ -45,13 +45,13 @@ export function TrackModal({ id, origin }: Props) {
   return (
     <ModalBase detached>
       <BottomSheetScrollView>
-        <Heading as="h1" asLine className="px-4">
+        <Heading as="h2" asLine className="px-4">
           {data.name}
         </Heading>
         <Heading
           as="h4"
           asLine
-          className={cn("mb-8 px-4 text-accent50", {
+          className={cn("mb-6 px-4 text-accent50", {
             "mb-4": origin === "artist" && !data.album?.name,
           })}
         >

--- a/src/features/modal/modals/upcoming-track/index.tsx
+++ b/src/features/modal/modals/upcoming-track/index.tsx
@@ -1,4 +1,3 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
 import { FlashList } from "@shopify/flash-list";
 import { useAtomValue, useSetAtom } from "jotai";
@@ -7,6 +6,7 @@ import { View } from "react-native";
 
 import type { Track } from "@/db/schema";
 
+import { Ionicons } from "@/components/icons";
 import { trackDataAtom } from "@/features/playback/api/track";
 import { queueRemoveAtIdxAtom } from "@/features/playback/api/queue";
 import { nextTrackListAtom, queueTrackListAtom } from "./store";
@@ -105,7 +105,7 @@ function UpcomingTrack({ data, onPress }: UpcomingTrackProps) {
   return (
     <View className="mb-2">
       <ActionButton
-        onPress={() => {}}
+        onPress={undefined}
         textContent={[data.name, data.artistName]}
         Image={
           <MediaImage
@@ -117,11 +117,7 @@ function UpcomingTrack({ data, onPress }: UpcomingTrackProps) {
         }
         icon={{
           Element: inQueue ? (
-            <Ionicons
-              name="remove-circle-outline"
-              size={24}
-              color={Colors.accent50}
-            />
+            <Ionicons name="remove-circle-outline" color={Colors.accent50} />
           ) : undefined,
           onPress: inQueue ? onPress : undefined,
           label: inQueue ? "Remove track from queue." : undefined,

--- a/src/features/modal/modals/upcoming-track/index.tsx
+++ b/src/features/modal/modals/upcoming-track/index.tsx
@@ -105,7 +105,7 @@ function UpcomingTrack({ data, onPress }: UpcomingTrackProps) {
   return (
     <View className="mb-2">
       <ActionButton
-        onPress={inQueue ? onPress : undefined}
+        onPress={() => {}}
         textContent={[data.name, data.artistName]}
         Image={
           <MediaImage
@@ -123,6 +123,7 @@ function UpcomingTrack({ data, onPress }: UpcomingTrackProps) {
               color={Colors.accent50}
             />
           ) : undefined,
+          onPress: inQueue ? onPress : undefined,
           label: inQueue ? "Remove track from queue." : undefined,
         }}
         withoutIcon={!inQueue}

--- a/src/features/modal/modals/upcoming-track/index.tsx
+++ b/src/features/modal/modals/upcoming-track/index.tsx
@@ -26,21 +26,21 @@ export function UpcomingTrackModal() {
   return (
     <ModalBase>
       <BottomSheetScrollView className="px-4">
-        <Heading as="h1" className="mb-2 text-start">
+        <Heading as="h2" className="mb-2 text-start">
           Now Playing
         </Heading>
         <Suspense fallback={<LoadingIndicator />}>
           <CurrentTrack />
         </Suspense>
 
-        <Heading as="h1" className="mb-2 text-start">
+        <Heading as="h2" className="mb-2 text-start">
           Next in Queue
         </Heading>
         <Suspense fallback={<LoadingIndicator />}>
           <QueueListTracks />
         </Suspense>
 
-        <Heading as="h1" className="mb-2 text-start">
+        <Heading as="h2" className="mb-2 text-start">
           Next 5 Tracks
         </Heading>
         <Suspense fallback={<LoadingIndicator />}>

--- a/src/features/playback/components/media-controls.tsx
+++ b/src/features/playback/components/media-controls.tsx
@@ -43,7 +43,10 @@ function MediaToggleButton(props: {
 }) {
   const [isActive, setIsActive] = useAtom(props.atom);
   return (
-    <Pressable onPress={() => setIsActive(!isActive)} className="p-2">
+    <Pressable
+      onPress={() => setIsActive(!isActive)}
+      className="p-2 active:opacity-75"
+    >
       <Ionicons
         name={`${props.type}-sharp`}
         size={props.size}
@@ -75,7 +78,7 @@ export function PlayButton({
     <Pressable
       onPress={displayPause ? pauseFn : () => playFn({ source: trackSource })}
       className={cn(
-        "rounded-full bg-accent500 p-1",
+        "rounded-full bg-accent500 p-1 active:opacity-75",
         { "bg-surface500": displayPause },
         className,
       )}
@@ -103,7 +106,7 @@ export function PlayToggleButton({
     <Pressable
       onPress={playPauseToggle}
       className={cn(
-        "rounded-full bg-accent500 p-1",
+        "rounded-full bg-accent500 p-1 active:opacity-75",
         { "bg-surface500": isPlaying },
         className,
       )}
@@ -121,7 +124,7 @@ export function PlayToggleButton({
 export function NextButton({ size = 24 }) {
   const nextTrackFn = useSetAtom(nextAtom);
   return (
-    <Pressable onPress={nextTrackFn} className="p-2">
+    <Pressable onPress={nextTrackFn} className="p-2 active:opacity-75">
       <MaterialIcons name="skip-next" size={size} color={Colors.foreground50} />
     </Pressable>
   );
@@ -131,7 +134,7 @@ export function NextButton({ size = 24 }) {
 export function PreviousButton({ size = 24 }) {
   const prevTrackFn = useSetAtom(prevAtom);
   return (
-    <Pressable onPress={prevTrackFn} className="p-2">
+    <Pressable onPress={prevTrackFn} className="p-2 active:opacity-75">
       <MaterialIcons
         name="skip-previous"
         size={size}

--- a/src/features/playback/components/media-controls.tsx
+++ b/src/features/playback/components/media-controls.tsx
@@ -1,7 +1,7 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { Pressable } from "react-native";
+import { Pressable, View } from "react-native";
 
 import { repeatAtom, shuffleAtom } from "../api/configs";
 import {
@@ -18,6 +18,7 @@ import { areTrackReferencesEqual } from "../utils";
 
 import { Colors } from "@/constants/Styles";
 import { cn } from "@/lib/style";
+import { StyledPressable } from "@/components/ui/pressable";
 
 /**
  * @description Toggles whether we'll keep playing after we reach the
@@ -43,16 +44,19 @@ function MediaToggleButton(props: {
 }) {
   const [isActive, setIsActive] = useAtom(props.atom);
   return (
-    <Pressable
+    <StyledPressable
+      android_ripple={{ color: Colors.surface700, radius: props.size * 0.75 }}
       onPress={() => setIsActive(!isActive)}
-      className="p-2 active:opacity-75"
+      className="p-2"
     >
-      <Ionicons
-        name={`${props.type}-sharp`}
-        size={props.size}
-        color={isActive ? Colors.accent500 : Colors.foreground50}
-      />
-    </Pressable>
+      <View className="pointer-events-none">
+        <Ionicons
+          name={`${props.type}-sharp`}
+          size={props.size}
+          color={isActive ? Colors.accent500 : Colors.foreground50}
+        />
+      </View>
+    </StyledPressable>
   );
 }
 
@@ -124,9 +128,19 @@ export function PlayToggleButton({
 export function NextButton({ size = 24 }) {
   const nextTrackFn = useSetAtom(nextAtom);
   return (
-    <Pressable onPress={nextTrackFn} className="p-2 active:opacity-75">
-      <MaterialIcons name="skip-next" size={size} color={Colors.foreground50} />
-    </Pressable>
+    <StyledPressable
+      android_ripple={{ color: Colors.surface700, radius: size * 0.75 }}
+      onPress={nextTrackFn}
+      className="p-2"
+    >
+      <View className="pointer-events-none">
+        <MaterialIcons
+          name="skip-next"
+          size={size}
+          color={Colors.foreground50}
+        />
+      </View>
+    </StyledPressable>
   );
 }
 
@@ -134,12 +148,18 @@ export function NextButton({ size = 24 }) {
 export function PreviousButton({ size = 24 }) {
   const prevTrackFn = useSetAtom(prevAtom);
   return (
-    <Pressable onPress={prevTrackFn} className="p-2 active:opacity-75">
-      <MaterialIcons
-        name="skip-previous"
-        size={size}
-        color={Colors.foreground50}
-      />
-    </Pressable>
+    <StyledPressable
+      android_ripple={{ color: Colors.surface700, radius: size * 0.75 }}
+      onPress={prevTrackFn}
+      className="p-2"
+    >
+      <View className="pointer-events-none">
+        <MaterialIcons
+          name="skip-previous"
+          size={size}
+          color={Colors.foreground50}
+        />
+      </View>
+    </StyledPressable>
   );
 }

--- a/src/features/playback/components/media-controls.tsx
+++ b/src/features/playback/components/media-controls.tsx
@@ -1,8 +1,7 @@
-import Ionicons from "@expo/vector-icons/Ionicons";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { Pressable, View } from "react-native";
+import { Pressable } from "react-native";
 
+import { Ionicons, MaterialIcons } from "@/components/icons";
 import { repeatAtom, shuffleAtom } from "../api/configs";
 import {
   isPlayingAtom,
@@ -49,13 +48,11 @@ function MediaToggleButton(props: {
       onPress={() => setIsActive(!isActive)}
       className="p-2"
     >
-      <View className="pointer-events-none">
-        <Ionicons
-          name={`${props.type}-sharp`}
-          size={props.size}
-          color={isActive ? Colors.accent500 : Colors.foreground50}
-        />
-      </View>
+      <Ionicons
+        name={`${props.type}-sharp`}
+        size={props.size}
+        color={isActive ? Colors.accent500 : Colors.foreground50}
+      />
     </StyledPressable>
   );
 }
@@ -87,11 +84,7 @@ export function PlayButton({
         className,
       )}
     >
-      <MaterialIcons
-        name={displayPause ? "pause" : "play-arrow"}
-        size={size}
-        color={Colors.foreground50}
-      />
+      <MaterialIcons name={displayPause ? "pause" : "play-arrow"} size={size} />
     </Pressable>
   );
 }
@@ -115,11 +108,7 @@ export function PlayToggleButton({
         className,
       )}
     >
-      <MaterialIcons
-        name={isPlaying ? "pause" : "play-arrow"}
-        size={size}
-        color={Colors.foreground50}
-      />
+      <MaterialIcons name={isPlaying ? "pause" : "play-arrow"} size={size} />
     </Pressable>
   );
 }
@@ -133,13 +122,7 @@ export function NextButton({ size = 24 }) {
       onPress={nextTrackFn}
       className="p-2"
     >
-      <View className="pointer-events-none">
-        <MaterialIcons
-          name="skip-next"
-          size={size}
-          color={Colors.foreground50}
-        />
-      </View>
+      <MaterialIcons name="skip-next" size={size} />
     </StyledPressable>
   );
 }
@@ -153,13 +136,7 @@ export function PreviousButton({ size = 24 }) {
       onPress={prevTrackFn}
       className="p-2"
     >
-      <View className="pointer-events-none">
-        <MaterialIcons
-          name="skip-previous"
-          size={size}
-          color={Colors.foreground50}
-        />
-      </View>
+      <MaterialIcons name="skip-previous" size={size} />
     </StyledPressable>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

When we changed the UI on the pages in the `/setting` route, we changed the styling of `text-title` — which was previously `32px`, now `36px`. This PR mainly aims to adjust any use of `text-title`.

In addition, we decided to improve the tap size of some components (due to Google recommending tap targets being at least `48px` in size). We've also utilized `android_ripple` on `<Pressable />` to add some micro animations.

We've also downgraded `@gorhom/bottom-sheet@5.0.0-alpha.10` to `@gorhom/bottom-sheet@5.0.0-alpha.9` due to a regression with the "Keyboard Handling" feature where dismissing the keyboard keeps the modal in the same position, instead of moving it back to the bottom of the screen.

I also found some unintended behavior for removing a track from the queue — we could previously press anywhere in the track widget and it would remove the track from the queue, instead of the removal happening only when you click the delete/remove button.

# How

<!--
How did you build this feature or fix this bug and why?
-->

For the prior use of `text-title`, we ended up bumping down the font-size to use our `text-subtitle` class, which is `28px`.

For making use of `android_ripple` easier, we created a new `<StyledPressable />` component which uses `android_ripple` on Android and fallback to `opacity-75` on other platforms. We have a `forIcon` prop that applies some styling to help icons (expected to be `24px` in size) hit that `48px` threshold.
- One problem I found with `android_ripple` is that it can't determine the origin of the press if we press an SVG inside the `<Pressable />`, so those SVGs need to be wrapped with a `<View />` with `pointerEvents="none"`.
- In addition, if we want to have a border radius, we need to wrap `<StyledPressable />` with a `<View />` with the border radius & `overflow-hidden` as the ripple effect doesn't respect the border radius.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Go through the app and see if anything visually broke or looks off.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
