### PR TITLE
feat: Support tracks without tags

### DIFF
--- a/src/app/setting/insights.tsx
+++ b/src/app/setting/insights.tsx
@@ -97,6 +97,7 @@ function StatisticsWidget() {
       <ValueRow label="Images" value={data.images} />
       <ValueRow label="Playlists" value={data.playlists} />
       <ValueRow label="Tracks" value={data.tracks} />
+      <ValueRow label="Save Errors" value={data.invalidTracks} />
 
       <ValueRow
         label="Total Duration"

--- a/src/components/navigation/animated-boot-splash.tsx
+++ b/src/components/navigation/animated-boot-splash.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Dimensions, Text } from "react-native";
+import { Dimensions, Text, View } from "react-native";
 import BootSplash from "react-native-bootsplash";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 
@@ -30,10 +30,15 @@ export function AnimatedBootSplash() {
           style={{ width: Dimensions.get("window").width - 64 }}
           className="absolute bottom-16 left-8"
         >
-          <Text className="mb-2 text-center font-geistMono text-base text-foreground50">
-            Saving tracks in progress
-            <AnimatedTextEllipsis color={Colors.foreground50} />
-          </Text>
+          <View className="mb-2 flex-row items-center justify-center">
+            <Text className="font-geistMono text-base text-foreground50">
+              Saving tracks in progress
+            </Text>
+            <AnimatedTextEllipsis
+              color={Colors.foreground50}
+              textClass="font-geistMono text-base"
+            />
+          </View>
           <Text className="text-center font-geistMonoLight text-xs text-foreground100">
             This may take a while if you just installed the app, added a lot of
             new tracks, or the app is fixing some data.

--- a/src/components/navigation/animated-header.tsx
+++ b/src/components/navigation/animated-header.tsx
@@ -65,6 +65,10 @@ export function AnimatedHeader({ title, children }: AnimatedHeaderProps) {
       : snappedHeight - initialContentHeight.value;
   });
 
