### PR TITLE
feat: View tracks in "Folder" structure

### DIFF
--- a/src/api/file-nodes/[...id].ts
+++ b/src/api/file-nodes/[...id].ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { db } from "@/db";
+import { formatTracksForTrack } from "@/db/utils/formatters";
+import { fileNodeKeys } from "./_queryKeys";
+
+import type { ExtractFnReturnType } from "@/utils/types";
+import { MUSIC_DIRECTORY } from "@/features/indexing/Config";
+
+export async function getFolderInfo(path: string) {
+  const fullPath = `${MUSIC_DIRECTORY}${path.slice(6)}`;
+  const fileRegex = new RegExp(`^${fullPath}(?!.*/).*$`);
+
+  return {
+    subDirectories: await db.query.fileNode.findMany({
+      where: (fields, { eq }) => eq(fields.parentPath, path),
+      orderBy: (fields, { asc }) => asc(fields.name),
+    }),
+    tracks: (
+      await db.query.tracks.findMany({
+        where: (fields, { like }) => like(fields.uri, `${fullPath}%`),
+        with: { album: true },
+        orderBy: (fields, { asc }) => asc(fields.name),
+      })
+    ).filter(({ uri }) => fileRegex.test(uri)),
+  };
+}
+
+type QueryFnData = ExtractFnReturnType<typeof getFolderInfo>;
+
+/** Get the list of subdirectories & tracks in this music directory. */
+export const useFolderContentForPath = (path: string) =>
+  useQuery({
+    queryKey: fileNodeKeys.detail(path),
+    queryFn: () => getFolderInfo(path.endsWith("/") ? path : `${path}/`),
+    select: useCallback(
+      ({ subDirectories, tracks }: QueryFnData) => ({
+        subDirectories,
+        tracks: formatTracksForTrack({ type: "track", data: tracks }),
+      }),
+      [],
+    ),
+  });

--- a/src/api/file-nodes/_queryKeys.ts
+++ b/src/api/file-nodes/_queryKeys.ts
@@ -1,0 +1,6 @@
+/** Query keys for "fileNodes" related queries. */
+export const fileNodeKeys = {
+  all: [{ entity: "file-nodes" }] as const,
+  details: () => [{ ...fileNodeKeys.all[0], scope: "detail" }] as const,
+  detail: (path: string) => [{ ...fileNodeKeys.details()[0], path }] as const,
+};

