### PR TITLE
fix: Epilepsy on Insights (prev "Storage") page

### DIFF
--- a/src/components/ui/progress-bar.tsx
+++ b/src/components/ui/progress-bar.tsx
@@ -36,7 +36,7 @@ export function ProgressBar(props: {
     <View
       onLayout={({ nativeEvent }) => setBarWidth(nativeEvent.layout.width)}
       className={cn(
-        "h-3 flex-1 flex-row overflow-hidden rounded-full",
+        "h-3 flex-row overflow-hidden rounded-full",
         props.className,
       )}
     >


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Closes #25.

There was a report of a very glitchy "Storage & Backup" screen, in which it was an epilepsy nightmare. I was a bit confused as I wasn't having this issue on my Nothing Phone 2a & OnePlus 6 on the version released in the Play Store `v1.0.0-rc.8`.

I opened up a dev instance of the app (via `pnpm android`) and went to the "Insights" page (since we broke up the "Storage & Backup" page) and saw this issue.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I initially thought it was due to the user not having any images stored by the app, causing this weirdness to occur. Well, this wasn't the case.

I then started messing around with logging and saw that `onLayout` in `<ProgressBar />` was getting called repeatedly. After investigating and removing some classes, I narrowed down the cause to the `flex-1` class being applied to the container.

I honestly don't know what's causing the conflict here in this case - I though it would be from having it with `flex-row` but it wasn't.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Make sure the "Insights" screen isn't an epilepsy danger.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
