### PR TITLE
chore: Improved rescan feature

### DIFF
--- a/src/app/setting/library.tsx
+++ b/src/app/setting/library.tsx
@@ -1,17 +1,15 @@
 import { StorageVolumesDirectoryPaths } from "@missingcore/react-native-metadata-retriever";
 import { FlashList } from "@shopify/flash-list";
-import { useMutation } from "@tanstack/react-query";
 import { useAtom, useSetAtom } from "jotai";
 import { Pressable, Text, View } from "react-native";
-import { Toast } from "react-native-toast-notifications";
 
 import {
   CloseOutline,
   CreateNewFolderOutline,
 } from "@/assets/svgs/MaterialSymbol";
 import { Ionicons } from "@/components/icons";
-import { AdjustmentFunctionMap } from "@/features/indexing/api/index-override";
 import { allowListAtom, blockListAtom } from "@/features/setting/api/library";
+import { useRescanLibrary } from "@/features/setting/api/library-rescan";
 import { settingModalAtom } from "@/features/setting/store";
 
 import { Colors } from "@/constants/Styles";
@@ -25,15 +23,6 @@ import {
 import { StyledPressable } from "@/components/ui/pressable";
 import { Description, Heading } from "@/components/ui/text";
 
-/** Re-run the library scan logic. */
-const useRescanLibrary = () =>
-  useMutation({
-    mutationFn: AdjustmentFunctionMap["library-scan"],
-    onSuccess: () => {
-      Toast.show("Finished re-scanning folder structure.");
-    },
-  });
-
 /** Screen for `/setting/library` route. */
 export default function LibraryScreen() {
   const rescanLibrary = useRescanLibrary();
@@ -41,7 +30,7 @@ export default function LibraryScreen() {
   return (
     <AnimatedHeader title="LIBRARY">
       <Heading as="h4" className="mb-4 text-start">
-        Re-Scan Folder Structure
+        Rescan Folder Structure
       </Heading>
       <View className="mb-8 flex-row gap-4">
         <Description intent="setting" className="shrink">
@@ -52,7 +41,7 @@ export default function LibraryScreen() {
           </Text>
         </Description>
         <Pressable
-          accessibilityLabel="Re-scan folder structure"
+          accessibilityLabel="Rescan folder structure"
           disabled={rescanLibrary.isPending}
           onPress={() => mutateGuard(rescanLibrary, undefined)}
           className="self-start rounded border border-foreground100 p-3 active:opacity-75 disabled:opacity-25"

--- a/src/app/setting/library.tsx
+++ b/src/app/setting/library.tsx
@@ -29,22 +29,20 @@ export default function LibraryScreen() {
 
   return (
     <AnimatedHeader title="LIBRARY">
-      <Heading as="h4" className="mb-4 text-start">
-        Rescan Folder Structure
-      </Heading>
-      <View className="mb-8 flex-row gap-4">
-        <Description intent="setting" className="shrink">
-          Go through all the indexed tracks and re-create the structure seen in
-          the `FOLDERS` tab, removing any old and unused entries.{"\n\n"}
-          <Text className="text-accent50">
-            This doesn't look for any new tracks. To do that, relaunch the app.
-          </Text>
-        </Description>
+      <View className="mb-8 flex-row justify-between gap-4">
+        <View className="shrink">
+          <Heading as="h4" className="mb-4 text-start">
+            Rescan
+          </Heading>
+          <Description intent="setting">
+            Look for any new tracks on your device.
+          </Description>
+        </View>
         <Pressable
           accessibilityLabel="Rescan folder structure"
           disabled={rescanLibrary.isPending}
           onPress={() => mutateGuard(rescanLibrary, undefined)}
-          className="self-start rounded border border-foreground100 p-3 active:opacity-75 disabled:opacity-25"
+          className="self-end rounded border border-foreground100 p-3 active:opacity-75 disabled:opacity-25"
         >
           <Ionicons name="refresh-outline" color={Colors.foreground100} />
         </Pressable>

--- a/src/features/setting/api/library-rescan.ts
+++ b/src/features/setting/api/library-rescan.ts
@@ -1,0 +1,53 @@
+import { useMutation } from "@tanstack/react-query";
+import { getDefaultStore } from "jotai";
+import { Toast } from "react-native-toast-notifications";
+
+import { cleanUpArtwork } from "@/features/indexing/api/artwork-cleanup";
+import { saveArtwork } from "@/features/indexing/api/artwork-save";
+import { cleanUpDb } from "@/features/indexing/api/db-cleanup";
+import { doAudioIndexing } from "@/features/indexing/api/index-audio";
+import { AdjustmentFunctionMap } from "@/features/indexing/api/index-override";
+import { resynchronizeOnAtom } from "@/features/playback/api/synchronize";
+
+export async function rescanLibrary() {
+  const toastId = Toast.show("Rescanning library...", { duration: 0 });
+
+  try {
+    // Slight buffer before we run our code due to the code blocking the
+    // JS thread, causing `isPending` to not update immediately, allowing
+    // the user to spam the button to rescan the library.
+    await new Promise((resolve) => {
+      setTimeout(() => resolve(true), 100);
+    });
+
+    // Re-create the "folder" structure for tracks we've already saved.
+    await AdjustmentFunctionMap["library-scan"]();
+    // Rescan library for any new tracks and delete any old ones.
+    const { foundFiles } = await doAudioIndexing();
+    await cleanUpDb(new Set(foundFiles.map(({ id }) => id)));
+    // Get the artwork for any new tracks.
+    await saveArtwork();
+    await cleanUpArtwork();
+
+    // Make sure the "recents" list is correct.
+    await getDefaultStore().set(resynchronizeOnAtom, {
+      action: "update",
+      data: null,
+    });
+
+    Toast.update(toastId, "Finished rescanning library.", { duration: 3000 });
+  } catch (err) {
+    console.log(err);
+    Toast.update(toastId, "Failed to rescan library.", {
+      type: "danger",
+      duration: 3000,
+    });
+  }
+}
+
+/**
+ * Re-create the list of file nodes used for the "Folders" feature. In addition,
+ * looks for any new tracks.
+ */
+export const useRescanLibrary = () =>
+  useMutation({ mutationFn: rescanLibrary });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This improves the "rescan" feature to now also look for any new tracks and save it into the database so it can be searched up in the app. This supplements for a potential future "auto rescan" feature (user can manually request a rescan instead of needing to relaunch the app).

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Change the values in the allowlist & blocklist and then use the new rescan feature to see if it displays the expected tracks.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
