### PR TITLE
fix: `Missing MEDIA_LIBRARY permissions.`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,15 +19,13 @@
   <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" tools:node="remove" />
   <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
     tools:node="remove" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-    android:maxSdkVersion="32" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <!--
     Does nothing in Android 11 (API Level 30) and above; however, `expo-media-library`
     still needs it on Android 11 as it throws an error.
       - https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE
   -->
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-    android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

When submitting the app to the Play Console, it typically runs a test suite against it. I noticed in the Sentry logs that we got this issue, but only for Android 12. I assumed it was to them not accepting permissions.

Then we got #62, which shown that this was in fact a real issue and seems to be affecting Android 12.

# How

<!--
How did you build this feature or fix this bug and why?
-->

The issue stemmed from the `expo-media-library` package. In fact, I actually encountered this issue in the past when testing the app on my OnePlus 6 running Android 11. I was limiting the scope of the `WRITE_EXTERNAL_STORAGE` permission to only take effect up-to Android 10 as in [Android 11, the permission has not effect](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE).

So the problem stems from me limiting the scope of the `WRITE_EXTERNAL_STORAGE` permission based on Android versions and `expo-media-library` not correctly recognizing that the permission is no longer necessary in Android 11+.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See if the app doesn't throw an the `Missing MEDIA_LIBRARY permissions.` on an emulated Android 12 device.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
