### PR TITLE
fix: Album "fracturizaiton"

### DIFF
--- a/src/app/(app)/(current)/artist/[id].tsx
+++ b/src/app/(app)/(current)/artist/[id].tsx
@@ -47,6 +47,11 @@ export default function CurrentArtistScreen() {
         config={{ source: trackSource, origin: "artist" }}
         ListHeaderComponent={<ArtistAlbums albums={data.albums} />}
         contentContainerStyle={{ paddingHorizontal: 20 }}
+        ListEmptyComponent={
+          <Description className="text-start">
+            Artist has no tracks.
+          </Description>
+        }
       />
     </>
   );

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,6 +23,7 @@ export const albums = sqliteTable("albums", {
   id: text("id")
     .primaryKey()
     .$defaultFn(() => createId()),
+  // The `artistName` is the album artist.
   artistName: text("artist_name")
     .notNull()
     .references(() => artists.name),

--- a/src/features/indexing/api/db-cleanup.ts
+++ b/src/features/indexing/api/db-cleanup.ts
@@ -81,11 +81,16 @@ export async function removeUnlinkedAlbums() {
 /** @description Remove from the database any artists that have no tracks. */
 export async function removeUnlinkedArtists() {
   const allArtists = await db.query.artists.findMany({
-    with: { tracks: { columns: { id: true } } },
+    with: {
+      albums: { columns: { id: true } },
+      tracks: { columns: { id: true } },
+    },
   });
   await Promise.allSettled(
     allArtists
-      .filter(({ tracks }) => tracks.length === 0)
+      .filter(
+        ({ albums, tracks }) => albums.length === 0 && tracks.length === 0,
+      )
       .map(({ name }) => db.delete(artists).where(eq(artists.name, name))),
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

An issue brought up by `trad0r.` in the Discord is that for albums with tracks from different artists, with the way we currently implemented things, we'll create different album instances for each artist, when the expected behavior is that they should all be combined.

The solution is to use a new field - `albumArtist`, which we implemented in `@missingcore/audio-metadata@1.3.0`, and use this instead of `artist` for creating albums.

Closes #26.

# How

<!--
How did you build this feature or fix this bug and why?
-->

We had several things we needed to make sure is in working order:
- Update the `/artist/[id]` screen to handle the case where the artist has no tracks (ie: artist made just hold "collaboration albums").
- Make sure our cleanup logic for artists without tracks get changed based on the behavior change mentioned above (ie: take into consideration of the albums that artist has).
- Treat `albumArtist` as an `artist` (ie: create a new `Artist` entry).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

We added 3 new tracks with the same album & album artist, however all were from different artists. Previously, we would see 3 new album entries — now, we should see 1 new album entry.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
