### PR TITLE
feat: Search Functionality

### DIFF
--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -12,7 +12,7 @@ import type { Maybe } from "@/utils/types";
 import { Ripple } from "@/components/Form";
 import { Loading } from "@/components/Loading";
 import { StyledText } from "@/components/Typography";
-import { MediaImage } from "@/modules/media/components";
+import { SearchResult } from "@/modules/search/components";
 
 /** Screen for `/artist` route. */
 export default function ArtistScreen() {
@@ -51,12 +51,8 @@ const ArtistIndexPreset = (props: {
             router.navigate(`/artist/${encodeURIComponent(item.name)}`)
           }
           wrapperClassName="rounded-full mt-4"
-          className="pr-4"
         >
-          <MediaImage type="artist" size={48} source={null} />
-          <StyledText numberOfLines={1} className="shrink grow">
-            {item.name}
-          </StyledText>
+          <SearchResult type="artist" source={null} title={item.name} />
         </Ripple>
       ),
     ListEmptyComponent: props.isPending ? (

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -35,8 +35,9 @@ import type { Maybe } from "@/utils/types";
 import { Ripple } from "@/components/Form";
 import { Loading } from "@/components/Loading";
 import { StyledText } from "@/components/Typography";
-import { MediaImage, Track } from "@/modules/media/components";
+import { Track } from "@/modules/media/components";
 import type { PlayListSource } from "@/modules/media/types";
+import { SearchResult } from "@/modules/search/components";
 
 /** Animated scrollview supporting gestures. */
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
@@ -127,12 +128,8 @@ const FolderListPreset = (props: {
         ) : (
           <Ripple
             onPress={() => props.setDirSegments((prev) => [...prev, item.name])}
-            className="pr-4"
           >
-            <MediaImage type="folder" size={48} source={null} radius="sm" />
-            <StyledText numberOfLines={1} className="shrink grow">
-              {item.name}
-            </StyledText>
+            <SearchResult type="folder" source={null} title={item.name} />
           </Ripple>
         )}
       </View>

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -140,6 +140,9 @@ function NavigationList() {
             </StyledText>
           </Button>
         )}
+        // Suppresses error from `scrollToIndex` when we remount this layout
+        // as a result of using the `push` navigation on the `/search` screen.
+        onScrollToIndexFailed={() => {}}
         showsHorizontalScrollIndicator={false}
         contentContainerClassName="px-2"
       />

--- a/mobile/src/app/search.tsx
+++ b/mobile/src/app/search.tsx
@@ -26,10 +26,9 @@ const searchScope = ["album", "artist", "playlist", "track"] as const;
 /** Actions that we want to run when we click on a search item. */
 const searchCallbacks: SearchCallbacks = {
   /* Visit the media's page. */
-  album: ({ id }) => router.navigate(`/album/${id}`),
-  artist: ({ name }) => router.navigate(`/artist/${encodeURIComponent(name)}`),
-  playlist: ({ name }) =>
-    router.navigate(`/playlist/${encodeURIComponent(name)}`),
+  album: ({ id }) => router.push(`/album/${id}`),
+  artist: ({ name }) => router.push(`/artist/${encodeURIComponent(name)}`),
+  playlist: ({ name }) => router.push(`/playlist/${encodeURIComponent(name)}`),
   /* Play the specified track. */
   track: ({ id }) =>
     playFromMediaList({

--- a/mobile/src/app/search.tsx
+++ b/mobile/src/app/search.tsx
@@ -1,29 +1,39 @@
-import { useState } from "react";
+import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
-import { Search } from "@/icons";
+import { playFromMediaList } from "@/modules/media/services/Playback";
 
-import { TextInput } from "@/components/Form";
 import { AccentText } from "@/components/Typography";
+import { ReservedPlaylists } from "@/modules/media/constants";
+import { SearchEngine } from "@/modules/search/components";
+import type { SearchCallbacks } from "@/modules/search/types";
 
 /** Screen for `/search` route. */
 export default function SearchScreen() {
   const { t } = useTranslation();
-  const [query, setQuery] = useState("");
-
   return (
-    <View className="grow gap-6 p-4 pt-8">
+    <View className="grow gap-6 px-4 pt-8">
       <AccentText className="text-3xl">{t("header.search")}</AccentText>
-
-      <View className="flex-row items-center gap-2 rounded-full bg-surface px-4">
-        <Search />
-        <TextInput
-          onChangeText={(text) => setQuery(text)}
-          placeholder={t("form.placeholder.searchMedia")}
-          className="shrink grow"
-        />
-      </View>
+      <SearchEngine searchScope={searchScope} callbacks={searchCallbacks} />
     </View>
   );
 }
+
+/** List of media we want to appear in the search. */
+const searchScope = ["album", "artist", "playlist", "track"] as const;
+
+/** Actions that we want to run when we click on a search item. */
+const searchCallbacks: SearchCallbacks = {
+  /* Visit the media's page. */
+  album: ({ id }) => router.navigate(`/album/${id}`),
+  artist: ({ name }) => router.navigate(`/artist/${encodeURIComponent(name)}`),
+  playlist: ({ name }) =>
+    router.navigate(`/playlist/${encodeURIComponent(name)}`),
+  /* Play the specified track. */
+  track: ({ id }) =>
+    playFromMediaList({
+      trackId: id,
+      source: { type: "playlist", id: ReservedPlaylists.tracks },
+    }),
+};

--- a/mobile/src/components/Typography/Kbd.tsx
+++ b/mobile/src/components/Typography/Kbd.tsx
@@ -1,0 +1,23 @@
+import { Text, View } from "react-native";
+
+import { cn } from "@/lib/style";
+
+/** Our version of the HTML keyboard input element. */
+export function Kbd(props: { text: string; className?: string }) {
+  return (
+    <View
+      aria-hidden
+      className={cn(
+        "size-[14px] items-center justify-center rounded-sm bg-onSurface",
+        props.className,
+      )}
+    >
+      <Text
+        style={{ fontSize: 8 }}
+        className="text-roboto text-center leading-tight text-foreground"
+      >
+        {props.text}
+      </Text>
+    </View>
+  );
+}

--- a/mobile/src/components/Typography/index.ts
+++ b/mobile/src/components/Typography/index.ts
@@ -1,2 +1,3 @@
 export { AccentText } from "./AccentText";
+export { Kbd } from "./Kbd";
 export { StyledText } from "./StyledText";

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -1,25 +1,56 @@
-import { useState } from "react";
+import { FlashList } from "@shopify/flash-list";
+import { LinearGradient } from "expo-linear-gradient";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
-import { Search } from "@/icons";
+import type {
+  AlbumWithTracks,
+  ArtistWithTracks,
+  PlaylistWithTracks,
+  TrackWithAlbum,
+} from "@/db/schema";
+import { getPlaylistCover, getTrackCover } from "@/db/utils";
 
-import { TextInput } from "@/components/Form";
+import { Search } from "@/icons";
+import { useTheme } from "@/hooks/useTheme";
+
+import { cn } from "@/lib/style";
+import { Ripple, TextInput } from "@/components/Form";
+import { StyledText } from "@/components/Typography";
 import { SearchResult } from "./SearchResult";
 import { useSearch } from "../hooks/useSearch";
-import type { SearchCallbacks, SearchCategories } from "../types";
+import type {
+  SearchCallbacks,
+  SearchCategories,
+  SearchResults,
+} from "../types";
 
-/** Contained search - tracks the query and displays results. */
+/** All-in-one search - tracks the query and displays results. */
 export function SearchEngine<TScope extends SearchCategories>(props: {
   searchScope: TScope;
   callbacks: Pick<SearchCallbacks, TScope[number]>;
+  bgColor?: string;
 }) {
   const { t } = useTranslation();
+  const { canvas } = useTheme();
   const [query, setQuery] = useState("");
   const results = useSearch(props.searchScope, query);
 
+  // Format results to be used in `<FlashList />`.
+  const data = useMemo(
+    () => (results ? formatResults(results) : undefined),
+    [results],
+  );
+
+  const shadowColor = useMemo(
+    () => props.bgColor ?? canvas,
+    [props.bgColor, canvas],
+  );
+
   return (
-    <>
+    <View className="grow">
+      {/* Search input. */}
       <View className="flex-row items-center gap-2 rounded-full bg-surface px-4">
         <Search />
         <TextInput
@@ -28,6 +59,94 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
           className="shrink grow"
         />
       </View>
-    </>
+      {/* Results list w/ scroll shadow. */}
+      <View className="relative grow">
+        <FlashList
+          estimatedItemSize={56} // 48px Height + 8px Margin Top
+          data={data}
+          keyExtractor={(_, index) => `${index}`}
+          renderItem={({ item, index }) => {
+            if (typeof item === "string") {
+              return (
+                <StyledText className={cn("text-xs", { "mt-4": index !== 0 })}>
+                  {t(`common.${item}`)}
+                </StyledText>
+              );
+            }
+            const { entry, ...rest } = item;
+
+            return (
+              <Ripple
+                /* @ts-expect-error - `type` should be limited to our scope. */
+                onPress={() => props.callbacks[rest.type](entry)}
+                wrapperClassName={cn("mt-2", {
+                  "rounded-full": rest.type === "artist",
+                })}
+              >
+                {/* @ts-expect-error - Values are of correct types. */}
+                <SearchResult {...rest} />
+              </Ripple>
+            );
+          }}
+          ListEmptyComponent={
+            query.length > 0 ? (
+              <StyledText center>{t("response.noResults")}</StyledText>
+            ) : undefined
+          }
+          showsVerticalScrollIndicator={false}
+          contentContainerClassName="pb-4 pt-6"
+        />
+
+        <LinearGradient
+          colors={[`${shadowColor}FF`, `${shadowColor}00`]}
+          start={{ x: 0.0, y: 0.0 }}
+          end={{ x: 0.0, y: 1.0 }}
+          className="absolute left-0 top-0 h-6 w-full"
+        />
+      </View>
+    </View>
   );
 }
+
+//#region Helpers
+/** Media items with an `artistName` field. */
+const withArtistName = ["album", "track"];
+
+/**
+ * Flatten results to be used in a `<FlashList />` that functions like a
+ * `<SectionList />`. Ensure the "sections" are in alphabetical order and
+ * remove any groups with no items before formatting.
+ */
+function formatResults(results: Partial<SearchResults>) {
+  return Object.entries(results)
+    .filter(([_, data]) => data.length > 0)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, data]) => [
+      key as SearchCategories[number],
+      ...data.map((item) => ({
+        type: key as SearchCategories[number],
+        // @ts-expect-error - Values are of correct types.
+        source: getArtwork({ type: key, data: item }),
+        title: item.name,
+        // @ts-expect-error - `artistName` should be present in these cases.
+        description: withArtistName.includes(key) ? item.artistName : undefined,
+        entry: item,
+      })),
+    ])
+    .flat();
+}
+
+type MediaRelations =
+  | { type: "album"; data: AlbumWithTracks }
+  | { type: "artist"; data: ArtistWithTracks }
+  | { type: "playlist"; data: PlaylistWithTracks }
+  | { type: "track"; data: TrackWithAlbum };
+
+/** Get the artwork of the media that'll be displayed. */
+function getArtwork(props: MediaRelations) {
+  if (props.type === "album") return props.data.artwork;
+  if (props.type === "artist") return null;
+  if (props.type === "playlist") return getPlaylistCover(props.data);
+  return getTrackCover(props.data);
+}
+//#endregion

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { View } from "react-native";
+
+import { Search } from "@/icons";
+
+import { TextInput } from "@/components/Form";
+import { SearchResult } from "./SearchResult";
+import { useSearch } from "../hooks/useSearch";
+import type { SearchCallbacks, SearchCategories } from "../types";
+
+/** Contained search - tracks the query and displays results. */
+export function SearchEngine<TScope extends SearchCategories>(props: {
+  searchScope: TScope;
+  callbacks: Pick<SearchCallbacks, TScope[number]>;
+}) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const results = useSearch(props.searchScope, query);
+
+  return (
+    <>
+      <View className="flex-row items-center gap-2 rounded-full bg-surface px-4">
+        <Search />
+        <TextInput
+          onChangeText={(text) => setQuery(text)}
+          placeholder={t("form.placeholder.searchMedia")}
+          className="shrink grow"
+        />
+      </View>
+    </>
+  );
+}

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -128,8 +128,9 @@ function formatResults(results: Partial<SearchResults>) {
         // @ts-expect-error - Values are of correct types.
         source: getArtwork({ type: key, data: item }),
         title: item.name,
+        // prettier-ignore
         // @ts-expect-error - `artistName` should be present in these cases.
-        description: withArtistName.includes(key) ? item.artistName : undefined,
+        description: withArtistName.includes(key) ? (item.artistName ?? "—") : undefined,
         entry: item,
       })),
     ])

