### PR TITLE
fix: Double Bootsplash

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -70,6 +70,14 @@ export default function RootLayout() {
 function RootLayoutNav() {
   const openModal = useSetAtom(modalAtom);
 
+  useEffect(() => {
+    // Encountered issue in Android 12+ where one of the bootsplashes
+    // persisted when it shouldn't. Make sure we close at least the bootsplash
+    // from `react-native-bootsplash` whenever we render the app (in case its
+    // "autohide" behavior doesn't work as expected).
+    Bootsplash.hide();
+  }, []);
+
   return (
     <AppProvider>
       <Stack screenOptions={{ headerShown: false }}>

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -110,7 +110,7 @@ function IntroModal() {
   return (
     <Modal
       animationType="fade"
-      visible={shownIntroModal === undefined}
+      visible={shownIntroModal === false}
       onRequestClose={() => {
         setShownIntroModal(true);
       }}

--- a/src/components/navigation/animated-boot-splash.tsx
+++ b/src/components/navigation/animated-boot-splash.tsx
@@ -1,4 +1,4 @@
-import { getDefaultStore, useAtomValue } from "jotai";
+import { useAtomValue } from "jotai";
 import { unwrap } from "jotai/utils";
 import { Dimensions, Text, View } from "react-native";
 import BootSplash from "react-native-bootsplash";

--- a/src/components/navigation/animated-boot-splash.tsx
+++ b/src/components/navigation/animated-boot-splash.tsx
@@ -37,10 +37,7 @@ export function AnimatedBootSplash() {
     manifest: require("../../../assets/bootsplash/manifest.json"),
     logo: require("../../../assets/bootsplash/logo.png"),
 
-    animate: async () => {
-      // Pre-load the value.
-      await getDefaultStore().get(shownIntroModalAsyncAtom);
-    },
+    animate: () => {},
   });
 
   const opacity = useAnimatedStyle(() => ({

--- a/src/features/indexing/Config.ts
+++ b/src/features/indexing/Config.ts
@@ -2,6 +2,7 @@ export const AdjustmentOptions = [
   "album-fracturization",
   "artwork-retry",
   "directory-lists",
+  "intro-modal",
   "invalid-tracks-retry",
   "library-scan",
 ] as const;
@@ -30,5 +31,9 @@ export const OverrideHistory: Record<
   1: {
     version: "v1.0.0-rc.11",
     changes: ["directory-lists", "invalid-tracks-retry", "library-scan"],
+  },
+  2: {
+    version: "v1.0.0-rc.12",
+    changes: ["intro-modal"],
   },
 };

--- a/src/features/indexing/api/index-override/index.ts
+++ b/src/features/indexing/api/index-override/index.ts
@@ -6,6 +6,7 @@ import { getDefaultStore } from "jotai";
 import { db } from "@/db";
 import { fileNodes, invalidTracks, tracks } from "@/db/schema";
 
+import { shownIntroModalAtom } from "@/components/navigation/animated-boot-splash";
 import { allowListAsyncAtom } from "@/features/setting/api/library";
 
 import { batch } from "@/utils/promise";
@@ -60,6 +61,11 @@ export const AdjustmentFunctionMap: Record<
       StorageVolumesDirectoryPaths.map(
         (path) => `${addTrailingSlash(path)}Music`,
       ),
+    );
+  },
+  "intro-modal": async () => {
+    await getDefaultStore().set(shownIntroModalAtom, async (prev) =>
+      (await prev) ? true : false,
     );
   },
   "invalid-tracks-retry": async () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

It seems like in Android 12+, `react-native-bootsplash`'s "autohide" behavior sometimes doesn't work as expected, causing the splash screen to persist when it shouldn't.

I've also fixed an issue where the Quick Start modal briefly appears with the splash screen.

This fixes #61.

# How

<!--
How did you build this feature or fix this bug and why?
-->

To fix the Quick Start modal issue, I created a new migration that sets the variable that tracks whether you dismissed the modal to `false` and only display the modal when we see `false` (previously, we checked for `undefined` and the default value was `undefined` - even if the variable hasn't been asynchronously read).

To fix the issue with `react-native-bootsplash`, I added an addition `useEffect()` that runs whenever the navigation gets mounted (ie: we finish our loading logic & haven't seen any errors).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Repeatedly open the app and make sure we don't get stuck on the splash screen.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
