### PR TITLE
fix: Dynamic `<AnimatedHeader />` size

### DIFF
--- a/src/components/navigation/header.tsx
+++ b/src/components/navigation/header.tsx
@@ -80,7 +80,7 @@ export function ReusableHeaderBase({
   return (
     <SafeContainer className="bg-canvas">
       <View
-        className={cn("flex h-14 flex-row items-center gap-4 p-1", {
+        className={cn("h-14 flex-row items-center gap-4 p-1", {
           "pl-4": !canGoBack,
           "pr-4": !options.headerRight,
         })}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

I usually do the dev testing on a OnePlus 6 to validate things work on older devices. However, during my fix of the epilepsy on the "Insights" (prev "Storage & Backup") screen, I noticed that the dynamic sizing we apply to the `<AnimatedHeader />` didn't work.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Checking `onLayout`, I noticed it was firing a lot - so I assumed the same problem occured as with #27, so I removed the `flex-1`. However, that wasn't a good solution as direct content (ie: `<FlashList />`) requires the parent to have `flex-1` for a better initial layout.

After a bit of experimenting, I narrowed down the problem to me conceptualizing the value from `useWindowDimensions()` in the wrong way - I though it also included the top status bar, but it doesn't.
- I'm kind of wondering why I didn't face this issue while working on the OnePlus 6 - is it maybe different behaviors across Android versions?

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verify visually that we apply a dynamic bottom margin on the contents of `<AnimatedHeader />` if we can scroll, but by default, we don't have enough scrolling room to complete the animation.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
