### PR TITLE
chore: Speed up folder structure generation

### DIFF
--- a/src/features/indexing/api/index-audio.ts
+++ b/src/features/indexing/api/index-audio.ts
@@ -14,6 +14,7 @@ import { createAlbum, deleteTrack } from "@/db/queries";
 
 import { Stopwatch } from "@/utils/debug";
 import { isFulfilled, isRejected } from "@/utils/promise";
+import { savePathComponents } from "./library-scan";
 import { addTrailingSlash } from "../utils";
 
 /*
@@ -123,6 +124,10 @@ export async function doAudioIndexing() {
 
           try {
             const trackEntry = await getTrackEntry(mediaAsset);
+
+            // Make sure we have the "folder" structure to this file.
+            await savePathComponents(uri);
+
             if (modifiedTracks.has(id) && !isRetry) {
               // Update existing track.
               await db.update(tracks).set(trackEntry).where(eq(tracks.id, id));

--- a/src/features/indexing/api/library-scan.ts
+++ b/src/features/indexing/api/library-scan.ts
@@ -1,9 +1,54 @@
+import { StorageVolumesDirectoryPaths } from "@missingcore/react-native-metadata-retriever";
 import * as FileSystem from "expo-file-system";
 
 import { db } from "@/db";
+import type { FileNode } from "@/db/schema";
 import { fileNodes } from "@/db/schema";
 
 import { isFulfilled } from "@/utils/promise";
+import { addTrailingSlash } from "../utils";
+
+/** Remove the `/` at the start. */
+const volumePaths = StorageVolumesDirectoryPaths.map((path) => path.slice(1));
+
+/**
+ * Generate the list of `FileNode` entries to a given uri. The uri should
+ * start with `file:///`.
+ */
+export async function savePathComponents(uri: string) {
+  // Removes the `file:///` at the start and the filename at the end of the uri.
+  const filePath = uri.slice(8).split("/").slice(0, -1).join("/");
+
+  // Check if the file path is in the database already,
+  const exists = await db.query.fileNodes.findFirst({
+    where: (fields, { eq }) => eq(fields.path, `${filePath}/`),
+  });
+  if (exists) return;
+
+  // Figure out which storage volume this file belongs to.
+  const usedVolume = volumePaths.filter((path) => filePath.startsWith(path))[0];
+  // Don't throw error, but exit if the uri doesn't belong to any of the
+  // storage volumes detected by `@missingcore/react-native-metadata-retriever`.
+  if (!usedVolume) return;
+
+  // List of `FileNode` entries that make up the uri.
+  const foundNodes: FileNode[] = [
+    { name: usedVolume, path: addTrailingSlash(usedVolume), parentPath: null },
+  ];
+
+  // Find remaining `FileNode` entries. `usedVolume.length + 1` is length
+  // of `usedVolume` with a trailing slash.
+  const segments = filePath.slice(usedVolume.length + 1).split("/");
+  segments.forEach((name, idx) => {
+    const parentPath = addTrailingSlash(
+      `${usedVolume}/${segments.slice(0, idx).join("/")}`,
+    );
+    foundNodes.push({ name, path: `${parentPath}${name}/`, parentPath });
+  });
+
+  // Insert found nodes into database.
+  await db.insert(fileNodes).values(foundNodes).onConflictDoNothing();
+}
 
 /**
  * Recursively scans library structure (starting from `file:///${dirName}`

--- a/src/features/indexing/hooks/useIndexAudio.ts
+++ b/src/features/indexing/hooks/useIndexAudio.ts
@@ -8,10 +8,7 @@ import { cleanUpArtwork } from "../api/artwork-cleanup";
 import { saveArtworkOnce } from "../api/artwork-save";
 import { cleanUpDb } from "../api/db-cleanup";
 import { doAudioIndexing } from "../api/index-audio";
-import {
-  AdjustmentFunctionMap,
-  dataReadjustments,
-} from "../api/index-override";
+import { dataReadjustments } from "../api/index-override";
 
 import { createImageDirectory } from "@/lib/file-system";
 import { Stopwatch } from "@/utils/debug";
@@ -43,13 +40,8 @@ export function useIndexAudio() {
     await dataReadjustments();
     console.log(`Completed data adjustments in ${stopwatch.lapTime()}.`);
 
-    const { foundFiles, changed } = await doAudioIndexing();
+    const { foundFiles } = await doAudioIndexing();
     await cleanUpDb(new Set(foundFiles.map(({ id }) => id)));
-    stopwatch.lapTime();
-    if (changed > 0) {
-      await AdjustmentFunctionMap["library-scan"]();
-      console.log(`Re-created library tree in ${stopwatch.lapTime()}.`);
-    }
     console.log(`Finished overall in ${stopwatch.stop()}.`);
 
     // Allow audio to play in the background.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

As mentioned in the previous pull request, I felt the generation of the paths that make up the "Folders" structure feature is kind of a bottleneck. Since we have to read & traverse through the directories on the user's device, the poor performance would really show when we add in the whitelist/blacklist feature as we'll end us scanning more directories (which may end up become all directories).

# How

<!--
How did you build this feature or fix this bug and why?
-->

The solution I probably should have done originally is to generate the paths for the folder structure based on the uris of the tracks we've saved. This ends up being a way faster operation and finishes drastically faster compared to the recursive reading of directories.

In addition, to prepare for the whitelist/blacklist feature, we slightly modified the generation so now, instead of having say `/storage/emulated/0/Music` in the `Root` section of the "Folders" structure feature, we have `/storage/emulated/0` and `/Music` nested under that.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

We expect on a fresh install of the app, to have the paths in the folder structure correctly generated. In addition, in the `Root` section, we should see `/storage/emulated/0` instead of `/storage/emulated/0/Music`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
