### PR TITLE
chore: indicator if we've saved all tracks

### DIFF
--- a/src/app/setting/insights.tsx
+++ b/src/app/setting/insights.tsx
@@ -1,8 +1,10 @@
 import { Text, View } from "react-native";
 
+import { Ionicons } from "@/components/icons";
 import {
   useUserDataInfo,
   useStatisticsInfo,
+  useImageSaveStatus,
 } from "@/features/setting/api/insights";
 
 import { Colors } from "@/constants/Styles";
@@ -21,8 +23,10 @@ export default function InsightsScreen() {
         See what <Text className="font-ndot57">Music</Text> has stored on your
         device along with information about the playable media.
       </Description>
+
       <UserDataWidget />
       <StatisticsWidget />
+      <AllImagesSavedWidget />
     </AnimatedHeader>
   );
 }
@@ -83,7 +87,7 @@ function StatisticsWidget() {
   const { isPending, error, data } = useStatisticsInfo();
   if (isPending || error) return null;
   return (
-    <View className="rounded-lg bg-surface800 p-4">
+    <View className="mb-6 rounded-lg bg-surface800 p-4">
       <Heading as="h4" className="mb-4 text-start tracking-tight">
         Statistics
       </Heading>
@@ -98,6 +102,22 @@ function StatisticsWidget() {
         label="Total Duration"
         value={getPlayTime(data.totalDuration)}
         className="mb-0 mt-2"
+      />
+    </View>
+  );
+}
+
+/** @description Display whether all images have been saved. */
+function AllImagesSavedWidget() {
+  const { isPending, error, data: allSaved } = useImageSaveStatus();
+  if (isPending || error) return null;
+  return (
+    <View className="flex-row justify-between gap-4 rounded-lg bg-surface800 p-4">
+      <Heading as="h4" className="text-start leading-tight tracking-tight">
+        All Images Saved?
+      </Heading>
+      <Ionicons
+        name={allSaved ? "checkmark-circle-outline" : "close-circle-outline"}
       />
     </View>
   );

--- a/src/app/setting/insights.tsx
+++ b/src/app/setting/insights.tsx
@@ -1,6 +1,9 @@
 import { Text, View } from "react-native";
 
-import { useStorageInfo } from "@/features/setting/api/storage";
+import {
+  useUserDataInfo,
+  useStatisticsInfo,
+} from "@/features/setting/api/insights";
 
 import { Colors } from "@/constants/Styles";
 import { cn } from "@/lib/style";
@@ -18,81 +21,85 @@ export default function InsightsScreen() {
         See what <Text className="font-ndot57">Music</Text> has stored on your
         device along with information about the playable media.
       </Description>
-      <InfoWidgets />
+      <UserDataWidget />
+      <StatisticsWidget />
     </AnimatedHeader>
   );
 }
 
-/** @description The 2 widgets containing information about storage & statistics. */
-function InfoWidgets() {
-  const { isPending, error, data } = useStorageInfo();
-
+/** @description Displays what's stored on this device. */
+function UserDataWidget() {
+  const { isPending, error, data } = useUserDataInfo();
   if (isPending || error) return null;
-
   return (
-    <>
-      <View className="mb-6 rounded-lg bg-surface800 p-4">
-        <Heading as="h4" className="mb-4 text-start tracking-tight">
-          User Data
-        </Heading>
+    <View className="mb-6 rounded-lg bg-surface800 p-4">
+      <Heading as="h4" className="mb-4 text-start tracking-tight">
+        User Data
+      </Heading>
 
-        <ProgressBar
-          entries={[
-            { color: Colors.accent500, value: data.userData.images },
-            { color: "#FFC800", value: data.userData.database },
-            { color: "#4142BE", value: data.userData.other },
-            { color: Colors.foreground100, value: data.userData.cache },
-          ]}
-          total={data.userData.total}
-          className="mb-4"
-        />
+      <ProgressBar
+        entries={[
+          { color: Colors.accent500, value: data.images },
+          { color: "#FFC800", value: data.database },
+          { color: "#4142BE", value: data.other },
+          { color: Colors.foreground100, value: data.cache },
+        ]}
+        total={data.total}
+        className="mb-4"
+      />
 
-        <ValueRow
-          label="Images"
-          value={abbreviateSize(data.userData.images)}
-          barColor={Colors.accent500}
-        />
-        <ValueRow
-          label="Database"
-          value={abbreviateSize(data.userData.database)}
-          barColor="#FFC800"
-        />
-        <ValueRow
-          label="Other"
-          value={abbreviateSize(data.userData.other)}
-          barColor="#4142BE"
-        />
-        <ValueRow
-          label="Cache"
-          value={abbreviateSize(data.userData.cache)}
-          barColor={Colors.foreground100}
-        />
+      <ValueRow
+        label="Images"
+        value={abbreviateSize(data.images)}
+        barColor={Colors.accent500}
+      />
+      <ValueRow
+        label="Database"
+        value={abbreviateSize(data.database)}
+        barColor="#FFC800"
+      />
+      <ValueRow
+        label="Other"
+        value={abbreviateSize(data.other)}
+        barColor="#4142BE"
+      />
+      <ValueRow
+        label="Cache"
+        value={abbreviateSize(data.cache)}
+        barColor={Colors.foreground100}
+      />
 
-        <ValueRow
-          label="Total"
-          value={abbreviateSize(data.userData.total)}
-          className="mb-0 mt-2"
-        />
-      </View>
+      <ValueRow
+        label="Total"
+        value={abbreviateSize(data.total)}
+        className="mb-0 mt-2"
+      />
+    </View>
+  );
+}
 
-      <View className="rounded-lg bg-surface800 p-4">
-        <Heading as="h4" className="mb-4 text-start tracking-tight">
-          Statistics
-        </Heading>
+/** @description Display what's tracked by the database. */
+function StatisticsWidget() {
+  const { isPending, error, data } = useStatisticsInfo();
+  if (isPending || error) return null;
+  return (
+    <View className="rounded-lg bg-surface800 p-4">
+      <Heading as="h4" className="mb-4 text-start tracking-tight">
+        Statistics
+      </Heading>
 
-        <ValueRow label="Albums" value={data.statistics.albums} />
-        <ValueRow label="Artists" value={data.statistics.artists} />
-        <ValueRow label="Images" value={data.statistics.images} />
-        <ValueRow label="Playlists" value={data.statistics.playlists} />
-        <ValueRow label="Tracks" value={data.statistics.tracks} />
+      <ValueRow label="Albums" value={data.albums} />
+      <ValueRow label="Artists" value={data.artists} />
+      <ValueRow label="Images" value={data.images} />
+      <ValueRow label="Playlists" value={data.playlists} />
+      <ValueRow label="Tracks" value={data.tracks} />
 
-        <ValueRow
-          label="Total Duration"
-          value={getPlayTime(data.statistics.totalDuration)}
-          className="mb-0 mt-2"
-        />
-      </View>
-    </>
+      <ValueRow
+        label="Total Duration"
+        value={getPlayTime(data.totalDuration)}
+        className="mb-0 mt-2"
+      />
+    </View>
   );
 }
 

--- a/src/features/setting/api/_queryKeys.ts
+++ b/src/features/setting/api/_queryKeys.ts
@@ -1,6 +1,8 @@
 /** @description Query keys for "setting" related queries. */
 export const settingKeys = {
   all: [{ entity: "settings" }] as const,
-  release: () => [{ ...settingKeys.all, variant: "release" }] as const,
-  storage: () => [{ ...settingKeys.all, variant: "storage" }] as const,
+  release: () => [{ ...settingKeys.all[0], variant: "release" }] as const,
+  storage: () => [{ ...settingKeys.all[0], variant: "storage" }] as const,
+  storageRelation: (relation: string) =>
+    [{ ...settingKeys.storage()[0], relation }] as const,
 };

--- a/src/features/setting/api/insights.ts
+++ b/src/features/setting/api/insights.ts
@@ -63,6 +63,15 @@ export async function getStatistics() {
   };
 }
 
+export async function getImageSaveStatus() {
+  const isNotAllSaved = Boolean(
+    await db.query.tracks.findFirst({
+      where: (fields, { eq }) => eq(fields.fetchedArt, false),
+    }),
+  );
+  return !isNotAllSaved;
+}
+
 /** @description Get information on what's stored on the device. */
 export const useUserDataInfo = () =>
   useQuery({
@@ -76,5 +85,13 @@ export const useStatisticsInfo = () =>
   useQuery({
     queryKey: settingKeys.storageRelation("statistics"),
     queryFn: getStatistics,
+    gcTime: 0,
+  });
+
+/** @description See if all images are saved. */
+export const useImageSaveStatus = () =>
+  useQuery({
+    queryKey: settingKeys.storageRelation("image-save-status"),
+    queryFn: getImageSaveStatus,
     gcTime: 0,
   });

--- a/src/hooks/useSaveAudio/cleanUpImages.ts
+++ b/src/hooks/useSaveAudio/cleanUpImages.ts
@@ -1,8 +1,10 @@
 import * as FileSystem from "expo-file-system";
 
 import { db } from "@/db";
+import { settingKeys } from "@/features/setting/api/_queryKeys";
 
 import { deleteFile } from "@/lib/file-system";
+import { queryClient } from "@/lib/react-query";
 
 /**
  * @description Get all the images we stored in this app's "private"
@@ -51,4 +53,10 @@ export async function cleanUpImages() {
   console.log(
     `Deleted ${unlinkedImages.length} unlinked images in ${((performance.now() - start) / 1000).toFixed(4)}s.`,
   );
+
+  if (unlinkedImages.length > 0) {
+    queryClient.invalidateQueries({
+      queryKey: settingKeys.storageRelation("image-save-status"),
+    });
+  }
 }

--- a/src/hooks/useSaveAudio/cleanUpImages.ts
+++ b/src/hooks/useSaveAudio/cleanUpImages.ts
@@ -1,10 +1,8 @@
 import * as FileSystem from "expo-file-system";
 
 import { db } from "@/db";
-import { settingKeys } from "@/features/setting/api/_queryKeys";
 
 import { deleteFile } from "@/lib/file-system";
-import { queryClient } from "@/lib/react-query";
 
 /**
  * @description Get all the images we stored in this app's "private"
@@ -53,10 +51,4 @@ export async function cleanUpImages() {
   console.log(
     `Deleted ${unlinkedImages.length} unlinked images in ${((performance.now() - start) / 1000).toFixed(4)}s.`,
   );
-
-  if (unlinkedImages.length > 0) {
-    queryClient.invalidateQueries({
-      queryKey: settingKeys.storageRelation("image-save-status"),
-    });
-  }
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Adding an indicator on whether all images have been saved can help narrow down whether an issue is due to a bug or due to images not all being saved.

# How

<!--
How did you build this feature or fix this bug and why?
-->

We display this information in the "Insights" screen. We can take advantage of the `fetchedArt` field in the `Track` schema.

We've also broke up the logic for generating the widgets for better separation of concerns.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check the "Insights" screen and see the new "widget" displays whether all images have been saved. If we stayed on that page while images are being saved, it should update once all images have been saved.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