--- a/mobile/src/modules/search/components/SearchResult.tsx
+++ b/mobile/src/modules/search/components/SearchResult.tsx
@@ -1,0 +1,52 @@
+import { View } from "react-native";
+
+import { cn } from "@/lib/style";
+import type { Prettify } from "@/utils/types";
+import { StyledText } from "@/components/Typography";
+import { MediaImage } from "@/modules/media/components";
+
+/** Displays information about a media item. */
+export function SearchResult(
+  props: Prettify<
+    MediaImage.ImageContent & {
+      title: string;
+      description?: string;
+      /** Element that's placed next to the title. */
+      Indicator?: React.ReactElement;
+      className?: string;
+    }
+  >,
+) {
+  return (
+    <View
+      className={cn(
+        "min-h-12 flex-row items-center gap-2 pr-4",
+        props.className,
+      )}
+    >
+      {/* @ts-expect-error - These props are type-safe.*/}
+      <MediaImage
+        type={props.type}
+        size={48}
+        source={props.source}
+        radius="sm"
+      />
+      <View className="shrink grow">
+        <View className="shrink flex-row items-end gap-1">
+          {props.Indicator}
+          <StyledText
+            numberOfLines={1}
+            className={cn("shrink grow", { "text-sm": !!props.description })}
+          >
+            {props.title}
+          </StyledText>
+        </View>
+        {!!props.description && (
+          <StyledText preset="dimOnCanvas" numberOfLines={1}>
+            {props.description}
+          </StyledText>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/mobile/src/modules/search/components/SearchResult.tsx
+++ b/mobile/src/modules/search/components/SearchResult.tsx
@@ -2,7 +2,7 @@ import { View } from "react-native";
 
 import { cn } from "@/lib/style";
 import type { Prettify } from "@/utils/types";
-import { StyledText } from "@/components/Typography";
+import { Kbd, StyledText } from "@/components/Typography";
 import { MediaImage } from "@/modules/media/components";
 
 /** Displays information about a media item. */
@@ -12,7 +12,7 @@ export function SearchResult(
       title: string;
       description?: string;
       /** Element that's placed next to the title. */
-      Indicator?: React.ReactElement;
+      kbdLetter?: string;
       className?: string;
     }
   >,
@@ -33,7 +33,9 @@ export function SearchResult(
       />
       <View className="shrink grow">
         <View className="shrink flex-row items-end gap-1">
-          {props.Indicator}
+          {props.kbdLetter ? (
+            <Kbd text={props.kbdLetter} className="mb-0.5" />
+          ) : undefined}
           <StyledText
             numberOfLines={1}
             className={cn("shrink grow", { "text-sm": !!props.description })}

--- a/mobile/src/modules/search/components/index.ts
+++ b/mobile/src/modules/search/components/index.ts
@@ -1,0 +1,1 @@
+export { SearchResult } from "./SearchResult";

--- a/mobile/src/modules/search/components/index.ts
+++ b/mobile/src/modules/search/components/index.ts
@@ -1,1 +1,2 @@
+export { SearchEngine } from "./SearchEngine";
 export { SearchResult } from "./SearchResult";

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -17,12 +17,12 @@ export function useSearch<TScope extends SearchCategories>(
   const { data } = useAllMedia();
   return useMemo(() => {
     if (!data || !query) return undefined;
-    let q = query.toLowerCase();
+    let q = query.toLocaleLowerCase();
     // Keep results if we have a partial match with the "name".
     return Object.fromEntries(
       scope.map((mediaType) => [
         mediaType,
-        data[mediaType].filter((item) => item.name.toLowerCase().includes(q)),
+        data[mediaType].filter((i) => i.name.toLocaleLowerCase().includes(q)),
       ]),
     ) as Pick<SearchResults, TScope[number]>;
   }, [data, query, scope]);

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -18,11 +18,17 @@ export function useSearch<TScope extends SearchCategories>(
   return useMemo(() => {
     if (!data || !query) return undefined;
     let q = query.toLocaleLowerCase();
-    // Keep results if we have a partial match with the "name".
     return Object.fromEntries(
       scope.map((mediaType) => [
         mediaType,
-        data[mediaType].filter((i) => i.name.toLocaleLowerCase().includes(q)),
+        data[mediaType].filter(
+          (i) =>
+            // Partial match with the `name` field.
+            i.name.toLocaleLowerCase().includes(q) ||
+            // Track's album starts with the query.
+            // @ts-expect-error - We ensured the `album` field is present.
+            (i.album && i.album.name.toLocaleLowerCase().startsWith(q)),
+        ),
       ]),
     ) as Pick<SearchResults, TScope[number]>;
   }, [data, query, scope]);

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import type {
+  AlbumWithTracks,
+  ArtistWithTracks,
+  PlaylistWithTracks,
+  TrackWithAlbum,
+} from "@/db/schema";
+
+import { getAlbums } from "@/api/album";
+import { getArtists } from "@/api/artist";
+import { getPlaylists } from "@/api/playlist";
+import { getTracks } from "@/api/track";
+
+import type { Prettify } from "@/utils/types";
+import type { MediaType } from "@/modules/media/types";
+
+type Results = {
+  album: AlbumWithTracks[];
+  artist: ArtistWithTracks[];
+  // folder: unknown[];
+  playlist: PlaylistWithTracks[];
+  track: TrackWithAlbum[];
+};
+
+/** Returns media specified by query in the given scope. */
+export function useSearch<
+  TScope extends ReadonlyArray<Exclude<MediaType, "folder">>,
+>(
+  scope: TScope,
+  query?: string,
+): Prettify<Pick<Results, TScope[number]>> | undefined {
+  const { data } = useAllMedia();
+  return useMemo(() => {
+    if (!data || !query) return undefined;
+    let q = query.toLowerCase();
+    // Keep results if we have a partial match with the "name".
+    return Object.fromEntries(
+      scope.map((mediaType) => [
+        mediaType,
+        data[mediaType].filter((item) => item.name.toLowerCase().includes(q)),
+      ]),
+    ) as Pick<Results, TScope[number]>;
+  }, [data, query, scope]);
+}
+
+//#region Helpers
+async function getAllMedia() {
+  return {
+    album: await getAlbums(),
+    artist: await getArtists(),
+    playlist: await getPlaylists(),
+    track: (await getTracks()).sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+const queryKey = ["search"];
+
+function useAllMedia() {
+  return useQuery({ queryKey, queryFn: getAllMedia });
+}
+//#endregion

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -1,36 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-import type {
-  AlbumWithTracks,
-  ArtistWithTracks,
-  PlaylistWithTracks,
-  TrackWithAlbum,
-} from "@/db/schema";
-
 import { getAlbums } from "@/api/album";
 import { getArtists } from "@/api/artist";
 import { getPlaylists } from "@/api/playlist";
 import { getTracks } from "@/api/track";
 
 import type { Prettify } from "@/utils/types";
-import type { MediaType } from "@/modules/media/types";
-
-type Results = {
-  album: AlbumWithTracks[];
-  artist: ArtistWithTracks[];
-  // folder: unknown[];
-  playlist: PlaylistWithTracks[];
-  track: TrackWithAlbum[];
-};
+import type { SearchCategories, SearchResults } from "../types";
 
 /** Returns media specified by query in the given scope. */
-export function useSearch<
-  TScope extends ReadonlyArray<Exclude<MediaType, "folder">>,
->(
+export function useSearch<TScope extends SearchCategories>(
   scope: TScope,
   query?: string,
-): Prettify<Pick<Results, TScope[number]>> | undefined {
+): Prettify<Pick<SearchResults, TScope[number]>> | undefined {
   const { data } = useAllMedia();
   return useMemo(() => {
     if (!data || !query) return undefined;
@@ -41,7 +24,7 @@ export function useSearch<
         mediaType,
         data[mediaType].filter((item) => item.name.toLowerCase().includes(q)),
       ]),
-    ) as Pick<Results, TScope[number]>;
+    ) as Pick<SearchResults, TScope[number]>;
   }, [data, query, scope]);
 }
 

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -1,0 +1,29 @@
+import type {
+  AlbumWithTracks,
+  ArtistWithTracks,
+  PlaylistWithTracks,
+  TrackWithAlbum,
+} from "@/db/schema";
+
+import type { MediaType } from "@/modules/media/types";
+
+/** Categories of media that can be returned by search. */
+export type SearchCategories = ReadonlyArray<Exclude<MediaType, "folder">>;
+
+/** Functions that can be triggered on the categories of media. */
+export type SearchCallbacks = {
+  album: (album: AlbumWithTracks) => void | Promise<void>;
+  artist: (artist: ArtistWithTracks) => void | Promise<void>;
+  // folder: (folder: unknown) => void | Promise<void>;
+  playlist: (playlist: PlaylistWithTracks) => void | Promise<void>;
+  track: (track: TrackWithAlbum) => void | Promise<void>;
+};
+
+/** Data that can be returned from search. */
+export type SearchResults = {
+  album: AlbumWithTracks[];
+  artist: ArtistWithTracks[];
+  // folder: unknown[];
+  playlist: PlaylistWithTracks[];
+  track: TrackWithAlbum[];
+};

--- a/mobile/src/queries/artist.ts
+++ b/mobile/src/queries/artist.ts
@@ -33,7 +33,7 @@ export function useArtistsForIndex() {
       const groupedArtists: Record<string, Artist[]> = {};
       data.forEach(({ tracks: _, ...artist }) => {
         const key = /[a-zA-Z]/.test(artist.name.charAt(0))
-          ? artist.name.charAt(0).toUpperCase()
+          ? artist.name.charAt(0).toLocaleUpperCase()
           : "#";
         if (Object.hasOwn(groupedArtists, key)) {
           groupedArtists[key]!.push(artist);

--- a/mobile/src/screens/Sheets/ScanFilterList/index.tsx
+++ b/mobile/src/screens/Sheets/ScanFilterList/index.tsx
@@ -57,10 +57,7 @@ export default function ScanFilterListSheet(
         keyExtractor={(item) => item}
         renderItem={({ item, index }) => (
           <Swipeable
-            containerClassName={cn("px-4", {
-              "mt-1": index !== 0,
-              "mb-4": index === listEntries!.length - 1,
-            })}
+            containerClassName={cn("px-4", { "mt-1": index !== 0 })}
             renderRightActions={() => (
               <View className="pr-4">
                 <IconButton
@@ -86,6 +83,7 @@ export default function ScanFilterListSheet(
           <StyledText center>{t("response.noFilters")}</StyledText>
         }
         showsVerticalScrollIndicator={false}
+        contentContainerClassName="pb-4"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackToPlaylist.tsx
+++ b/mobile/src/screens/Sheets/TrackToPlaylist.tsx
@@ -53,10 +53,7 @@ export default function TrackToPlaylistSheet(
                   item.name,
                 )
               }
-              wrapperClassName={cn({
-                "mt-1": index !== 0,
-                "mb-4": index === data!.length - 1,
-              })}
+              wrapperClassName={cn({ "mt-1": index !== 0 })}
             >
               <Marquee color={selected ? surface : canvasAlt}>
                 <StyledText>{item.name}</StyledText>
@@ -72,6 +69,7 @@ export default function TrackToPlaylistSheet(
           )
         }
         showsVerticalScrollIndicator={false}
+        contentContainerClassName="pb-4"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -60,7 +60,6 @@ export default function TrackUpcomingSheet(
           const wrapperStyle = cn("px-4", {
             "opacity-25": index >= disableIndex,
             "mt-1": index !== 0,
-            "mb-4": index === data!.length - 1,
           });
 
           if (index < queueList.length) {
@@ -93,6 +92,7 @@ export default function TrackUpcomingSheet(
           );
         }}
         showsVerticalScrollIndicator={false}
+        contentContainerClassName="pb-4"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -13,7 +13,6 @@ import { cn } from "@/lib/style";
 import { IconButton } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { Swipeable } from "@/components/Swipeable";
-import { StyledText } from "@/components/Typography";
 import { SearchResult } from "@/modules/search/components";
 
 /**
@@ -116,18 +115,7 @@ function TrackItem({
     <SearchResult
       type="track"
       {...props}
-      Indicator={
-        inQueue ? (
-          <View
-            aria-hidden
-            className="mb-0.5 size-[14px] items-center justify-center rounded-sm bg-onSurface"
-          >
-            <StyledText style={{ fontSize: 8 }} className="leading-tight">
-              Q
-            </StyledText>
-          </View>
-        ) : undefined
-      }
+      kbdLetter={inQueue ? "Q" : undefined}
       className="rounded-sm bg-canvas pr-0 dark:bg-neutral5"
     />
   );

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -14,7 +14,7 @@ import { IconButton } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { Swipeable } from "@/components/Swipeable";
 import { StyledText } from "@/components/Typography";
-import { MediaImage } from "@/modules/media/components";
+import { SearchResult } from "@/modules/search/components";
 
 /**
  * Sheet allowing us to see the upcoming tracks and remove tracks from
@@ -53,9 +53,9 @@ export default function TrackUpcomingSheet(
         keyExtractor={({ name }, index) => `${name}_${index}`}
         renderItem={({ item, index }) => {
           const itemContent = {
-            name: item.name,
-            artistName: item.artistName ?? "—",
-            artwork: getTrackCover(item),
+            title: item.name,
+            description: item.artistName ?? "—",
+            source: getTrackCover(item),
           };
 
           const wrapperStyle = cn("px-4", {
@@ -103,35 +103,32 @@ export default function TrackUpcomingSheet(
  * Essentially `<Track />` without any playing functionality. Has special
  * behavior if the rendered track is part of the queue.
  */
-function TrackItem(props: {
-  name: string;
-  artistName: string;
-  artwork: string | null;
+function TrackItem({
+  inQueue,
+  ...props
+}: {
+  title: string;
+  description: string;
+  source: string | null;
   inQueue?: boolean;
 }) {
   return (
-    <View className="min-h-12 flex-row items-center gap-2 bg-canvas dark:bg-neutral5">
-      <MediaImage type="track" size={48} source={props.artwork} radius="sm" />
-      <View className="shrink grow">
-        <View className="shrink flex-row items-end gap-1">
-          {props.inQueue && (
-            <View
-              aria-hidden
-              className="mb-0.5 size-[14px] items-center justify-center rounded-sm bg-onSurface"
-            >
-              <StyledText style={{ fontSize: 8 }} className="leading-tight">
-                Q
-              </StyledText>
-            </View>
-          )}
-          <StyledText numberOfLines={1} className="shrink grow text-sm">
-            {props.name}
-          </StyledText>
-        </View>
-        <StyledText preset="dimOnCanvas" numberOfLines={1}>
-          {props.artistName}
-        </StyledText>
-      </View>
-    </View>
+    <SearchResult
+      type="track"
+      {...props}
+      Indicator={
+        inQueue ? (
+          <View
+            aria-hidden
+            className="mb-0.5 size-[14px] items-center justify-center rounded-sm bg-onSurface"
+          >
+            <StyledText style={{ fontSize: 8 }} className="leading-tight">
+              Q
+            </StyledText>
+          </View>
+        ) : undefined
+      }
+      className="rounded-sm bg-canvas pr-0 dark:bg-neutral5"
+    />
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Add a basic search feature which returns albums, artists, playlists, and tracks through:
- Partial match (ie: the query matches part of the name).
- Partial album match for tracks (ie: the album on a track starts with the query).

> [!NOTE]  
> What we return from the specified query may change in the future based on behavior expected by users.

The press behavior of the results are as follows:
- Clicking on a track will play that track from "all tracks" (ie: same behavior as finding and playing a track on the Track screen).
- Clicking on an album, artist, or playlist will bring you to their respective pages.

# How

<!--
How did you build this feature or fix this bug and why?
-->

One weird behavior when working on the `onPress` actions on the Search screen is that when we go "back" after doing a `navigate` action, we don't return to the Search screen. Using a `push` navigation will allow the "back" action go to the Search screen, but if we searched while not on the home screen, we end up with an `scrollToIndex` error. This error I think was caused by another layout being mounted with the navigation and the the `scrollToIndex` failing because of this. This ended up being solved by providing a "noop" function for the `onScrollToIndexFailed` prop.
- One downside of this remount behavior is that the miniplayer will appear after a delay after navigating to the album, artist, or playlist screen from the search screen.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Have the expected behaviors of search work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [x] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
