### PR TITLE
feat: Experimental support for music on SD card

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Refer to the [performance section](#performance) of this README.
 
 > How do I add music to the app? Why are my music files not displayed?
 
-Place your music files in the "Music" folder on your Android device. It doesn't matter if you put the tracks directly into the folder or in sub-folders for better organization.
+Place your music files in the "Music" folder on your Android device or SD card. It doesn't matter if you put the tracks directly into the folder or in sub-folders for better organization.
 
 You can look [here](https://developer.android.com/media/platform/supported-formats#audio-formats) for the list of supported audio files & metadata formats from the Android documentation.
 

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -32,6 +32,7 @@
 | heroicons | MIT | https://heroicons.com |
 | Ionicons | MIT | https://github.com/ionic-team/ionicons |
 | jotai | MIT | https://github.com/pmndrs/jotai |
+| jotai-scope | MIT | https://github.com/jotaijs/jotai-scope |
 | Material Symbols | Apache-2.0 | https://github.com/google/material-design-icons |
 | nativewind | MIT | https://github.com/marklawlor/nativewind |
 | react | MIT | https://github.com/facebook/react |

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "expo-sqlite": "^14.0.4",
     "expo-web-browser": "~13.0.3",
     "jotai": "^2.9.0",
+    "jotai-scope": "^0.7.0",
     "nativewind": "^4.0.36",
     "react": "18.2.0",
     "react-native": "0.74.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ dependencies:
   jotai:
     specifier: ^2.9.0
     version: 2.9.0(@types/react@18.2.79)(react@18.2.0)
+  jotai-scope:
+    specifier: ^0.7.0
+    version: 0.7.0(jotai@2.9.0)(react@18.2.0)
   nativewind:
     specifier: ^4.0.36
     version: 4.0.36(@babel/core@7.24.9)(react-native-reanimated@3.14.0)(react-native-safe-area-context@4.10.8)(react-native-svg@15.4.0)(react-native@0.74.3)(react@18.2.0)(tailwindcss@3.4.5)
@@ -8418,6 +8421,16 @@ packages:
 
   /join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
+    dev: false
+
+  /jotai-scope@0.7.0(jotai@2.9.0)(react@18.2.0):
+    resolution: {integrity: sha512-xB4cKhY412vn+9cJrbzuLtsb6kWYUAzMTMDwJB+CIUGOnpQhLdM5zUjBnfIn9YhARZfDndMD4FQI3aPaLMzrLw==}
+    peerDependencies:
+      jotai: '>=2.5.0'
+      react: '>=17.0.0'
+    dependencies:
+      jotai: 2.9.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
     dev: false
 
   /jotai@2.9.0(@types/react@18.2.79)(react@18.2.0):

--- a/src/api/file-nodes/[...id].ts
+++ b/src/api/file-nodes/[...id].ts
@@ -19,15 +19,16 @@ export async function getFolderTracks(path: string) {
   ).filter(({ uri }) => !uri.slice(fullPath.length).includes("/"));
 }
 
-export async function getFolderSubdirectories(path: string) {
+export async function getFolderSubdirectories(path: string | null) {
   const fileNodes = await db.query.fileNode.findMany({
-    where: (fields, { eq }) => eq(fields.parentPath, path),
+    where: (fields, { eq, isNull }) =>
+      path ? eq(fields.parentPath, path) : isNull(fields.parentPath),
     orderBy: (fields, { asc }) => asc(fields.name),
   });
   const hasChild = await Promise.all(
-    fileNodes.map(({ path }) =>
+    fileNodes.map(({ path: subDir }) =>
       db.query.tracks.findFirst({
-        where: (fields, { like }) => like(fields.uri, `file:///${path}%`),
+        where: (fields, { like }) => like(fields.uri, `file:///${subDir}%`),
         columns: { id: true },
       }),
     ),
@@ -35,20 +36,22 @@ export async function getFolderSubdirectories(path: string) {
   return fileNodes.filter((_, idx) => hasChild[idx] !== undefined);
 }
 
-export async function getFolderInfo(path: string) {
+export async function getFolderInfo(path: string | null) {
   return {
     subDirectories: await getFolderSubdirectories(path),
-    tracks: await getFolderTracks(path),
+    // Assume no tracks are in the "root" (when `path = null`) as this
+    // could break some things.
+    tracks: path ? await getFolderTracks(path) : [],
   };
 }
 
 type QueryFnData = ExtractFnReturnType<typeof getFolderInfo>;
 
 /** Get the list of subdirectories & tracks in this music directory. */
-export const useFolderContentForPath = (path: string) =>
+export const useFolderContentForPath = (path?: string) =>
   useQuery({
-    queryKey: fileNodeKeys.detail(path),
-    queryFn: () => getFolderInfo(addTrailingSlash(path)),
+    queryKey: fileNodeKeys.detail(path ?? ".root"),
+    queryFn: () => getFolderInfo(path ? addTrailingSlash(path) : null),
     select: useCallback(
       ({ subDirectories, tracks }: QueryFnData) => ({
         subDirectories,

--- a/src/app/(app)/(home)/_layout.tsx
+++ b/src/app/(app)/(home)/_layout.tsx
@@ -24,10 +24,7 @@ export default function HomeLayout() {
 /** List of routes we'll display buttons for on the "home" page. */
 const NavRoutes = [
   { href: "/", label: "HOME" },
-  {
-    href: `/folder/${encodeURIComponent("storage/emulated/0/Music")}`,
-    label: "FOLDERS",
-  },
+  { href: "/folder", label: "FOLDERS" },
   { href: "/playlist", label: "PLAYLISTS" },
   { href: "/track", label: "TRACKS" },
   { href: "/album", label: "ALBUMS" },

--- a/src/app/(app)/(home)/_layout.tsx
+++ b/src/app/(app)/(home)/_layout.tsx
@@ -24,7 +24,10 @@ export default function HomeLayout() {
 /** List of routes we'll display buttons for on the "home" page. */
 const NavRoutes = [
   { href: "/", label: "HOME" },
-  { href: "/folder/Music", label: "FOLDERS" },
+  {
+    href: `/folder/${encodeURIComponent("storage/emulated/0/Music")}`,
+    label: "FOLDERS",
+  },
   { href: "/playlist", label: "PLAYLISTS" },
   { href: "/track", label: "TRACKS" },
   { href: "/album", label: "ALBUMS" },

--- a/src/app/(app)/(home)/_layout.tsx
+++ b/src/app/(app)/(home)/_layout.tsx
@@ -11,8 +11,7 @@ export default function HomeLayout() {
       <NavigationBar />
       <Stack screenOptions={{ animation: "fade", headerShown: false }}>
         <Stack.Screen name="index" />
-        <Stack.Screen name="folder/index" />
-        <Stack.Screen name="folder/[...id]" />
+        <Stack.Screen name="folder" />
         <Stack.Screen name="playlist" />
         <Stack.Screen name="track" />
         <Stack.Screen name="album" />

--- a/src/app/(app)/(home)/folder/[...id].tsx
+++ b/src/app/(app)/(home)/folder/[...id].tsx
@@ -1,66 +1,34 @@
 import { FlashList } from "@shopify/flash-list";
-import { Link, router, useLocalSearchParams } from "expo-router";
-import { useEffect, useRef } from "react";
-import { ScrollView, Text, View } from "react-native";
+import { router, useLocalSearchParams } from "expo-router";
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+import { ScrollView, View } from "react-native";
 
 import { ArrowRight } from "@/assets/svgs/ArrowRight";
 import { FolderOutline } from "@/assets/svgs/MaterialSymbol";
 import { useFolderContentForPath } from "@/api/file-nodes/[...id]";
+import { folderPathAtom } from "./_layout";
 
-import { cn } from "@/lib/style";
 import { ActionButton } from "@/components/form/action-button";
-import { ScrollRow } from "@/components/ui/container";
-import { ScrollShadow } from "@/components/ui/scroll-shadow";
 import { Description } from "@/components/ui/text";
 import { Track } from "@/features/track/components/track";
 
 /** Screen for `/folder/[id]` route. */
 export default function FolderScreen() {
   const { id = ["Music"] } = useLocalSearchParams<{ id: string[] }>();
+  const updateFolderPath = useSetAtom(folderPathAtom);
+
+  useEffect(() => {
+    updateFolderPath(id);
+  }, [id, updateFolderPath]);
 
   return (
     <ScrollView
       showsVerticalScrollIndicator={false}
-      contentContainerClassName="grow pt-5"
+      contentContainerClassName="grow pt-2"
     >
-      <View style={{ height: 34 }} className="pb-4">
-        <Breadcrumbs pathSegments={id} />
-        <ScrollShadow size={16} />
-      </View>
       <FolderContents currPath={id.join("/")} />
     </ScrollView>
-  );
-}
-
-function Breadcrumbs({ pathSegments }: { pathSegments: string[] }) {
-  const breadcrumbsRef = useRef<ScrollRow.Ref>(null);
-
-  useEffect(() => {
-    if (breadcrumbsRef.current) breadcrumbsRef.current.scrollToEnd();
-  }, [pathSegments]);
-
-  return (
-    <ScrollRow ref={breadcrumbsRef}>
-      {pathSegments.map((dirName, idx) => (
-        <View key={idx} className="flex-row gap-2">
-          {idx !== 0 && (
-            <Text className="px-1 font-geistMono text-sm text-foreground50">
-              /
-            </Text>
-          )}
-          <Link
-            href={`/folder/${pathSegments.slice(0, idx + 1).join("/")}`}
-            disabled={idx === pathSegments.length - 1}
-            className={cn(
-              "font-geistMono text-sm text-foreground50 active:opacity-75",
-              { "text-accent50": idx === pathSegments.length - 1 },
-            )}
-          >
-            {dirName}
-          </Link>
-        </View>
-      ))}
-    </ScrollRow>
   );
 }
 

--- a/src/app/(app)/(home)/folder/[...id].tsx
+++ b/src/app/(app)/(home)/folder/[...id].tsx
@@ -15,7 +15,9 @@ import { Track } from "@/features/track/components/track";
 
 /** Screen for `/folder/[id]` route. */
 export default function FolderScreen() {
-  const { id = ["Music"] } = useLocalSearchParams<{ id: string[] }>();
+  const { id = ["storage/emulated/0/Music"] } = useLocalSearchParams<{
+    id: string[];
+  }>();
   const updateFolderPath = useSetAtom(folderPathAtom);
 
   useEffect(() => {
@@ -27,13 +29,17 @@ export default function FolderScreen() {
       showsVerticalScrollIndicator={false}
       contentContainerClassName="grow pt-2"
     >
-      <FolderContents currPath={id.join("/")} />
+      <FolderContents
+        currPath={id.map((segment) => encodeURIComponent(segment)).join("/")}
+      />
     </ScrollView>
   );
 }
 
 function FolderContents({ currPath }: { currPath: string }) {
-  const { isPending, error, data } = useFolderContentForPath(currPath);
+  const { isPending, error, data } = useFolderContentForPath(
+    decodeURIComponent(currPath),
+  );
 
   if (isPending) return <View className="w-full flex-1 px-4" />;
   else if (error) {
@@ -53,8 +59,8 @@ function FolderContents({ currPath }: { currPath: string }) {
   // Information about this track list.
   const trackSource = {
     type: "folder",
-    name: `[Folder] ${currPath.split("/").at(-1)}`,
-    id: `${currPath}/`,
+    name: `[Folder] ${decodeURIComponent(currPath).split("/").at(-1)}`,
+    id: `${decodeURIComponent(currPath)}/`,
   } as const;
 
   return (

--- a/src/app/(app)/(home)/folder/[...id].tsx
+++ b/src/app/(app)/(home)/folder/[...id].tsx
@@ -10,6 +10,7 @@ import { useFolderContentForPath } from "@/api/file-nodes/[...id]";
 import { folderPathAtom } from "./_layout";
 
 import { ActionButton } from "@/components/form/action-button";
+import { LoadingIndicator } from "@/components/ui/loading";
 import { Description } from "@/components/ui/text";
 import { Track } from "@/features/track/components/track";
 
@@ -20,29 +21,21 @@ export default function FolderScreen() {
   }>();
   const updateFolderPath = useSetAtom(folderPathAtom);
 
+  const fullPath = id.join("/");
+
+  const { isPending, error, data } = useFolderContentForPath(fullPath);
+
   useEffect(() => {
     updateFolderPath(id);
   }, [id, updateFolderPath]);
 
-  return (
-    <ScrollView
-      showsVerticalScrollIndicator={false}
-      contentContainerClassName="grow pt-2"
-    >
-      <FolderContents
-        currPath={id.map((segment) => encodeURIComponent(segment)).join("/")}
-      />
-    </ScrollView>
-  );
-}
-
-function FolderContents({ currPath }: { currPath: string }) {
-  const { isPending, error, data } = useFolderContentForPath(
-    decodeURIComponent(currPath),
-  );
-
-  if (isPending) return <View className="w-full flex-1 px-4" />;
-  else if (error) {
+  if (isPending) {
+    return (
+      <View className="w-full flex-1 px-4">
+        <LoadingIndicator />
+      </View>
+    );
+  } else if (error) {
     return (
       <View className="w-full flex-1 px-4">
         <Description intent="error">Error: Directory not found</Description>
@@ -59,44 +52,53 @@ function FolderContents({ currPath }: { currPath: string }) {
   // Information about this track list.
   const trackSource = {
     type: "folder",
-    name: `[Folder] ${decodeURIComponent(currPath).split("/").at(-1)}`,
-    id: `${decodeURIComponent(currPath)}/`,
+    name: `[Folder] ${fullPath.split("/").at(-1)}`,
+    id: `${fullPath}/`,
   } as const;
 
   return (
-    <FlashList
-      estimatedItemSize={66} // 58px Height + 8px Margin Bottom
-      data={[...data.subDirectories, undefined, ...data.tracks]}
-      keyExtractor={(_, index) => `${index}`}
-      renderItem={({ item }) => {
-        // Render divider if we have subdirectories & tracks.
-        if (item === undefined) {
-          if (data.subDirectories.length > 0 && data.tracks.length > 0)
-            return <View className="mb-2 h-px bg-surface850" />;
-          else return null;
-        }
-        return (
-          <View className="mb-2">
-            {isTrackContent(item) ? (
-              <Track {...{ ...item, trackSource }} />
-            ) : (
-              <ActionButton
-                onPress={() => router.push(`/folder/${currPath}/${item.name}`)}
-                textContent={[item.name, null]}
-                Image={
-                  <View className="pointer-events-none rounded-sm bg-surface800 p-1">
-                    <FolderOutline size={40} />
-                  </View>
-                }
-                icon={{ Element: <ArrowRight size={24} /> }}
-              />
-            )}
-          </View>
-        );
-      }}
+    <ScrollView
       showsVerticalScrollIndicator={false}
-      contentContainerStyle={{ paddingHorizontal: 16 }}
-    />
+      contentContainerClassName="grow pt-2"
+    >
+      <FlashList
+        estimatedItemSize={66} // 58px Height + 8px Margin Bottom
+        data={[...data.subDirectories, undefined, ...data.tracks]}
+        keyExtractor={(_, index) => `${index}`}
+        renderItem={({ item }) => {
+          // Render divider if we have subdirectories & tracks.
+          if (item === undefined) {
+            if (data.subDirectories.length > 0 && data.tracks.length > 0)
+              return <View className="mb-2 h-px bg-surface850" />;
+            else return null;
+          }
+          return (
+            <View className="mb-2">
+              {isTrackContent(item) ? (
+                <Track {...{ ...item, trackSource }} />
+              ) : (
+                <ActionButton
+                  onPress={() =>
+                    router.push(
+                      `/folder/${id.map((segment) => encodeURIComponent(segment)).join("/")}/${item.name}`,
+                    )
+                  }
+                  textContent={[item.name, null]}
+                  Image={
+                    <View className="pointer-events-none rounded-sm bg-surface800 p-1">
+                      <FolderOutline size={40} />
+                    </View>
+                  }
+                  icon={{ Element: <ArrowRight size={24} /> }}
+                />
+              )}
+            </View>
+          );
+        }}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingHorizontal: 16 }}
+      />
+    </ScrollView>
   );
 }
 

--- a/src/app/(app)/(home)/folder/_layout.tsx
+++ b/src/app/(app)/(home)/folder/_layout.tsx
@@ -55,7 +55,10 @@ function Breadcrumbs() {
           )}
           <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
             <Link
-              href={`/folder/${pathSegments.slice(0, idx + 1).join("/")}`}
+              href={`/folder/${pathSegments
+                .slice(0, idx + 1)
+                .map((segment) => encodeURIComponent(segment))
+                .join("/")}`}
               disabled={idx === pathSegments.length - 1}
               className={cn(
                 "font-geistMono text-sm text-foreground50 active:opacity-75",

--- a/src/app/(app)/(home)/folder/_layout.tsx
+++ b/src/app/(app)/(home)/folder/_layout.tsx
@@ -2,8 +2,13 @@ import { Link, Stack } from "expo-router";
 import { atom, useAtomValue } from "jotai";
 import { ScopeProvider } from "jotai-scope";
 import { Fragment, useEffect, useRef } from "react";
-import { Text, View } from "react-native";
-import Animated, { FadeInLeft, FadeOutRight } from "react-native-reanimated";
+import { View } from "react-native";
+import Animated, {
+  FadeInLeft,
+  FadeOutRight,
+  useAnimatedStyle,
+  useSharedValue,
+} from "react-native-reanimated";
 
 import { cn } from "@/lib/style";
 import { ScrollRow } from "@/components/ui/container";
@@ -38,38 +43,87 @@ export default function FolderLayout() {
 /** Custom folder structure breadcrumbs. */
 function Breadcrumbs() {
   const pathSegments = useAtomValue(folderPathAtom);
+  const prevPathSegments = useRef<string[]>([]);
   const breadcrumbsRef = useRef<ScrollRow.Ref>(null);
+  const containerWidth = useSharedValue(0);
+  const currWidth = useSharedValue(0);
+  const lastWidth = useSharedValue(0);
+  const removedWidth = useSharedValue(0);
+
+  const onLayoutShift = (newWidth: number) => {
+    currWidth.value = newWidth;
+    if (newWidth < lastWidth.value) {
+      removedWidth.value = lastWidth.value - newWidth;
+    }
+    lastWidth.value = newWidth;
+  };
+
+  const wrapperStyle = useAnimatedStyle(() => ({
+    paddingRight: removedWidth.value,
+  }));
 
   useEffect(() => {
-    if (breadcrumbsRef.current) breadcrumbsRef.current.scrollToEnd();
+    // Automatically scroll if we've going deeper in the tree.
+    if (prevPathSegments.current.length <= pathSegments.length) {
+      if (breadcrumbsRef.current) breadcrumbsRef.current.scrollToEnd();
+    }
+    prevPathSegments.current = pathSegments;
   }, [pathSegments]);
 
   return (
-    <ScrollRow ref={breadcrumbsRef} className="pb-2">
-      {pathSegments.map((dirName, idx) => (
-        <Fragment key={idx}>
-          {idx !== 0 && (
-            <Text className="px-1 font-geistMono text-sm text-foreground50">
-              /
-            </Text>
-          )}
-          <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
-            <Link
-              href={`/folder/${pathSegments
-                .slice(0, idx + 1)
-                .map((segment) => encodeURIComponent(segment))
-                .join("/")}`}
-              disabled={idx === pathSegments.length - 1}
-              className={cn(
-                "font-geistMono text-sm text-foreground50 active:opacity-75",
-                { "text-accent50": idx === pathSegments.length - 1 },
-              )}
-            >
-              {dirName}
-            </Link>
-          </Animated.View>
-        </Fragment>
-      ))}
+    <ScrollRow
+      ref={breadcrumbsRef}
+      onLayout={({ nativeEvent }) => {
+        containerWidth.value = nativeEvent.layout.width;
+      }}
+      className="pb-2"
+    >
+      <Animated.View
+        onLayout={({ nativeEvent }) => onLayoutShift(nativeEvent.layout.width)}
+        className="flex-row gap-2"
+      >
+        {pathSegments.map((dirName, idx) => (
+          <Fragment key={idx}>
+            {idx !== 0 && (
+              <Animated.Text
+                entering={FadeInLeft}
+                exiting={FadeOutRight}
+                className="px-1 font-geistMono text-sm text-foreground50"
+              >
+                /
+              </Animated.Text>
+            )}
+            <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
+              <Link
+                href={`/folder/${pathSegments
+                  .slice(0, idx + 1)
+                  .map((segment) => encodeURIComponent(segment))
+                  .join("/")}`}
+                disabled={idx === pathSegments.length - 1}
+                className={cn(
+                  "font-geistMono text-sm text-foreground50 active:opacity-75",
+                  { "text-accent50": idx === pathSegments.length - 1 },
+                )}
+              >
+                {dirName}
+              </Link>
+            </Animated.View>
+          </Fragment>
+        ))}
+      </Animated.View>
+      <Animated.View
+        onLayout={({ nativeEvent }) => {
+          if (nativeEvent.layout.width !== 0) {
+            breadcrumbsRef.current?.scrollTo({
+              x: currWidth.value - removedWidth.value - containerWidth.value,
+            });
+            setTimeout(() => {
+              removedWidth.value = 0;
+            }, 300);
+          }
+        }}
+        style={wrapperStyle}
+      />
     </ScrollRow>
   );
 }

--- a/src/app/(app)/(home)/folder/_layout.tsx
+++ b/src/app/(app)/(home)/folder/_layout.tsx
@@ -1,0 +1,72 @@
+import { Link, Stack } from "expo-router";
+import { atom, useAtomValue } from "jotai";
+import { ScopeProvider } from "jotai-scope";
+import { Fragment, useEffect, useRef } from "react";
+import { Text, View } from "react-native";
+import Animated, { FadeInLeft, FadeOutRight } from "react-native-reanimated";
+
+import { cn } from "@/lib/style";
+import { ScrollRow } from "@/components/ui/container";
+import { ScrollShadow } from "@/components/ui/scroll-shadow";
+
+/**
+ * FIXME: Need to use atom to get the current layout path since although
+ * `useLocalSearchParams()` re-renders in this `_layout.tsx` file when
+ * navigating between `[...id]` routes, the value doesn't change.
+ *
+ * With this solution, we also encouter a problem with the value persisting
+ * after the screen is popped off the stack (which makes sense). To reset
+ * after being popped, we use `jotai-scope`.
+ */
+export const folderPathAtom = atom<string[]>([]);
+
+export default function FolderLayout() {
+  return (
+    <ScopeProvider atoms={[folderPathAtom]}>
+      <View>
+        <Breadcrumbs />
+        <ScrollShadow size={16} />
+      </View>
+      <Stack screenOptions={{ animation: "fade", headerShown: false }}>
+        <Stack.Screen name="index" />
+        <Stack.Screen name="[...id]" />
+      </Stack>
+    </ScopeProvider>
+  );
+}
+
+/** Custom folder structure breadcrumbs. */
+function Breadcrumbs() {
+  const pathSegments = useAtomValue(folderPathAtom);
+  const breadcrumbsRef = useRef<ScrollRow.Ref>(null);
+
+  useEffect(() => {
+    if (breadcrumbsRef.current) breadcrumbsRef.current.scrollToEnd();
+  }, [pathSegments]);
+
+  return (
+    <ScrollRow ref={breadcrumbsRef} className="pb-2">
+      {pathSegments.map((dirName, idx) => (
+        <Fragment key={idx}>
+          {idx !== 0 && (
+            <Text className="px-1 font-geistMono text-sm text-foreground50">
+              /
+            </Text>
+          )}
+          <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
+            <Link
+              href={`/folder/${pathSegments.slice(0, idx + 1).join("/")}`}
+              disabled={idx === pathSegments.length - 1}
+              className={cn(
+                "font-geistMono text-sm text-foreground50 active:opacity-75",
+                { "text-accent50": idx === pathSegments.length - 1 },
+              )}
+            >
+              {dirName}
+            </Link>
+          </Animated.View>
+        </Fragment>
+      ))}
+    </ScrollRow>
+  );
+}

--- a/src/app/(app)/(home)/folder/_layout.tsx
+++ b/src/app/(app)/(home)/folder/_layout.tsx
@@ -1,8 +1,8 @@
-import { Link, Stack } from "expo-router";
+import { Stack, router } from "expo-router";
 import { atom, useAtomValue } from "jotai";
 import { ScopeProvider } from "jotai-scope";
 import { Fragment } from "react";
-import { View, useWindowDimensions } from "react-native";
+import { Pressable, Text, View, useWindowDimensions } from "react-native";
 import Animated, {
   FadeInLeft,
   FadeOutRight,
@@ -39,7 +39,6 @@ export default function FolderLayout() {
         <ScrollShadow size={16} />
       </View>
       <Stack screenOptions={{ animation: "fade", headerShown: false }}>
-        <Stack.Screen name="index" />
         <Stack.Screen name="[...id]" />
       </Stack>
     </ScopeProvider>
@@ -82,7 +81,7 @@ function Breadcrumbs() {
         onLayout={({ nativeEvent }) => onLayoutShift(nativeEvent.layout.width)}
         className="flex-row gap-2"
       >
-        {pathSegments.map((dirName, idx) => (
+        {[undefined, ...pathSegments].map((dirName, idx) => (
           <Fragment key={idx}>
             {idx !== 0 && (
               <Animated.Text
@@ -94,19 +93,26 @@ function Breadcrumbs() {
               </Animated.Text>
             )}
             <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
-              <Link
-                href={`/folder/${pathSegments
-                  .slice(0, idx + 1)
-                  .map((segment) => encodeURIComponent(segment))
-                  .join("/")}`}
-                disabled={idx === pathSegments.length - 1}
-                className={cn(
-                  "pb-2 font-geistMono text-sm text-foreground50 active:opacity-75",
-                  { "text-accent50": idx === pathSegments.length - 1 },
-                )}
+              <Pressable
+                onPress={() => {
+                  // Pop the segments we pushed onto the stack and update
+                  // the path segments atom accordingly.
+                  router.dismiss(pathSegments.length - idx);
+                }}
+                // `pathSegments.length` instead of `pathSegments.length - 1`
+                // due to us prepending an extra entry to denote the "Root".
+                disabled={idx === pathSegments.length}
+                className="active:opacity-75"
               >
-                {dirName}
-              </Link>
+                <Text
+                  className={cn(
+                    "pb-2 font-geistMono text-sm text-foreground50",
+                    { "text-accent50": idx === pathSegments.length },
+                  )}
+                >
+                  {dirName ?? "Root"}
+                </Text>
+              </Pressable>
             </Animated.View>
           </Fragment>
         ))}

--- a/src/app/(app)/(home)/folder/index.tsx
+++ b/src/app/(app)/(home)/folder/index.tsx
@@ -1,5 +1,0 @@
-import { Redirect } from "expo-router";
-
-export default function FoldersScreen() {
-  return <Redirect href="/folder/Music" />;
-}

--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -255,6 +255,14 @@
     "license": "MIT",
     "licenseText": "MIT License\n\nCopyright (c) 2020-2023 Poimandres\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
+  "jotai-scope": {
+    "name": "jotai-scope",
+    "version": "0.7.0",
+    "copyright": "Copyright (c) 2023 Daishi Kato",
+    "source": "https://github.com/jotaijs/jotai-scope",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2023 Daishi Kato\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE."
+  },
   "Material Symbols": {
     "name": "Material Symbols",
     "version": "0.20.0",

--- a/src/components/ui/container.tsx
+++ b/src/components/ui/container.tsx
@@ -58,3 +58,37 @@ export const ScrollRow = forwardRef<ScrollRow.Ref, ScrollRow.Props>(
     );
   },
 );
+
+// eslint-disable-next-line import/export
+export namespace AnimatedScrollRow {
+  export type Ref = Animated.ScrollView;
+
+  export type Props = Omit<
+    React.ComponentProps<Animated.ScrollView>,
+    "horizontal" | "showsHorizontalScrollIndicator"
+  >;
+}
+
+/**
+ * Horizontal-scrolling list with default styling. Uses `Animated.ScrollView`
+ * from `react-native-reanimated`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare, import/export
+export const AnimatedScrollRow = forwardRef<
+  AnimatedScrollRow.Ref,
+  AnimatedScrollRow.Props
+>(function AnimatedScrollRow({ contentContainerClassName, ...props }, ref) {
+  return (
+    <Animated.ScrollView
+      ref={ref}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      overScrollMode="never"
+      contentContainerClassName={cn(
+        "grow gap-2 px-4",
+        contentContainerClassName,
+      )}
+      {...props}
+    />
+  );
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -119,7 +119,7 @@ export const tracksToPlaylistsRelations = relations(
 );
 
 export const fileNode = sqliteTable("file_node", {
-  // Excludes the verbose `file:///storage/emulated/0/`. Ends with a trailing `/`.
+  // Excludes the `file:///` at the beginning. Ends with a trailing `/`.
   path: text("path").primaryKey(),
   // `null` if `path = "Music"`. Ends with a trailing `/`.
   parentPath: text("parent_path").references(

--- a/src/features/indexing/Config.ts
+++ b/src/features/indexing/Config.ts
@@ -23,7 +23,7 @@ export const OverrideHistory: Record<
   },
   1: {
     version: "v1.0.0-rc.11",
-    changes: ["invalid-tracks-retry"],
+    changes: ["invalid-tracks-retry", "library-scan"],
   },
 };
 

--- a/src/features/indexing/Config.ts
+++ b/src/features/indexing/Config.ts
@@ -26,9 +26,3 @@ export const OverrideHistory: Record<
     changes: ["invalid-tracks-retry", "library-scan"],
   },
 };
-
-/**
- * `file://` URI pointing to the directory where music is stored. Ends
- * with a trailing `/`.
- */
-export const MUSIC_DIRECTORY = "file:///storage/emulated/0/Music/";

--- a/src/features/indexing/api/index-audio.ts
+++ b/src/features/indexing/api/index-audio.ts
@@ -1,5 +1,6 @@
 import {
   MetadataPresets,
+  StorageVolumesDirectoryPaths,
   getMetadata,
 } from "@missingcore/react-native-metadata-retriever";
 import { eq } from "drizzle-orm";
@@ -12,7 +13,7 @@ import { createAlbum, deleteTrack } from "@/db/queries";
 import { Stopwatch } from "@/utils/debug";
 import { isFulfilled, isRejected } from "@/utils/promise";
 import type { Maybe } from "@/utils/types";
-import { MUSIC_DIRECTORY } from "../Config";
+import { addTrailingSlash } from "../utils";
 
 /** Index tracks into our database for fast retrieval. */
 export async function indexAudio() {
@@ -23,7 +24,11 @@ export async function indexAudio() {
   const { totalCount } = await MediaLibrary.getAssetsAsync(assetOptions);
   const audioFiles = (
     await MediaLibrary.getAssetsAsync({ ...assetOptions, first: totalCount })
-  ).assets.filter((a) => a.uri.startsWith(MUSIC_DIRECTORY));
+  ).assets.filter((a) =>
+    StorageVolumesDirectoryPaths.some((dir) =>
+      a.uri.startsWith(`file://${addTrailingSlash(dir)}Music/`),
+    ),
+  );
 
   // Get relevant entries inside our database.
   const allAlbums = await db.query.albums.findMany();

--- a/src/features/indexing/api/index-override/index.ts
+++ b/src/features/indexing/api/index-override/index.ts
@@ -1,3 +1,4 @@
+import { StorageVolumesDirectoryPaths } from "@missingcore/react-native-metadata-retriever";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { db } from "@/db";
@@ -7,6 +8,7 @@ import { fixAlbumFracturization } from "./album-fracturization";
 import { scanLibrary } from "../library-scan";
 import type { AdjustmentOption } from "../../Config";
 import { OverrideHistory } from "../../Config";
+import { addTrailingSlash } from "../../utils";
 
 /**
  * Force any re-indexing based on any changes that we made in the code
@@ -56,6 +58,11 @@ export const AdjustmentFunctionMap: Record<
   "library-scan": async () => {
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(fileNode);
-    await scanLibrary({ dirName: "Music" });
+    await Promise.allSettled(
+      StorageVolumesDirectoryPaths.map((dir) =>
+        // We want to remove the front forward slash.
+        scanLibrary({ dirName: `${addTrailingSlash(dir).slice(1)}Music` }),
+      ),
+    );
   },
 };

--- a/src/features/indexing/utils.ts
+++ b/src/features/indexing/utils.ts
@@ -1,0 +1,4 @@
+/** Ensure a path ends with a trailing forward slash. */
+export function addTrailingSlash(path: string) {
+  return path.endsWith("/") ? path : `${path}/`;
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR aims to add experimental support for music on SD cards. We currently can't test this as I don't have an Android device that supports one (hence why this is experimental). **We carry on the restriction that we'll look only for music files inside a `Music` folder on the "root" level** (mainly to prevent any potentially non-music audio that gets saved - ie: ringtones).
- This restriction will probably be lifted in the future once we implement some sort of "whitelist" feature.

In addition, this PR also:
- Fixed weird behavior w/ "back gesture" when on the `FOLDERS` tab in some scenarios.
- Add some animations to the breadcrumbs on the `FOLDERS` tab.

# How

<!--
How did you build this feature or fix this bug and why?
-->

The first thing we needed to do is fix the stack behavior on the `FOLDERS` tab along with enabling displaying other external storage medias (instead of hardcoding `/storage/emulated/0/Music`).
- We noticed that having the separate `index.tsx` & `[...id].tsx` seemed to be breaking the stack behavior, so we now only have `[...id].tsx` and reworked the code to allow for `id` to be `undefined`.

For making things more "dynamic" in terms of the `FOLDERS` tab, we removed the `MUSIC_DIRECTORY` constant as it was hard-coded and only allows for music files on the device (and not on any other external storages such as an SD card).


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Since we can't really test the support for the SD card, we tested to see if our changes to the `FOLDERS` tab work:
- We checked to see if we go to the `FOLDERS` tab, we see a list of `Music` folders in each external storage device found.
- We visually see the entering & exit animations on the breadcrumbs in the tab when navigating through the folders.
- We see if the back gestures do what is expected (ie: popping the latest segment in the breadcrumb).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [x] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