--- a/src/app/(app)/(home)/_layout.tsx
+++ b/src/app/(app)/(home)/_layout.tsx
@@ -11,6 +11,7 @@ export default function HomeLayout() {
       <NavigationBar />
       <Stack screenOptions={{ animation: "fade", headerShown: false }}>
         <Stack.Screen name="index" />
+        <Stack.Screen name="folder/[...id]" />
         <Stack.Screen name="playlist" />
         <Stack.Screen name="track" />
         <Stack.Screen name="album" />
@@ -23,6 +24,7 @@ export default function HomeLayout() {
 /** List of routes we'll display buttons for on the "home" page. */
 const NavRoutes = [
   { href: "/", label: "HOME" },
+  { href: "/folder/Music", label: "FOLDERS" },
   { href: "/playlist", label: "PLAYLISTS" },
   { href: "/track", label: "TRACKS" },
   { href: "/album", label: "ALBUMS" },
@@ -42,7 +44,10 @@ function NavigationBar() {
             accessibilityRole="button"
             className={cn(
               "px-2 py-4 font-geistMonoLight text-lg text-foreground50",
-              { "text-accent500": pathname === href },
+              {
+                "text-accent500":
+                  href === "/" ? pathname === "/" : pathname.startsWith(href),
+              },
             )}
           >
             {label}

--- a/src/app/(app)/(home)/_layout.tsx
+++ b/src/app/(app)/(home)/_layout.tsx
@@ -11,6 +11,7 @@ export default function HomeLayout() {
       <NavigationBar />
       <Stack screenOptions={{ animation: "fade", headerShown: false }}>
         <Stack.Screen name="index" />
+        <Stack.Screen name="folder/index" />
         <Stack.Screen name="folder/[...id]" />
         <Stack.Screen name="playlist" />
         <Stack.Screen name="track" />

--- a/src/app/(app)/(home)/folder/[...id].tsx
+++ b/src/app/(app)/(home)/folder/[...id].tsx
@@ -16,7 +16,7 @@ import { Description } from "@/components/ui/text";
 import { Track } from "@/features/track/components/track";
 
 /** Screen for `/folder/[id]` route. */
-export default function TrackScreen() {
+export default function FolderScreen() {
   const { id = ["Music"] } = useLocalSearchParams<{ id: string[] }>();
 
   return (
@@ -43,14 +43,13 @@ function Breadcrumbs({ pathSegments }: { pathSegments: string[] }) {
   return (
     <ScrollRow ref={breadcrumbsRef}>
       {pathSegments.map((dirName, idx) => (
-        <>
+        <View key={idx} className="flex-row gap-2">
           {idx !== 0 && (
             <Text className="px-1 font-geistMono text-sm text-foreground50">
               /
             </Text>
           )}
           <Link
-            key={idx}
             href={`/folder/${pathSegments.slice(0, idx + 1).join("/")}`}
             disabled={idx === pathSegments.length - 1}
             className={cn(
@@ -60,7 +59,7 @@ function Breadcrumbs({ pathSegments }: { pathSegments: string[] }) {
           >
             {dirName}
           </Link>
-        </>
+        </View>
       ))}
     </ScrollRow>
   );
@@ -74,6 +73,12 @@ function FolderContents({ currPath }: { currPath: string }) {
     return (
       <View className="w-full flex-1 px-4">
         <Description intent="error">Error: Directory not found</Description>
+      </View>
+    );
+  } else if (data.subDirectories.length === 0 && data.tracks.length === 0) {
+    return (
+      <View className="w-full flex-1 px-4">
+        <Description>Directory is empty</Description>
       </View>
     );
   }

--- a/src/app/(app)/(home)/folder/[...id].tsx
+++ b/src/app/(app)/(home)/folder/[...id].tsx
@@ -6,7 +6,6 @@ import { ScrollView, Text, View } from "react-native";
 import { ArrowRight } from "@/assets/svgs/ArrowRight";
 import { FolderOutline } from "@/assets/svgs/MaterialSymbol";
 import { useFolderContentForPath } from "@/api/file-nodes/[...id]";
-import { SpecialPlaylists } from "@/features/playback/constants";
 
 import { cn } from "@/lib/style";
 import { ActionButton } from "@/components/form/action-button";
@@ -85,9 +84,9 @@ function FolderContents({ currPath }: { currPath: string }) {
 
   // Information about this track list.
   const trackSource = {
-    type: "playlist",
-    name: SpecialPlaylists.tracks,
-    id: SpecialPlaylists.tracks,
+    type: "folder",
+    name: `[Folder] ${currPath.split("/").at(-1)}`,
+    id: `${currPath}/`,
   } as const;
 
   return (

--- a/src/app/(app)/(home)/folder/[...id].tsx
+++ b/src/app/(app)/(home)/folder/[...id].tsx
@@ -1,0 +1,127 @@
+import { FlashList } from "@shopify/flash-list";
+import { Link, router, useLocalSearchParams } from "expo-router";
+import { useEffect, useRef } from "react";
+import { ScrollView, Text, View } from "react-native";
+
+import { ArrowRight } from "@/assets/svgs/ArrowRight";
+import { FolderOutline } from "@/assets/svgs/MaterialSymbol";
+import { useFolderContentForPath } from "@/api/file-nodes/[...id]";
+import { SpecialPlaylists } from "@/features/playback/constants";
+
+import { cn } from "@/lib/style";
+import { ActionButton } from "@/components/form/action-button";
+import { ScrollRow } from "@/components/ui/container";
+import { ScrollShadow } from "@/components/ui/scroll-shadow";
+import { Description } from "@/components/ui/text";
+import { Track } from "@/features/track/components/track";
+
+/** Screen for `/folder/[id]` route. */
+export default function TrackScreen() {
+  const { id = ["Music"] } = useLocalSearchParams<{ id: string[] }>();
+
+  return (
+    <ScrollView
+      showsVerticalScrollIndicator={false}
+      contentContainerClassName="grow pt-5"
+    >
+      <View style={{ height: 34 }} className="pb-4">
+        <Breadcrumbs pathSegments={id} />
+        <ScrollShadow size={16} />
+      </View>
+      <FolderContents currPath={id.join("/")} />
+    </ScrollView>
+  );
+}
+
+function Breadcrumbs({ pathSegments }: { pathSegments: string[] }) {
+  const breadcrumbsRef = useRef<ScrollRow.Ref>(null);
+
+  useEffect(() => {
+    if (breadcrumbsRef.current) breadcrumbsRef.current.scrollToEnd();
+  }, [pathSegments]);
+
+  return (
+    <ScrollRow ref={breadcrumbsRef}>
+      {pathSegments.map((dirName, idx) => (
+        <>
+          {idx !== 0 && (
+            <Text className="px-1 font-geistMono text-sm text-foreground50">
+              /
+            </Text>
+          )}
+          <Link
+            key={idx}
+            href={`/folder/${pathSegments.slice(0, idx + 1).join("/")}`}
+            disabled={idx === pathSegments.length - 1}
+            className={cn(
+              "font-geistMono text-sm text-foreground50 active:opacity-75",
+              { "text-accent50": idx === pathSegments.length - 1 },
+            )}
+          >
+            {dirName}
+          </Link>
+        </>
+      ))}
+    </ScrollRow>
+  );
+}
+
+function FolderContents({ currPath }: { currPath: string }) {
+  const { isPending, error, data } = useFolderContentForPath(currPath);
+
+  if (isPending) return <View className="w-full flex-1 px-4" />;
+  else if (error) {
+    return (
+      <View className="w-full flex-1 px-4">
+        <Description intent="error">Error: Directory not found</Description>
+      </View>
+    );
+  }
+
+  // Information about this track list.
+  const trackSource = {
+    type: "playlist",
+    name: SpecialPlaylists.tracks,
+    id: SpecialPlaylists.tracks,
+  } as const;
+
+  return (
+    <FlashList
+      estimatedItemSize={66} // 58px Height + 8px Margin Bottom
+      data={[...data.subDirectories, undefined, ...data.tracks]}
+      keyExtractor={(_, index) => `${index}`}
+      renderItem={({ item }) => {
+        // Render divider if we have subdirectories & tracks.
+        if (item === undefined) {
+          if (data.subDirectories.length > 0 && data.tracks.length > 0)
+            return <View className="mb-2 h-px bg-surface850" />;
+          else return null;
+        }
+        return (
+          <View className="mb-2">
+            {isTrackContent(item) ? (
+              <Track {...{ ...item, trackSource }} />
+            ) : (
+              <ActionButton
+                onPress={() => router.push(`/folder/${currPath}/${item.name}`)}
+                textContent={[item.name, null]}
+                Image={
+                  <View className="pointer-events-none rounded-sm bg-surface800 p-1">
+                    <FolderOutline size={40} />
+                  </View>
+                }
+                icon={{ Element: <ArrowRight size={24} /> }}
+              />
+            )}
+          </View>
+        );
+      }}
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={{ paddingHorizontal: 16 }}
+    />
+  );
+}
+
+function isTrackContent(data: unknown): data is Track.Content {
+  return (data as Track.Content).id !== undefined;
+}

--- a/src/app/(app)/(home)/folder/index.tsx
+++ b/src/app/(app)/(home)/folder/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function FoldersScreen() {
+  return <Redirect href="/folder/Music" />;
+}

--- a/src/assets/svgs/MaterialSymbol.tsx
+++ b/src/assets/svgs/MaterialSymbol.tsx
@@ -77,6 +77,20 @@ export function FavoriteFilled({
   );
 }
 
+export function FolderOutline({
+  size,
+  color = Colors.foreground50,
+}: {
+  size: number;
+  color?: string;
+}) {
+  return (
+    <Svg width={size} height={size} viewBox="0 -960 960 960" fill={color}>
+      <Path d="M187.52-206.15q-25.77 0-43.57-17.8t-17.8-43.64v-424.82q0-25.84 17.8-43.64t43.74-17.8h199.23l76.93 76.93h308.63q25.77 0 43.57 17.8t17.8 43.74v347.69q0 25.94-17.8 43.74t-43.57 17.8H187.52Zm.17-36.93h584.62q10.77 0 17.69-6.92 6.92-6.92 6.92-17.69v-347.69q0-10.77-6.92-17.7-6.92-6.92-17.69-6.92H449l-76.92-76.92H187.69q-10.77 0-17.69 6.92-6.92 6.92-6.92 17.69v424.62q0 10.77 6.92 17.69 6.92 6.92 17.69 6.92Zm-24.61 0V-716.92-243.08Z" />
+    </Svg>
+  );
+}
+
 export function HideImageOutline({
   size,
   color = Colors.foreground50,

--- a/src/components/ui/container.tsx
+++ b/src/components/ui/container.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import type { ViewProps } from "react-native";
 import { View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
@@ -28,24 +29,32 @@ export function SafeContainer({
   );
 }
 
-/** Horizontal-scrolling list with default styling. */
-export function ScrollRow({
-  contentContainerClassName,
-  ...props
-}: Omit<
-  React.ComponentProps<typeof ScrollView>,
-  "horizontal" | "showsHorizontalScrollIndicator"
->) {
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      overScrollMode="never"
-      contentContainerClassName={cn(
-        "grow gap-2 px-4",
-        contentContainerClassName,
-      )}
-      {...props}
-    />
-  );
+// eslint-disable-next-line import/export
+export namespace ScrollRow {
+  export type Ref = ScrollView;
+
+  export type Props = Omit<
+    React.ComponentProps<typeof ScrollView>,
+    "horizontal" | "showsHorizontalScrollIndicator"
+  >;
 }
+
+/** Horizontal-scrolling list with default styling. */
+// eslint-disable-next-line @typescript-eslint/no-redeclare, import/export
+export const ScrollRow = forwardRef<ScrollRow.Ref, ScrollRow.Props>(
+  function ScrollRow({ contentContainerClassName, ...props }, ref) {
+    return (
+      <ScrollView
+        ref={ref}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        overScrollMode="never"
+        contentContainerClassName={cn(
+          "grow gap-2 px-4",
+          contentContainerClassName,
+        )}
+        {...props}
+      />
+    );
+  },
+);

--- a/src/db/drizzle/0002_third_giant_man.sql
+++ b/src/db/drizzle/0002_third_giant_man.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `file_node` (
+	`path` text PRIMARY KEY NOT NULL,
+	`parent_path` text,
+	`name` text NOT NULL,
+	FOREIGN KEY (`parent_path`) REFERENCES `file_node`(`path`) ON UPDATE no action ON DELETE no action
+);

--- a/src/db/drizzle/meta/0002_snapshot.json
+++ b/src/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,378 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "675b831d-7406-4f02-bc39-96d14feb156f",
+  "prevId": "5fcc762d-eee0-493d-ac5f-e3c66a97ce17",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "playlist_name",
+            "track_id"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1721187130348,
       "tag": "0001_wooden_wallop",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1721343767586,
+      "tag": "0002_third_giant_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/drizzle/migrations.js
+++ b/src/db/drizzle/migrations.js
@@ -3,12 +3,14 @@
 import journal from './meta/_journal.json';
 import m0000 from './0000_complete_greymalkin.sql';
 import m0001 from './0001_wooden_wallop.sql';
+import m0002 from './0002_third_giant_man.sql';
 
   export default {
     journal,
     migrations: {
       m0000,
-m0001
+m0001,
+m0002
     }
   }
   

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -119,9 +119,9 @@ export const tracksToPlaylistsRelations = relations(
 );
 
 export const fileNode = sqliteTable("file_node", {
-  // Excludes the verbose `file:///storage/emulated/0/`.
+  // Excludes the verbose `file:///storage/emulated/0/`. Ends with a trailing `/`.
   path: text("path").primaryKey(),
-  // `null` if `path = "Music"`.
+  // `null` if `path = "Music"`. Ends with a trailing `/`.
   parentPath: text("parent_path").references(
     (): AnySQLiteColumn => fileNode.path,
   ),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import type { InferSelectModel } from "drizzle-orm";
 import { relations } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 import {
   integer,
   primaryKey,
@@ -117,6 +118,23 @@ export const tracksToPlaylistsRelations = relations(
   }),
 );
 
+export const fileNode = sqliteTable("file_node", {
+  // Excludes the verbose `file:///storage/emulated/0/`.
+  path: text("path").primaryKey(),
+  // `null` if `path = "Music"`.
+  parentPath: text("parent_path").references(
+    (): AnySQLiteColumn => fileNode.path,
+  ),
+  name: text("name").notNull(), // Name of directory.
+});
+
+export const fileNodeRelations = relations(fileNode, ({ one }) => ({
+  parent: one(fileNode, {
+    fields: [fileNode.parentPath],
+    references: [fileNode.path],
+  }),
+}));
+
 export type Artist = InferSelectModel<typeof artists>;
 export type ArtistWithTracks = Prettify<Artist & { tracks: TrackWithAlbum[] }>;
 
@@ -137,3 +155,8 @@ export type PlaylistWithTracks = Prettify<
 >;
 
 export type TrackToPlaylist = InferSelectModel<typeof tracksToPlaylists>;
+
+export type FileNode = InferSelectModel<typeof fileNode>;
+export type FileNodeWithParent = Prettify<
+  FileNode & { parent: FileNode | null }
+>;

--- a/src/db/utils/sorting.ts
+++ b/src/db/utils/sorting.ts
@@ -9,11 +9,11 @@ export function sortTracks({
   type,
   tracks,
 }: {
-  type: Media;
+  type: Media | "folder";
   tracks: Track[] | TrackWithAlbum[];
 }) {
   return [...tracks].sort((a, b) => {
-    if (type === "playlist" || type === "track") {
+    if (type !== "album" && type !== "artist") {
       return a.name.localeCompare(b.name);
     } else if (type === "album") {
       return a.track - b.track;

--- a/src/features/indexing/Config.ts
+++ b/src/features/indexing/Config.ts
@@ -2,6 +2,7 @@ export const AdjustmentOptions = [
   "album-fracturization",
   "artwork-retry",
   "invalid-tracks-retry",
+  "library-scan",
 ] as const;
 
 export type AdjustmentOption = (typeof AdjustmentOptions)[number];
@@ -13,7 +14,12 @@ export const OverrideHistory: Record<
 > = {
   0: {
     version: "v1.0.0-rc.10",
-    changes: ["invalid-tracks-retry", "artwork-retry", "album-fracturization"],
+    changes: [
+      "artwork-retry",
+      "invalid-tracks-retry",
+      "album-fracturization",
+      "library-scan",
+    ],
   },
 };
 

--- a/src/features/indexing/Config.ts
+++ b/src/features/indexing/Config.ts
@@ -16,3 +16,9 @@ export const OverrideHistory: Record<
     changes: ["invalid-tracks-retry", "artwork-retry", "album-fracturization"],
   },
 };
+
+/**
+ * `file://` URI pointing to the directory where music is stored. Ends
+ * with a trailing `/`.
+ */
+export const MUSIC_DIRECTORY = "file:///storage/emulated/0/Music/";

--- a/src/features/indexing/api/index-audio.ts
+++ b/src/features/indexing/api/index-audio.ts
@@ -192,7 +192,7 @@ export async function indexAudio() {
     ),
   );
 
-  return audioFiles;
+  return { foundFiles: audioFiles, changed: incomingTrackData.length };
 }
 
 /** Ensure we use the right key to get the album id. */

--- a/src/features/indexing/api/index-audio.ts
+++ b/src/features/indexing/api/index-audio.ts
@@ -8,6 +8,7 @@ import { createAlbum, deleteTrack } from "@/db/queries";
 
 import { Stopwatch } from "@/utils/debug";
 import { isFulfilled, isRejected } from "@/utils/promise";
+import { MUSIC_DIRECTORY } from "../Config";
 
 /** Metadata tags we want to save from each track. */
 const wantedTags = [
@@ -30,7 +31,7 @@ export async function indexAudio() {
     (a) =>
       wantedExtensions.some((ext) => a.filename.endsWith(`.${ext}`)) &&
       // Limit media to those in the `Music` folder on our device.
-      a.uri.startsWith("file:///storage/emulated/0/Music/"),
+      a.uri.startsWith(MUSIC_DIRECTORY),
   );
 
   // Get relevant entries inside our database.

--- a/src/features/indexing/api/index-override/index.ts
+++ b/src/features/indexing/api/index-override/index.ts
@@ -1,9 +1,10 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { db } from "@/db";
-import { invalidTracks, tracks } from "@/db/schema";
+import { fileNode, invalidTracks, tracks } from "@/db/schema";
 
 import { fixAlbumFracturization } from "./album-fracturization";
+import { scanLibrary } from "../library-scan";
 import type { AdjustmentOption } from "../../Config";
 import { OverrideHistory } from "../../Config";
 
@@ -39,7 +40,10 @@ export async function dataReadjustments() {
 }
 
 /** Logic we want to run depending on what adjustments we need to make. */
-const AdjustmentFunctionMap: Record<AdjustmentOption, () => Promise<void>> = {
+export const AdjustmentFunctionMap: Record<
+  AdjustmentOption,
+  () => Promise<void>
+> = {
   "album-fracturization": fixAlbumFracturization,
   "artwork-retry": async () => {
     // eslint-disable-next-line drizzle/enforce-update-with-where
@@ -48,5 +52,10 @@ const AdjustmentFunctionMap: Record<AdjustmentOption, () => Promise<void>> = {
   "invalid-tracks-retry": async () => {
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(invalidTracks);
+  },
+  "library-scan": async () => {
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(fileNode);
+    await scanLibrary({ dirName: "Music" });
   },
 };

--- a/src/features/indexing/api/library-scan.ts
+++ b/src/features/indexing/api/library-scan.ts
@@ -1,0 +1,56 @@
+import * as FileSystem from "expo-file-system";
+
+import { db } from "@/db";
+import { fileNode } from "@/db/schema";
+
+import { isFulfilled } from "@/utils/promise";
+import { MUSIC_DIRECTORY } from "../Config";
+
+/**
+ * Recursively scans library structure in `file:///storage/emulated/0/Music/`,
+ * going all the way down the tree until we no longer find any folders.
+ */
+export async function scanLibrary({
+  dirName,
+  parentPath,
+}: {
+  dirName: string;
+  parentPath?: string; // If `undefined`, means we're starting at the root of `Music`.
+}) {
+  // Create new entry in database.
+  const currPath = parentPath ? `${parentPath}${dirName}/` : `${dirName}/`;
+  await db
+    .insert(fileNode)
+    .values({ name: dirName, parentPath, path: currPath })
+    .onConflictDoNothing();
+
+  // Look for child directories (filtering out names with file extensions).
+  // We use `.slice(6)` to remove the `Music/`.
+  const fullPath = `${MUSIC_DIRECTORY}${currPath.slice(6)}`;
+  // We'll assume that if a file name has a period that's not at the beginning,
+  // it's before the file extension and thus isn't a directory.
+  const childDirNames = (await FileSystem.readDirectoryAsync(fullPath)).filter(
+    (fileName) => !fileName.includes("."),
+  );
+  // Make sure that `childDirNames` only contain directory names.
+  const childDirectories = (
+    await Promise.allSettled(
+      childDirNames.map(async (dirName) => {
+        const uri = `${fullPath}${dirName}`;
+        const { isDirectory } = await FileSystem.getInfoAsync(uri);
+        return isDirectory ? uri : undefined;
+      }),
+    )
+  )
+    .filter(isFulfilled)
+    .map(({ value }) => value)
+    .filter((uri) => uri !== undefined);
+
+  // Recursively add remaining directories.
+  await Promise.allSettled(
+    childDirectories.map((uri) => {
+      const dirName = uri.split(fullPath)[1]!;
+      return scanLibrary({ dirName, parentPath: currPath });
+    }),
+  );
+}

--- a/src/features/playback/api/actions.ts
+++ b/src/features/playback/api/actions.ts
@@ -78,7 +78,8 @@ export const playAtom = atom(
     if (isDifferentTrack) set(playTrackAtom, { action: "new" });
     else set(playTrackAtom);
 
-    // 3b. Add track source to "recently played".
+    // 3b. Add track source to "recently played". Ignore for folders.
+    if (source.type === "folder") return;
     const currRecentlyPlayed = await get(recentlyPlayedAsyncAtom);
     set(recentlyPlayedAsyncAtom, [
       source,

--- a/src/features/playback/api/recent.ts
+++ b/src/features/playback/api/recent.ts
@@ -39,6 +39,8 @@ export const recentlyPlayedDataAtom = unwrap(
 
 /** Information about media formatted as `MediaCardContent`. */
 async function getRecentMediaInfo({ type, id }: TrackListSource) {
+  if (type === "folder") throw new Error("Unsupported.");
+
   if (type === "album") {
     const data = await getAlbum([eq(albums.id, id)]);
     return formatForMediaCard({ type: "album", data });

--- a/src/features/playback/types.ts
+++ b/src/features/playback/types.ts
@@ -1,4 +1,8 @@
 import type { MediaList } from "@/components/media/types";
 
 /** Describes list of current playing track. */
-export type TrackListSource = { type: MediaList; id: string; name: string };
+export type TrackListSource = {
+  type: MediaList | "folder";
+  id: string;
+  name: string;
+};

--- a/src/features/playback/utils.ts
+++ b/src/features/playback/utils.ts
@@ -6,6 +6,7 @@ import { getPlaylist, getTracks } from "@/db/queries";
 import { formatAsTrackIdList } from "@/db/utils/formatters";
 import { sortTracks } from "@/db/utils/sorting";
 
+import { getFolderTracks } from "@/api/file-nodes/[...id]";
 import { SpecialPlaylists } from "./constants";
 import type { TrackListSource } from "./types";
 
@@ -31,6 +32,9 @@ export async function getTrackList({ type, id }: TrackListSource) {
   } else if (type === "artist") {
     const data = await getTracks([eq(tracks.artistName, id)]);
     sortedTracks = sortTracks({ type: "artist", tracks: data });
+  } else if (type === "folder") {
+    const data = await getFolderTracks(id); // `id` contains pathname.
+    sortedTracks = sortTracks({ type: "folder", tracks: data });
   } else {
     if (id === SpecialPlaylists.tracks) {
       const data = await getTracks();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This was something requested by `Ghouless` on the [Nothing Forums](https://nothing.community/d/12384-music-open-source-offline-music-player/5) to relieve some potential issues with our current setup in regards to organization & searchability and should close #23.

Theoretically, everything in this PR should allow for folder structure and playing a track in some directory in the folder structure should only play the tracks directly in this directory.

When trying to implement the above, I realized that the core logic controlling the app is pretty messy and a bit all over the place. With that in mind, after improving file support in the app, I'll probably work on refactoring the logic and probably rewrite the playing logic, which might fix some of the other issues (ie: `#30`).

# How

<!--
How did you build this feature or fix this bug and why?
-->

### Generating the file system tree in the music directory

The overall idea ended up with us design the schema to be a tree data structure essentially with nodes.

For populating the tree, we know that `file:///storage/emulated/0/Music/` is where music is stored on the device. We can go check the files in that directory and keep those that are actually directories, along with adding them to the database. We can then recursively repeat the process for each directory down the tree.

I've planned on potentially adding a "Re Scan" feature in the settings page, which would rebuild the file system tree, but that can come later. For now, I currently have some code that would initialize the tree as by default, this data doesn't exist. In addition, we have the tree automatically "regenerate" whenever we detect a new or deleted track.

### UI Design

We wanted something that could reuse what we had already on hand, so we opted in for the simple design. This might get changed in the future, but for now, it works.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

What we've tested is the following:
1. We replicated the folder structure in the `Music` folder (excluded any private folders that start with a `.`).
2. When going through the folder feature, we displayed the tracks & subdirectories in a given directory.
3. When playing a track in a directory in the folder feature, the list of upcoming tracks are all from tracks that are directly in this directory (ie: doesn't include any tracks in the subdirectory).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
