### PR TITLE
feat: Support additional track metadata

### DIFF
--- a/mobile/src/api/album.ts
+++ b/mobile/src/api/album.ts
@@ -18,7 +18,11 @@ export const getAlbum: QuerySingleFn<AlbumWithTracks> = async (
 ) => {
   const album = await db.query.albums.findFirst({
     where: eq(albums.id, id),
-    with: { tracks: { orderBy: (fields, { asc }) => [asc(fields.track)] } },
+    with: {
+      tracks: {
+        orderBy: (fields, { asc }) => [asc(fields.disc), asc(fields.track)],
+      },
+    },
   });
   if (shouldThrow && !album) throw new Error(i18next.t("response.noAlbums"));
   return album;
@@ -28,7 +32,11 @@ export const getAlbum: QuerySingleFn<AlbumWithTracks> = async (
 export async function getAlbums(where: DrizzleFilter = []) {
   return db.query.albums.findMany({
     where: and(...where),
-    with: { tracks: { orderBy: (fields, { asc }) => [asc(fields.track)] } },
+    with: {
+      tracks: {
+        orderBy: (fields, { asc }) => [asc(fields.disc), asc(fields.track)],
+      },
+    },
     orderBy: (fields) => [iAsc(fields.name), iAsc(fields.artistName)],
   });
 }

--- a/mobile/src/app/current-track.tsx
+++ b/mobile/src/app/current-track.tsx
@@ -12,7 +12,7 @@ import {
   VolumeMute,
   VolumeUp,
 } from "@/icons";
-import { useFavoriteTrack, useTrackExcerpt } from "@/queries/track";
+import { useFavoriteTrack, useTrack } from "@/queries/track";
 import { useMusicStore } from "@/modules/media/services/Music";
 import { MusicControls } from "@/modules/media/services/Playback";
 import { useUserPreferencesStore } from "@/services/UserPreferences";
@@ -190,7 +190,7 @@ function VolumeSlider() {
 /** Actions rendered on the bottom of the screen. */
 function BottomAppBar({ trackId }: { trackId: string }) {
   const { t } = useTranslation();
-  const { data } = useTrackExcerpt(trackId); // Since we don't revalidate the Zustand store.
+  const { data } = useTrack(trackId); // Since we don't revalidate the Zustand store.
   const favoriteTrack = useFavoriteTrack(trackId);
 
   const isFav = favoriteTrack.isPending

--- a/mobile/src/components/TopAppBar.tsx
+++ b/mobile/src/components/TopAppBar.tsx
@@ -67,7 +67,7 @@ export function TopAppBarMarquee({ options, route }: NativeStackHeaderProps) {
           <ArrowBack />
         </IconButton>
 
-        <Marquee color={canvas} center>
+        <Marquee color={canvas} center wrapperClassName="shrink">
           <StyledText className="text-xs">{title}</StyledText>
         </Marquee>
 

--- a/mobile/src/db/drizzle/0005_nappy_talon.sql
+++ b/mobile/src/db/drizzle/0005_nappy_talon.sql
@@ -1,0 +1,37 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_tracks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`artist_name` text,
+	`album_id` text,
+	`artwork` text,
+	`is_favorite` integer DEFAULT false NOT NULL,
+	`duration` integer NOT NULL,
+	`disc` integer,
+	`track` integer,
+	`format` text,
+	`bitrate` integer,
+	`sample_rate` integer,
+	`size` integer NOT NULL,
+	`uri` text NOT NULL,
+	`modification_time` integer NOT NULL,
+	`fetched_art` integer DEFAULT false NOT NULL,
+	FOREIGN KEY (`artist_name`) REFERENCES `artists`(`name`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`album_id`) REFERENCES `albums`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_tracks`("id", "name", "artist_name", "album_id", "artwork", "is_favorite", "duration", "disc", "track", "format", "bitrate", "sample_rate", "size", "uri", "modification_time", "fetched_art") SELECT "id", "name", "artist_name", "album_id", "artwork", "is_favorite", "duration", "disc", "track", "format", "bitrate", "sample_rate", "size", "uri", "modification_time", "fetched_art" FROM `tracks`;--> statement-breakpoint
+DROP TABLE `tracks`;--> statement-breakpoint
+ALTER TABLE `__new_tracks` RENAME TO `tracks`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_tracks_to_playlists` (
+	`track_id` text NOT NULL,
+	`playlist_name` text NOT NULL,
+	PRIMARY KEY(`track_id`, `playlist_name`),
+	FOREIGN KEY (`track_id`) REFERENCES `tracks`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`playlist_name`) REFERENCES `playlists`(`name`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_tracks_to_playlists`("track_id", "playlist_name") SELECT "track_id", "playlist_name" FROM `tracks_to_playlists`;--> statement-breakpoint
+DROP TABLE `tracks_to_playlists`;--> statement-breakpoint
+ALTER TABLE `__new_tracks_to_playlists` RENAME TO `tracks_to_playlists`;

--- a/mobile/src/db/drizzle/meta/0005_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,444 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0e52e805-e00f-4877-8094-75569a74888b",
+  "prevId": "21d0dc15-7e03-4a52-ae16-12b68edbaf9e",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "albums_name_artist_name_release_year_unique": {
+          "name": "albums_name_artist_name_release_year_unique",
+          "columns": [
+            "name",
+            "artist_name",
+            "release_year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1725684724459,
       "tag": "0004_past_starfox",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1733689925630,
+      "tag": "0005_nappy_talon",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -6,6 +6,7 @@ import m0001 from "./0001_wooden_wallop.sql";
 import m0002 from "./0002_third_giant_man.sql";
 import m0003 from "./0003_breezy_wolverine.sql";
 import m0004 from "./0004_past_starfox.sql";
+import m0005 from "./0005_nappy_talon.sql";
 
 export default {
   journal,
@@ -15,5 +16,6 @@ export default {
     m0002,
     m0003,
     m0004,
+    m0005,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -55,13 +55,19 @@ export const tracks = sqliteTable("tracks", {
   artistName: text().references(() => artists.name),
   albumId: text().references(() => albums.id),
   artwork: text(),
-  track: integer().notNull().default(-1), // Track number in album if available
-  duration: integer().notNull(), // Track duration in seconds
   isFavorite: integer({ mode: "boolean" }).notNull().default(false),
+  duration: integer().notNull(), // Track duration in seconds
+  // Album relations
+  disc: integer(),
+  track: integer(),
+  // Other metadata
+  format: text(), // Currently the mimetype of the file
+  bitrate: integer(),
+  sampleRate: integer(),
+  size: integer().notNull(),
   uri: text().notNull(),
   modificationTime: integer().notNull(),
-
-  /* Data checking fields. */
+  // Data checking fields.
   fetchedArt: integer({ mode: "boolean" }).notNull().default(false),
 });
 

--- a/mobile/src/modules/scanning/constants.ts
+++ b/mobile/src/modules/scanning/constants.ts
@@ -1,4 +1,4 @@
-const MigrationOptions = ["v1-to-v2-store"] as const;
+const MigrationOptions = ["v1-to-v2-store", "v1-to-v2-schema"] as const;
 
 export type MigrationOption = (typeof MigrationOptions)[number];
 
@@ -20,5 +20,8 @@ export const MigrationHistory: Record<
   0: { version: "v1.0.0-rc.10", changes: [] },
   1: { version: "v1.0.0-rc.11", changes: [] },
   2: { version: "v1.0.0-rc.12", changes: [] },
-  3: { version: "v2.0.0-rc.1", changes: ["v1-to-v2-store"] },
+  3: {
+    version: "v2.0.0-rc.1",
+    changes: ["v1-to-v2-store", "v1-to-v2-schema"],
+  },
 };

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -33,6 +33,7 @@ export async function findAndSaveArtwork() {
   });
 
   let newArtworkCount = 0;
+  let checkedFiles = 0;
 
   for (const { id, albumId, uri, name, artwork } of uncheckedTracks) {
     // Make sure the track doesn't have `artwork` and either be unassociated
@@ -59,7 +60,12 @@ export async function findAndSaveArtwork() {
 
     // Indicate we attempted to find artwork for a track.
     await updateTrack(id, { fetchedArt: true });
-    onboardingStore.setState((prev) => ({ checked: prev.checked + 1 }));
+    checkedFiles++;
+    // Prevent excessive `setState` on Zustand store which may cause an
+    // "Warning: Maximum update depth exceeded.".
+    if (checkedFiles % 25 === 0) {
+      onboardingStore.setState({ checked: checkedFiles });
+    }
   }
   console.log(
     `Finished saving ${newArtworkCount} new cover images in ${stopwatch.lapTime()}.`,

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -230,9 +230,9 @@ async function getTrackEntry({
   return {
     ...{ id, name: meta.title ?? removeFileExtension(filename) },
     ...{ artistName: meta.artist, albumId, track: meta.trackNumber },
-    ...{ disc: meta.discNumber, format: meta.sampleMimeType },
-    ...{ bitrate, sampleRate, size: assetInfo.exists ? assetInfo.size : 0 },
-    ...{ duration, uri, modificationTime, fetchedArt: false },
+    ...{ disc: meta.discNumber, format: meta.sampleMimeType, bitrate },
+    ...{ sampleRate, duration, uri, modificationTime, fetchedArt: false },
+    ...{ size: assetInfo.exists ? (assetInfo.size ?? 0) : 0 },
   };
 }
 //#endregion

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -4,6 +4,7 @@ import {
   getMetadata,
 } from "@missingcore/react-native-metadata-retriever";
 import { eq } from "drizzle-orm";
+import * as FileSystem from "expo-file-system";
 import * as MediaLibrary from "expo-media-library";
 
 import { db } from "@/db";
@@ -189,6 +190,11 @@ export async function findAndSaveAudio() {
   };
 }
 
+const wantedMetadata = [
+  ...MetadataPresets.standard,
+  ...["discNumber", "bitrate", "sampleMimeType", "sampleRate"],
+] as const;
+
 async function getTrackEntry({
   id,
   uri,
@@ -196,12 +202,15 @@ async function getTrackEntry({
   modificationTime,
   filename,
 }: MediaLibrary.Asset) {
-  const { albumArtist, albumTitle, artist, title, trackNumber, year } =
-    await getMetadata(uri, MetadataPresets.standard);
+  const { bitrate, sampleRate, ...meta } = await getMetadata(
+    uri,
+    wantedMetadata,
+  );
+  const assetInfo = await FileSystem.getInfoAsync(uri);
 
   // Add new artists to the database.
   await Promise.allSettled(
-    [artist, albumArtist]
+    [meta.artist, meta.albumArtist]
       .filter((name) => name !== null)
       .map((name) => createArtist({ name })),
   );
@@ -209,18 +218,20 @@ async function getTrackEntry({
   // Add new album to the database. The unique key on `Album` covers the rare
   // case where an artist releases multiple albums with the same name.
   let albumId: string | null = null;
-  if (!!albumTitle && !!albumArtist) {
+  if (!!meta.albumTitle && !!meta.albumArtist) {
     const newAlbum = await upsertAlbum({
-      name: albumTitle,
-      artistName: albumArtist,
-      releaseYear: year,
+      name: meta.albumTitle,
+      artistName: meta.albumArtist,
+      releaseYear: meta.year,
     });
     if (newAlbum) albumId = newAlbum.id;
   }
 
   return {
-    ...{ id, name: title ?? removeFileExtension(filename) },
-    ...{ artistName: artist, albumId, track: trackNumber ?? undefined },
+    ...{ id, name: meta.title ?? removeFileExtension(filename) },
+    ...{ artistName: meta.artist, albumId, track: meta.trackNumber },
+    ...{ disc: meta.discNumber, format: meta.sampleMimeType },
+    ...{ bitrate, sampleRate, size: assetInfo.exists ? assetInfo.size : 0 },
     ...{ duration, uri, modificationTime, fetchedArt: false },
   };
 }

--- a/mobile/src/modules/scanning/helpers/migrations.ts
+++ b/mobile/src/modules/scanning/helpers/migrations.ts
@@ -1,4 +1,8 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { tracks } from "@/db/schema";
 
 import { userPreferencesStore } from "@/services/UserPreferences";
 
@@ -43,6 +47,13 @@ export const MigrationFunctionMap: Record<
     const listBlock = await readFilterList("directory-blocklist");
 
     userPreferencesStore.setState({ listAllow, listBlock });
+  },
+  "v1-to-v2-schema": async () => {
+    // We now allow the `track` field to be null.
+    await db.update(tracks).set({ track: null }).where(eq(tracks.track, -1));
+    // Easy way of rechecking all tracks.
+    // eslint-disable-next-line drizzle/enforce-update-with-where
+    await db.update(tracks).set({ modificationTime: -1 });
   },
 };
 

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -1,6 +1,6 @@
 import { toast } from "@backpackapp-io/react-native-toast";
 import { useMutation } from "@tanstack/react-query";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { fileNodes, invalidTracks, tracks } from "@/db/schema";
@@ -48,7 +48,7 @@ export async function rescanForTracks() {
     await db
       .update(tracks)
       .set({ fetchedArt: false })
-      .where(eq(tracks.fetchedArt, true));
+      .where(and(eq(tracks.fetchedArt, true), isNull(tracks.artwork)));
 
     // Rescan library for any new tracks and delete any old ones.
     const { foundFiles, unstagedFiles } = await findAndSaveAudio();

--- a/mobile/src/queries/track.ts
+++ b/mobile/src/queries/track.ts
@@ -7,20 +7,12 @@ import { Resynchronize } from "@/modules/media/services/Resynchronize";
 import { useSortTracks } from "@/modules/media/services/SortPreferences";
 import { queries as q } from "./keyStore";
 
-import { pickKeys } from "@/utils/object";
 import { ReservedPlaylists } from "@/modules/media/constants";
 
 //#region Queries
-/** Return the most-used subset of track data. */
-export function useTrackExcerpt(trackId: string) {
-  return useQuery({
-    ...q.tracks.detail(trackId),
-    select: (data) => ({
-      ...pickKeys(data, ["id", "name", "artistName", "duration", "isFavorite"]),
-      album: data.album ? pickKeys(data.album, ["id", "name"]) : null,
-      imageSource: data.artwork,
-    }),
-  });
+/** Get specified track. */
+export function useTrack(trackId: string) {
+  return useQuery({ ...q.tracks.detail(trackId) });
 }
 
 /** Return the names of the playlists this track is in. */

--- a/mobile/src/utils/number.ts
+++ b/mobile/src/utils/number.ts
@@ -6,6 +6,11 @@ export function abbreviateNum(num: number) {
   }).format(num);
 }
 
+/** Convert bit rate to kbit/s. */
+export function abbreviateBitRate(rate: number) {
+  return `${(rate / 1000).toFixed(2).replace(".00", "")} kbit/s`;
+}
+
 /** Abbreviate size in bytes. */
 export function abbreviateSize(size: number) {
   if (size >= 1e9) {
@@ -17,6 +22,14 @@ export function abbreviateSize(size: number) {
   } else {
     return `${size} B`;
   }
+}
+
+/** Convert epoch time to `YYYY-MM-DD` */
+export function formatEpoch(ms: number) {
+  const date = new Date(ms);
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
 }
 
 /**


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Satisfies one of the feature requests from way back and enables us to improve sorting within albums.
- Add metadata for disc number, bitrate, sample rate, format (file mimetype), and file size.
- Now sort tracks in albums by disc number then track number.
- Add new "stats" section in track modal, displaying additional information about the track such as bitrate, sample rate, size, etc.
  - Known issue where `.flac` files don't have a bitrate assigned to it (will be revisiting our `@missingcore/react-native-metadata-retriever` package later).
- Fixed "bricking" that occurs due to encountering an Out of Memory error when saving artwork of tracks.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Ensure that our migrations to get the new metadata work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [x] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