+  const contentAnimatedStyles = useAnimatedStyle(() => ({
+    marginBottom: contentBuffer.value,
+  }));
+
   return (
     <>
       <Stack.Screen
@@ -111,7 +115,7 @@ export function AnimatedHeader({ title, children }: AnimatedHeaderProps) {
           onLayout={({ nativeEvent }) => {
             initialContentHeight.value = nativeEvent.layout.height;
           }}
-          style={{ marginBottom: contentBuffer }}
+          style={contentAnimatedStyles}
           className="flex-1 pb-8"
         >
           {children}

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import { View } from "react-native";
 import Animated, {
   Easing,
   interpolateColor,
+  useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
   withRepeat,
@@ -55,16 +57,15 @@ export function LoadingIndicator() {
   );
 }
 
-/**
- * Loading animation for inside a `<Text />` — animated 3 consecutive
- * periods.
- */
+/** Loading animation of animated 3 consecutive periods. */
 export function AnimatedTextEllipsis({
   color,
   durationMs: duration = 2500,
+  textClass,
 }: {
   color: `#${string}`;
   durationMs?: number;
+  textClass?: string;
 }) {
   const progress = useSharedValue(0);
 
@@ -97,11 +98,21 @@ export function AnimatedTextEllipsis({
     ),
   );
 
+  const dot1Style = useAnimatedStyle(() => ({ color: colorOpacity1.value }));
+  const dot2Style = useAnimatedStyle(() => ({ color: colorOpacity2.value }));
+  const dot3Style = useAnimatedStyle(() => ({ color: colorOpacity3.value }));
+
   return (
-    <>
-      <Animated.Text style={{ color: colorOpacity1 }}>.</Animated.Text>
-      <Animated.Text style={{ color: colorOpacity2 }}>.</Animated.Text>
-      <Animated.Text style={{ color: colorOpacity3 }}>.</Animated.Text>
-    </>
+    <View className="flex-row">
+      <Animated.Text style={dot1Style} className={textClass}>
+        .
+      </Animated.Text>
+      <Animated.Text style={dot2Style} className={textClass}>
+        .
+      </Animated.Text>
+      <Animated.Text style={dot3Style} className={textClass}>
+        .
+      </Animated.Text>
+    </View>
   );
 }

--- a/src/db/drizzle/0001_wooden_wallop.sql
+++ b/src/db/drizzle/0001_wooden_wallop.sql
@@ -1,0 +1,25 @@
+PRAGMA foreign_keys=off;
+--> statement-breakpoint
+CREATE TABLE `_tracks_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`artist_name` text,
+	`album_id` text,
+	`name` text NOT NULL,
+	`artwork` text,
+	`track` integer DEFAULT -1 NOT NULL,
+	`duration` integer NOT NULL,
+	`is_favorite` integer DEFAULT false NOT NULL,
+	`uri` text NOT NULL,
+	`modification_time` integer NOT NULL,
+	`fetched_art` integer DEFAULT false NOT NULL,
+	FOREIGN KEY (`artist_name`) REFERENCES `artists`(`name`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`album_id`) REFERENCES `albums`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `_tracks_new` SELECT * FROM `tracks`;
+--> statement-breakpoint
+DROP TABLE `tracks`;
+--> statement-breakpoint
+ALTER TABLE `_tracks_new` RENAME TO `tracks`;
+--> statement-breakpoint
+PRAGMA foreign_keys=on;

--- a/src/db/drizzle/meta/0001_snapshot.json
+++ b/src/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,334 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5fcc762d-eee0-493d-ac5f-e3c66a97ce17",
+  "prevId": "681c97a6-3565-4740-a6fa-09313aa6d1b6",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "playlist_name",
+            "track_id"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1715564309559,
       "tag": "0000_complete_greymalkin",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1721187130348,
+      "tag": "0001_wooden_wallop",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/drizzle/migrations.js
+++ b/src/db/drizzle/migrations.js
@@ -2,11 +2,13 @@
 
 import journal from './meta/_journal.json';
 import m0000 from './0000_complete_greymalkin.sql';
+import m0001 from './0001_wooden_wallop.sql';
 
   export default {
     journal,
     migrations: {
-      m0000
+      m0000,
+m0001
     }
   }
   

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,9 +45,7 @@ export const albumsRelations = relations(albums, ({ one, many }) => ({
 
 export const tracks = sqliteTable("tracks", {
   id: text("id").primaryKey(),
-  artistName: text("artist_name")
-    .notNull()
-    .references(() => artists.name),
+  artistName: text("artist_name").references(() => artists.name),
   albumId: text("album_id").references(() => albums.id),
   name: text("name").notNull(),
   artwork: text("artwork"),

--- a/src/db/utils/formatters.ts
+++ b/src/db/utils/formatters.ts
@@ -129,7 +129,7 @@ export function formatTrackforPlayer(track: TrackWithAlbum) {
     url: track.uri,
     artwork: getTrackCover(track) ?? undefined,
     title: track.name,
-    artist: track.artistName,
+    artist: track.artistName ?? "No Artist",
     duration: track.duration,
   } satisfies TrackPlayerTrack;
 }

--- a/src/features/indexing/Config.ts
+++ b/src/features/indexing/Config.ts
@@ -1,6 +1,7 @@
 export const AdjustmentOptions = [
   "album-fracturization",
-  "fetchedArt",
+  "artwork-retry",
+  "invalid-tracks-retry",
 ] as const;
 
 export type AdjustmentOption = (typeof AdjustmentOptions)[number];
@@ -12,6 +13,6 @@ export const OverrideHistory: Record<
 > = {
   0: {
     version: "v1.0.0-rc.10",
-    changes: ["fetchedArt", "album-fracturization"],
+    changes: ["invalid-tracks-retry", "artwork-retry", "album-fracturization"],
   },
 };

--- a/src/features/indexing/api/index-override/album-fracturization.ts
+++ b/src/features/indexing/api/index-override/album-fracturization.ts
@@ -47,7 +47,7 @@ export async function fixAlbumFracturization() {
       string,
       {
         albumIds: string[];
-        entry: { name: string; artistName: string; releaseYear: number | null };
+        entry: { name: string; artistName: string; releaseYear?: number };
       }
     > = {};
     await Promise.all(
@@ -64,7 +64,7 @@ export async function fixAlbumFracturization() {
         } else {
           albumInfoMap[key] = {
             albumIds: [id],
-            entry: { name: album!, artistName: aA!, releaseYear: year ?? null },
+            entry: { name: album!, artistName: aA!, releaseYear: year },
           };
         }
       }),

--- a/src/features/indexing/api/index-override/index.ts
+++ b/src/features/indexing/api/index-override/index.ts
@@ -2,7 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { eq } from "drizzle-orm";
 
 import { db } from "@/db";
-import { tracks } from "@/db/schema";
+import { invalidTracks, tracks } from "@/db/schema";
 
 import { fixAlbumFracturization } from "./album-fracturization";
 import type { AdjustmentOption } from "../../Config";
@@ -42,10 +42,12 @@ export async function dataReadjustments() {
 /** Logic we want to run depending on what adjustments we need to make. */
 const AdjustmentFunctionMap: Record<AdjustmentOption, () => Promise<void>> = {
   "album-fracturization": fixAlbumFracturization,
-  fetchedArt: async () => {
-    await db
-      .update(tracks)
-      .set({ fetchedArt: false })
-      .where(eq(tracks.fetchedArt, true));
+  "artwork-retry": async () => {
+    // eslint-disable-next-line drizzle/enforce-update-with-where
+    await db.update(tracks).set({ fetchedArt: false });
+  },
+  "invalid-tracks-retry": async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(invalidTracks);
   },
 };

--- a/src/features/modal/modals/track.tsx
+++ b/src/features/modal/modals/track.tsx
@@ -40,7 +40,9 @@ export function TrackModal({ id, origin }: Props) {
     : data.isFavorite;
 
   const hasSecondRow =
-    (!!data.album && origin !== "album") || origin !== "artist";
+    (origin !== "album" && !!data.album) ||
+    (origin !== "artist" && !!data.artistName) ||
+    origin === "current";
 
   return (
     <ModalBase detached>
@@ -52,7 +54,9 @@ export function TrackModal({ id, origin }: Props) {
           as="h4"
           asLine
           className={cn("mb-6 px-4 text-accent50", {
-            "mb-4": origin === "artist" && !data.album?.name,
+            "mb-4":
+              (origin === "artist" && !data.album?.name) ||
+              (origin !== "artist" && !data.artistName),
           })}
         >
           {origin === "artist" ? data.album?.name : data.artistName}
@@ -85,7 +89,7 @@ export function TrackModal({ id, origin }: Props) {
         )}
 
         <ScrollRow>
-          {!!data.album && origin !== "album" && (
+          {origin !== "album" && !!data.album && (
             <Button
               interaction="link"
               href={`/album/${data.album.id}`}
@@ -94,7 +98,7 @@ export function TrackModal({ id, origin }: Props) {
             />
           )}
 
-          {origin !== "artist" && (
+          {origin !== "artist" && !!data.artistName && (
             <Button
               interaction="link"
               href={`/artist/${encodeURIComponent(data.artistName)}`}

--- a/src/features/modal/modals/upcoming-track/index.tsx
+++ b/src/features/modal/modals/upcoming-track/index.tsx
@@ -106,7 +106,7 @@ function UpcomingTrack({ data, onPress }: UpcomingTrackProps) {
     <View className="mb-2">
       <ActionButton
         onPress={undefined}
-        textContent={[data.name, data.artistName]}
+        textContent={[data.name, data.artistName ?? "No Artist"]}
         Image={
           <MediaImage
             type="track"

--- a/src/features/playback/components/mini-player.tsx
+++ b/src/features/playback/components/mini-player.tsx
@@ -30,7 +30,7 @@ export function MiniPlayer() {
           className="rounded"
         />
         <TextStack
-          content={[trackData.name, trackData.artistName]}
+          content={[trackData.name, trackData.artistName ?? "No Artist"]}
           colors={{ row1: "text-foreground50", row2: "text-accent50" }}
           wrapperClassName="flex-1"
         />

--- a/src/features/setting/api/insights.ts
+++ b/src/features/setting/api/insights.ts
@@ -3,7 +3,7 @@ import { sum } from "drizzle-orm";
 import * as FileSystem from "expo-file-system";
 
 import { db } from "@/db";
-import { albums, artists, playlists, tracks } from "@/db/schema";
+import { albums, artists, playlists, tracks, invalidTracks } from "@/db/schema";
 import { countFrom } from "@/db/utils/formatters";
 
 import { settingKeys } from "./_queryKeys";
@@ -55,6 +55,7 @@ export async function getStatistics() {
     images: imgDirContent.length,
     playlists: await countFrom(playlists),
     tracks: await countFrom(tracks),
+    invalidTracks: await countFrom(invalidTracks),
     totalDuration:
       Number(
         (await db.select({ total: sum(tracks.duration) }).from(tracks))[0]


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

For the future folder feature & preparation for supporting decoding metadata for any audio file that Android supports, it would make sense to support tracks that don't have any tags.
- We'll fallback to the filename for the name of the track.
  - We have no plans for parsing the filename to potentially get the artist name (yet).
- We'll still **enforce that we must have an artist or album artist tag for an album**.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Implementing this change requires a couple of steps:
1. **Create a database migration** as we're changing the type on a column. This ended up being a bit more difficult than expected; given that Drizzle ORM doesn't automatically generate the migration file for SQLite and documentation for creating migrations manually is a bit sparse (spent most of my time wondering why my migration wasn't working and it was mainly due to not using `--> statement-breakpoint` for separating SQL statements and using a transaction inside the migration file, when it wasn't needed).
2. **Update the indexing logic & UI** to support these changes. I mainly had to find where we call `.artistName` and see if it's a place where it's potentially `null` and potentially provide a fallback value. For the indexing logic, we can remove the `throw` statements when we check to see if the artist name or track name is `undefined`. We've wrote code to fallback to the filename of the track (removing the audio extension) to ensure the track `name` is defined.
3. **Add the migration code** to allow checking of tracks we deemed as invalid in the past due to not having any tags.
4. **Update the backup logic** as tracks can potentially not have an `artist`.

During this process, we also did some other changes:
- We now display "Save Errors" in the "Statistics" section of the "Insights" page as it'll be more useful now to know if any tracks were rejected for some unknown bug from metadata saving.
- We encountered some broken animations when updating the animation packages used.
  - The first bug was with the `<AnimatedHeader />`, in which it seems the latest animated value wasn't being applied correctly - so we ended up using `useAnimatedStyle()` to fix this.
  - We had an issue with the "periods" loading animation on the loading screen, in which, it never displayed. Upon further investigation, this only occurred if the `<AnimatedTextEllipsis />` was nested inside another `<Text />` element. Going through each `react-native-reanimated` versions, I noticed that the animation broke on `v3.12.0`. On further investigation, it seems that our nested text animation should have never worked in the first place due to animation not working on "virtual components" (which a nested `<Text />` element is).
    - I've also utilized `useAnimatedStyle()` since we haven't used it here as well.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

We've uninstalled the current version of the app and then created a development version of the app built from the `v1.0.0-rc.9` build. This allows us to test the migration logic and see if everything works as expected. On my device, we have at least 1 tagless track, so that shouldn't be saved into the database normally.

We'll then install this version of the app with the changes and we should expect to see this tagless track in the "tracks" page. We've also look at any interactions involving this tagless track to see that our UI adjustments are working as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
