### PR TITLE
chore: Consistent & simpler props & components

### DIFF
--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -9,7 +9,6 @@ import { useBottomActionsContext } from "@/hooks/useBottomActionsContext";
 import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { mutateGuard } from "@/lib/react-query";
-import { cn } from "@/lib/style";
 import { IconButton } from "@/components/Form";
 import { Em, StyledText } from "@/components/Typography";
 import { Track } from "@/modules/media/components";
@@ -72,21 +71,21 @@ export default function CurrentAlbumScreen() {
           data={data.tracks}
           keyExtractor={({ id }) => id}
           renderItem={({ item, index }) => (
-            <View className={cn({ "mt-2": index > 0 })}>
+            <>
               {item.disc !== null && discLocation[item.disc] === index ? (
                 <Em
                   preset="dimOnCanvas"
-                  className={cn("mb-2", { "mt-2": index > 0 })}
+                  className={index === 0 ? "mb-2" : "mt-4"}
                 >
                   {t("common.disc", { count: item.disc })}
                 </Em>
               ) : null}
               <Track
-                {...item}
+                {...{ ...item, trackSource }}
                 LeftElement={<TrackNumber track={item.track} />}
-                trackSource={trackSource}
+                className={index > 0 ? "mt-2" : undefined}
               />
-            </View>
+            </>
           )}
           overScrollMode="never"
           showsVerticalScrollIndicator={false}

--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -10,6 +10,7 @@ import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { mutateGuard } from "@/lib/react-query";
 import { IconButton } from "@/components/Form";
+import { PagePlaceholder } from "@/components/Transition";
 import { Em, StyledText } from "@/components/Typography";
 import { Track } from "@/modules/media/components";
 
@@ -21,14 +22,7 @@ export default function CurrentAlbumScreen() {
   const { isPending, error, data } = useAlbumForScreen(albumId);
   const favoriteAlbum = useFavoriteAlbum(albumId);
 
-  if (isPending) return <View className="w-full flex-1 px-4" />;
-  else if (error) {
-    return (
-      <View className="w-full flex-1 p-4">
-        <StyledText center>{t("response.noContent")}</StyledText>
-      </View>
-    );
-  }
+  if (isPending || error) return <PagePlaceholder {...{ isPending }} />;
 
   // Add optimistic UI updates.
   const isToggled = favoriteAlbum.isPending

--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -1,4 +1,3 @@
-import { FlashList } from "@shopify/flash-list";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
@@ -9,6 +8,7 @@ import { useBottomActionsContext } from "@/hooks/useBottomActionsContext";
 import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { mutateGuard } from "@/lib/react-query";
+import { FlashList } from "@/components/Defaults";
 import { IconButton } from "@/components/Form";
 import { PagePlaceholder } from "@/components/Transition";
 import { Em, StyledText } from "@/components/Typography";
@@ -81,8 +81,6 @@ export default function CurrentAlbumScreen() {
               />
             </>
           )}
-          overScrollMode="never"
-          showsVerticalScrollIndicator={false}
           className="mx-4"
           contentContainerClassName="pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -83,17 +83,15 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
         data={albums}
         keyExtractor={({ id }) => id}
         renderItem={({ item, index }) => (
-          <View className={index > 0 ? "pl-3" : undefined}>
-            <MediaCard
-              key={item.id}
-              type="album"
-              size={width}
-              source={item.artwork}
-              href={`/album/${item.id}`}
-              title={item.name}
-              subtitle={`${item.releaseYear ?? "————"}`}
-            />
-          </View>
+          <MediaCard
+            type="album"
+            size={width}
+            source={item.artwork}
+            href={`/album/${item.id}`}
+            title={item.name}
+            description={`${item.releaseYear ?? "————"}`}
+            className={index > 0 ? "ml-3" : undefined}
+          />
         )}
         overScrollMode="never"
         showsHorizontalScrollIndicator={false}

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -1,4 +1,3 @@
-import { FlashList } from "@shopify/flash-list";
 import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 
@@ -10,6 +9,7 @@ import { useGetColumn } from "@/hooks/useGetColumn";
 import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { cn } from "@/lib/style";
+import { FlashList } from "@/components/Defaults";
 import { PagePlaceholder } from "@/components/Transition";
 import { Em } from "@/components/Typography";
 import { MediaCard, Track } from "@/modules/media/components";
@@ -43,8 +43,6 @@ export default function CurrentArtistScreen() {
           />
         )}
         ListHeaderComponent={<ArtistAlbums albums={data.albums} />}
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="pt-4"
         contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
       />
@@ -85,8 +83,6 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
             className={index > 0 ? "ml-3" : undefined}
           />
         )}
-        overScrollMode="never"
-        showsHorizontalScrollIndicator={false}
         contentContainerClassName="px-4"
       />
       <Em preset="dimOnCanvas" className="m-4 mb-2">

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -1,7 +1,6 @@
 import { FlashList } from "@shopify/flash-list";
 import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
 
 import type { Album } from "@/db/schema";
 
@@ -11,24 +10,17 @@ import { useGetColumn } from "@/hooks/useGetColumn";
 import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { cn } from "@/lib/style";
-import { Em, StyledText } from "@/components/Typography";
+import { PagePlaceholder } from "@/components/Transition";
+import { Em } from "@/components/Typography";
 import { MediaCard, Track } from "@/modules/media/components";
 
 /** Screen for `/artist/[id]` route. */
 export default function CurrentArtistScreen() {
-  const { t } = useTranslation();
   const { bottomInset } = useBottomActionsContext();
   const { id: artistName } = useLocalSearchParams<{ id: string }>();
   const { isPending, error, data } = useArtistForScreen(artistName);
 
-  if (isPending) return <View className="w-full flex-1 px-4" />;
-  else if (error) {
-    return (
-      <View className="w-full flex-1 p-4">
-        <StyledText center>{t("response.noContent")}</StyledText>
-      </View>
-    );
-  }
+  if (isPending || error) return <PagePlaceholder {...{ isPending }} />;
 
   // Information about this track list.
   const trackSource = { type: "artist", id: artistName } as const;

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -1,5 +1,4 @@
 import { useLocalSearchParams } from "expo-router";
-import { useTranslation } from "react-i18next";
 
 import type { Album } from "@/db/schema";
 
@@ -11,7 +10,7 @@ import { CurrentListLayout } from "@/layouts/CurrentList";
 import { cn } from "@/lib/style";
 import { FlashList } from "@/components/Defaults";
 import { PagePlaceholder } from "@/components/Transition";
-import { Em } from "@/components/Typography";
+import { TEm } from "@/components/Typography";
 import { MediaCard, Track } from "@/modules/media/components";
 
 /** Screen for `/artist/[id]` route. */
@@ -55,7 +54,6 @@ export default function CurrentArtistScreen() {
  * list only if the artist has albums.
  */
 function ArtistAlbums({ albums }: { albums: Album[] | null }) {
-  const { t } = useTranslation();
   const { width } = useGetColumn({
     ...{ cols: 1, gap: 0, gutters: 32, minWidth: 100 },
   });
@@ -64,9 +62,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
 
   return (
     <>
-      <Em preset="dimOnCanvas" className="mx-4 mb-2">
-        {t("common.albums")}
-      </Em>
+      <TEm preset="dimOnCanvas" textKey="common.albums" className="mx-4 mb-2" />
       <FlashList
         estimatedItemSize={width + 12} // Column width + gap from padding left
         horizontal
@@ -85,9 +81,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
         )}
         contentContainerClassName="px-4"
       />
-      <Em preset="dimOnCanvas" className="m-4 mb-2">
-        {t("common.tracks")}
-      </Em>
+      <TEm preset="dimOnCanvas" textKey="common.tracks" className="m-4 mb-2" />
     </>
   );
 }

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -45,9 +45,10 @@ export default function CurrentArtistScreen() {
         data={data.tracks}
         keyExtractor={({ id }) => id}
         renderItem={({ item, index }) => (
-          <View className={cn("mx-4", { "mt-2": index > 0 })}>
-            <Track {...item} trackSource={trackSource} />
-          </View>
+          <Track
+            {...{ ...item, trackSource }}
+            className={cn("mx-4", { "mt-2": index > 0 })}
+          />
         )}
         ListHeaderComponent={<ArtistAlbums albums={data.albums} />}
         overScrollMode="never"
@@ -82,7 +83,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
         data={albums}
         keyExtractor={({ id }) => id}
         renderItem={({ item, index }) => (
-          <View className={cn({ "pl-3": index !== 0 })}>
+          <View className={index > 0 ? "pl-3" : undefined}>
             <MediaCard
               key={item.id}
               type="album"

--- a/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
@@ -1,23 +1,29 @@
 import { FlashList } from "@shopify/flash-list";
-import { useTranslation } from "react-i18next";
 
 import { useFavoriteTracksForScreen } from "@/queries/favorite";
 import { useBottomActionsContext } from "@/hooks/useBottomActionsContext";
 import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { PagePlaceholder } from "@/components/Transition";
-import { TrackListPreset } from "@/modules/media/components";
+import { ReservedPlaylists } from "@/modules/media/constants";
+import { useTrackListPreset } from "@/modules/media/components";
 
 /** Screen for displaying favorited tracks. */
 export default function FavoriteTracksScreen() {
-  const { t } = useTranslation();
+  // Information about this track list.
+  const trackSource = {
+    type: "playlist",
+    id: ReservedPlaylists.favorites,
+  } as const;
+
   const { bottomInset } = useBottomActionsContext();
   const { isPending, error, data } = useFavoriteTracksForScreen();
+  const listPresets = useTrackListPreset({
+    ...{ data: data?.tracks, trackSource },
+    emptyMsgKey: "response.noTracks",
+  });
 
   if (isPending || error) return <PagePlaceholder {...{ isPending }} />;
-
-  // Information about this track list.
-  const trackSource = { type: "playlist", id: data.name } as const;
 
   return (
     <CurrentListLayout
@@ -27,12 +33,7 @@ export default function FavoriteTracksScreen() {
       mediaSource={trackSource}
     >
       <FlashList
-        {...TrackListPreset({
-          ...{ data: data.tracks, trackSource },
-          emptyMessage: t("response.noTracks"),
-        })}
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
+        {...listPresets}
         className="mx-4"
         contentContainerClassName="pt-4"
         contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}

--- a/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
@@ -1,12 +1,11 @@
 import { FlashList } from "@shopify/flash-list";
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
 
 import { useFavoriteTracksForScreen } from "@/queries/favorite";
 import { useBottomActionsContext } from "@/hooks/useBottomActionsContext";
 import { CurrentListLayout } from "@/layouts/CurrentList";
 
-import { StyledText } from "@/components/Typography";
+import { PagePlaceholder } from "@/components/Transition";
 import { TrackListPreset } from "@/modules/media/components";
 
 /** Screen for displaying favorited tracks. */
@@ -15,14 +14,7 @@ export default function FavoriteTracksScreen() {
   const { bottomInset } = useBottomActionsContext();
   const { isPending, error, data } = useFavoriteTracksForScreen();
 
-  if (isPending) return <View className="w-full flex-1 px-4" />;
-  else if (error) {
-    return (
-      <View className="w-full flex-1 p-4">
-        <StyledText center>{t("response.noContent")}</StyledText>
-      </View>
-    );
-  }
+  if (isPending || error) return <PagePlaceholder {...{ isPending }} />;
 
   // Information about this track list.
   const trackSource = { type: "playlist", id: data.name } as const;

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -10,7 +10,6 @@ import { CurrentListLayout } from "@/layouts/CurrentList";
 
 import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
-import { cn } from "@/lib/style";
 import { FlashList } from "@/components/Defaults";
 import { IconButton } from "@/components/Form";
 import { Swipeable } from "@/components/Swipeable";
@@ -73,7 +72,7 @@ export default function CurrentPlaylistScreen() {
           data={data.tracks}
           keyExtractor={({ id }) => id}
           renderItem={({ item, index }) => (
-            <View className={cn({ "mt-2": index > 0 })}>
+            <View className={index > 0 ? "mt-2" : undefined}>
               <PlaylistTrack
                 playlistName={data.name}
                 track={item}
@@ -112,7 +111,7 @@ function PlaylistTrack(props: {
           <Remove color={Colors.neutral100} />
         </IconButton>
       )}
-      childrenContainerClassName={cn("px-4")}
+      childrenContainerClassName="px-4"
     >
       <Track {...props.track} trackSource={props.trackSource} />
     </Swipeable>

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -1,4 +1,3 @@
-import { FlashList } from "@shopify/flash-list";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
@@ -12,10 +11,10 @@ import { CurrentListLayout } from "@/layouts/CurrentList";
 import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
 import { cn } from "@/lib/style";
+import { FlashList } from "@/components/Defaults";
 import { IconButton } from "@/components/Form";
 import { Swipeable } from "@/components/Swipeable";
 import { PagePlaceholder } from "@/components/Transition";
-import { StyledText } from "@/components/Typography";
 import { Track } from "@/modules/media/components";
 import type { PlayListSource } from "@/modules/media/types";
 
@@ -82,13 +81,9 @@ export default function CurrentPlaylistScreen() {
               />
             </View>
           )}
-          overScrollMode="never"
-          showsVerticalScrollIndicator={false}
           contentContainerClassName="pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
-          ListEmptyComponent={
-            <StyledText center>{t("response.noTracks")}</StyledText>
-          }
+          emptyMsgKey="response.noTracks"
         />
       </CurrentListLayout>
     </>

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -14,6 +14,7 @@ import { mutateGuard } from "@/lib/react-query";
 import { cn } from "@/lib/style";
 import { IconButton } from "@/components/Form";
 import { Swipeable } from "@/components/Swipeable";
+import { PagePlaceholder } from "@/components/Transition";
 import { StyledText } from "@/components/Typography";
 import { Track } from "@/modules/media/components";
 import type { PlayListSource } from "@/modules/media/types";
@@ -26,14 +27,7 @@ export default function CurrentPlaylistScreen() {
   const { isPending, error, data } = usePlaylistForScreen(id);
   const favoritePlaylist = useFavoritePlaylist(id);
 
-  if (isPending) return <View className="w-full flex-1 px-4" />;
-  else if (error) {
-    return (
-      <View className="w-full flex-1 p-4">
-        <StyledText center>{t("response.noContent")}</StyledText>
-      </View>
-    );
-  }
+  if (isPending || error) return <PagePlaceholder {...{ isPending }} />;
 
   // Add optimistic UI updates.
   const isToggled = favoritePlaylist.isPending

--- a/mobile/src/app/(main)/(home)/album.tsx
+++ b/mobile/src/app/(main)/(home)/album.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from "react-i18next";
-
 import { useAlbumsForCards } from "@/queries/album";
 import { StickyActionListLayout } from "@/layouts";
 
@@ -7,11 +5,10 @@ import { useMediaCardListPreset } from "@/modules/media/components";
 
 /** Screen for `/album` route. */
 export default function AlbumScreen() {
-  const { t } = useTranslation();
   const { isPending, data } = useAlbumsForCards();
   const presets = useMediaCardListPreset({
     ...{ data, isPending },
-    emptyMessage: t("response.noAlbums"),
+    emptyMsgKey: "response.noAlbums",
   });
 
   return <StickyActionListLayout titleKey="common.albums" {...presets} />;

--- a/mobile/src/app/(main)/(home)/album.tsx
+++ b/mobile/src/app/(main)/(home)/album.tsx
@@ -14,5 +14,5 @@ export default function AlbumScreen() {
     emptyMessage: t("response.noAlbums"),
   });
 
-  return <StickyActionListLayout title={t("common.albums")} {...presets} />;
+  return <StickyActionListLayout titleKey="common.albums" {...presets} />;
 }

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -9,7 +9,6 @@ import { StickyActionListLayout } from "@/layouts";
 
 import { cn } from "@/lib/style";
 import type { Maybe } from "@/utils/types";
-import { Ripple } from "@/components/Form";
 import { Loading } from "@/components/Transition";
 import { Em, StyledText } from "@/components/Typography";
 import { SearchResult } from "@/modules/search/components";
@@ -44,14 +43,13 @@ const ArtistIndexPreset = (props: {
       typeof item === "string" ? (
         <Em className={cn({ "mt-4": index !== 0 })}>{item}</Em>
       ) : (
-        <Ripple
+        <SearchResult
+          {...{ as: "ripple", type: "artist", title: item.name }}
           onPress={() =>
             router.navigate(`/artist/${encodeURIComponent(item.name)}`)
           }
           wrapperClassName="rounded-full mt-2"
-        >
-          <SearchResult type="artist" source={null} title={item.name} />
-        </Ripple>
+        />
       ),
     ListEmptyComponent: props.isPending ? (
       <Loading />

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -1,17 +1,19 @@
 import { router } from "expo-router";
-import { useTranslation } from "react-i18next";
 
 import { useArtistsForIndex } from "@/queries/artist";
 import { StickyActionListLayout } from "@/layouts";
 
-import { Loading } from "@/components/Transition";
-import { Em, StyledText } from "@/components/Typography";
+import { useListPresets } from "@/components/Defaults";
+import { Em } from "@/components/Typography";
 import { SearchResult } from "@/modules/search/components";
 
 /** Screen for `/artist` route. */
 export default function ArtistScreen() {
-  const { t } = useTranslation();
   const { isPending, data } = useArtistsForIndex();
+  const listPresets = useListPresets({
+    isPending,
+    emptyMsgKey: "response.noArtists",
+  });
 
   return (
     <StickyActionListLayout
@@ -33,13 +35,7 @@ export default function ArtistScreen() {
           />
         )
       }
-      ListEmptyComponent={
-        isPending ? (
-          <Loading />
-        ) : (
-          <StyledText center>{t("response.noArtists")}</StyledText>
-        )
-      }
+      {...listPresets}
     />
   );
 }

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -1,14 +1,9 @@
-import type { FlashListProps } from "@shopify/flash-list";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
-
-import type { Artist } from "@/db/schema";
 
 import { useArtistsForIndex } from "@/queries/artist";
 import { StickyActionListLayout } from "@/layouts";
 
-import { cn } from "@/lib/style";
-import type { Maybe } from "@/utils/types";
 import { Loading } from "@/components/Transition";
 import { Em, StyledText } from "@/components/Typography";
 import { SearchResult } from "@/modules/search/components";
@@ -21,41 +16,30 @@ export default function ArtistScreen() {
   return (
     <StickyActionListLayout
       title={t("common.artists")}
-      {...ArtistIndexPreset({
-        ...{ data, isPending },
-        emptyMessage: t("response.noArtists"),
-      })}
+      estimatedItemSize={56} // 48px Height + 8px Margin Top
+      data={data}
+      keyExtractor={(item) => (typeof item === "string" ? item : item.name)}
+      renderItem={({ item, index }) =>
+        typeof item === "string" ? (
+          <Em className={index > 0 ? "mt-4" : undefined}>{item}</Em>
+        ) : (
+          <SearchResult
+            {...{ as: "ripple", type: "artist", title: item.name }}
+            onPress={() =>
+              router.navigate(`/artist/${encodeURIComponent(item.name)}`)
+            }
+            wrapperClassName="mt-2 rounded-full"
+            className="pr-4"
+          />
+        )
+      }
+      ListEmptyComponent={
+        isPending ? (
+          <Loading />
+        ) : (
+          <StyledText center>{t("response.noArtists")}</StyledText>
+        )
+      }
     />
   );
 }
-
-//#region Preset
-const ArtistIndexPreset = (props: {
-  data: Maybe<ReadonlyArray<string | Artist>>;
-  emptyMessage?: string;
-  isPending?: boolean;
-}) =>
-  ({
-    estimatedItemSize: 56, // 48px Height + 8px Margin Top
-    data: props.data,
-    keyExtractor: (item) => (typeof item === "string" ? item : item.name),
-    renderItem: ({ item, index }) =>
-      typeof item === "string" ? (
-        <Em className={cn({ "mt-4": index !== 0 })}>{item}</Em>
-      ) : (
-        <SearchResult
-          {...{ as: "ripple", type: "artist", title: item.name }}
-          onPress={() =>
-            router.navigate(`/artist/${encodeURIComponent(item.name)}`)
-          }
-          wrapperClassName="mt-2 rounded-full"
-          className="pr-4"
-        />
-      ),
-    ListEmptyComponent: props.isPending ? (
-      <Loading />
-    ) : (
-      <StyledText center>{props.emptyMessage}</StyledText>
-    ),
-  }) satisfies FlashListProps<string | Artist>;
-//#endregion

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -48,7 +48,8 @@ const ArtistIndexPreset = (props: {
           onPress={() =>
             router.navigate(`/artist/${encodeURIComponent(item.name)}`)
           }
-          wrapperClassName="rounded-full mt-2"
+          wrapperClassName="mt-2 rounded-full"
+          className="pr-4"
         />
       ),
     ListEmptyComponent: props.isPending ? (

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -15,7 +15,7 @@ export default function ArtistScreen() {
 
   return (
     <StickyActionListLayout
-      title={t("common.artists")}
+      titleKey="common.artists"
       estimatedItemSize={56} // 48px Height + 8px Margin Top
       data={data}
       keyExtractor={(item) => (typeof item === "string" ? item : item.name)}

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -81,7 +81,7 @@ export default function FolderScreen() {
   return (
     <StickyActionListLayout
       listRef={listRef}
-      title={t("common.folder")}
+      titleKey="common.folder"
       estimatedItemSize={56} // 48px Height + 8px Margin Top
       data={[data?.subDirectories ?? [], data?.tracks ?? []].flat()}
       keyExtractor={(_, index) => `${index}`}

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -1,6 +1,5 @@
 import { useIsFocused } from "@react-navigation/native";
 import { Fragment, useCallback, useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { BackHandler, Pressable, useWindowDimensions } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import Animated, {
@@ -25,7 +24,7 @@ import {
 } from "@/layouts";
 
 import { cn } from "@/lib/style";
-import { Loading } from "@/components/Transition";
+import { useListPresets } from "@/components/Defaults";
 import { StyledText } from "@/components/Typography";
 import { Track } from "@/modules/media/components";
 import { SearchResult } from "@/modules/search/components";
@@ -37,7 +36,6 @@ type FolderData = FileNode | Track.Content;
 
 /** Screen for `/folder` route. */
 export default function FolderScreen() {
-  const { t } = useTranslation();
   const isFocused = useIsFocused();
   const listRef = useStickyActionListLayoutRef<FolderData>();
   const [dirSegments, _setDirSegments] = useState<string[]>([]);
@@ -45,6 +43,7 @@ export default function FolderScreen() {
   const fullPath = dirSegments.join("/");
 
   const { isPending, data } = useFolderContent(fullPath);
+  const listPresets = useListPresets({ isPending });
 
   /** Modified state setter that scrolls to the top of the page. */
   const setDirSegments: React.Dispatch<React.SetStateAction<string[]>> =
@@ -102,13 +101,7 @@ export default function FolderScreen() {
           )}
         </>
       )}
-      ListEmptyComponent={
-        isPending ? (
-          <Loading />
-        ) : (
-          <StyledText center>{t("response.noContent")}</StyledText>
-        )
-      }
+      {...listPresets}
       StickyAction={
         <Breadcrumbs
           dirSegments={dirSegments}

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -2,12 +2,7 @@ import { useIsFocused } from "@react-navigation/native";
 import type { FlashListProps } from "@shopify/flash-list";
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  BackHandler,
-  Pressable,
-  View,
-  useWindowDimensions,
-} from "react-native";
+import { BackHandler, Pressable, useWindowDimensions } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import Animated, {
   FadeInLeft,
@@ -121,16 +116,21 @@ const FolderListPreset = (props: {
     data: props.data,
     keyExtractor: (_, index) => `${index}`,
     renderItem: ({ item, index }) => (
-      <View className={cn({ "mt-2": index !== 0 })}>
+      <>
         {isTrackContent(item) ? (
-          <Track {...{ ...item, trackSource: props.trackSource }} />
+          <Track
+            {...{ ...item, trackSource: props.trackSource }}
+            className={index > 0 ? "mt-2" : undefined}
+          />
         ) : (
           <SearchResult
             {...{ as: "ripple", type: "folder", title: item.name }}
             onPress={() => props.setDirSegments((prev) => [...prev, item.name])}
+            wrapperClassName={index > 0 ? "mt-2" : undefined}
+            className="pr-4"
           />
         )}
-      </View>
+      </>
     ),
     ListEmptyComponent: props.isPending ? (
       <Loading />
@@ -194,7 +194,7 @@ function Breadcrumbs({
       >
         {[undefined, ...dirSegments].map((dirName, idx) => (
           <Fragment key={idx}>
-            {idx !== 0 ? (
+            {idx > 0 ? (
               <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
                 <StyledText className="px-1 text-xs">/</StyledText>
               </Animated.View>

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -32,7 +32,6 @@ import {
 
 import { cn } from "@/lib/style";
 import type { Maybe } from "@/utils/types";
-import { Ripple } from "@/components/Form";
 import { Loading } from "@/components/Transition";
 import { StyledText } from "@/components/Typography";
 import { Track } from "@/modules/media/components";
@@ -126,11 +125,10 @@ const FolderListPreset = (props: {
         {isTrackContent(item) ? (
           <Track {...{ ...item, trackSource: props.trackSource }} />
         ) : (
-          <Ripple
+          <SearchResult
+            {...{ as: "ripple", type: "folder", title: item.name }}
             onPress={() => props.setDirSegments((prev) => [...prev, item.name])}
-          >
-            <SearchResult type="folder" source={null} title={item.name} />
-          </Ripple>
+          />
         )}
       </View>
     ),

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -1,6 +1,5 @@
 import { FlashList } from "@shopify/flash-list";
 import { router } from "expo-router";
-import { useTranslation } from "react-i18next";
 import { useEffect, useRef, useState } from "react";
 import { ScrollView } from "react-native-gesture-handler";
 
@@ -15,7 +14,7 @@ import { StickyActionScrollLayout } from "@/layouts";
 import { cn } from "@/lib/style";
 import { abbreviateNum } from "@/utils/number";
 import { Button } from "@/components/Form";
-import { AccentText, Em, StyledText } from "@/components/Typography";
+import { AccentText, TEm, TStyledText } from "@/components/Typography";
 import { ReservedPlaylists } from "@/modules/media/constants";
 import {
   MediaCard,
@@ -25,13 +24,11 @@ import {
 
 /** Screen for `/` route. */
 export default function HomeScreen() {
-  const { t } = useTranslation();
   return (
     <StickyActionScrollLayout titleKey="header.home">
-      <Em className="-mb-4">{t("home.playedRecent")}</Em>
+      <TEm textKey="home.playedRecent" className="-mb-4" />
       <RecentlyPlayed />
-
-      <Em className="-mb-4">{t("home.favorites")}</Em>
+      <TEm textKey="home.favorites" className="-mb-4" />
       <Favorites />
     </StickyActionScrollLayout>
   );
@@ -40,7 +37,6 @@ export default function HomeScreen() {
 //#region Recently Played List
 /** Display list of media recently played. */
 function RecentlyPlayed() {
-  const { t } = useTranslation();
   const { width } = useGetColumn({
     ...{ cols: 1, gap: 0, gutters: 32, minWidth: 100 },
   });
@@ -80,9 +76,11 @@ function RecentlyPlayed() {
         />
       )}
       ListEmptyComponent={
-        <StyledText onLayout={() => setInitNoData(true)} className="my-4">
-          {t("response.noRecents")}
-        </StyledText>
+        <TStyledText
+          onLayout={() => setInitNoData(true)}
+          textKey="response.noRecents"
+          className="my-4"
+        />
       }
       renderScrollComponent={ScrollView}
       overScrollMode="never"
@@ -111,7 +109,6 @@ function Favorites() {
  * favorited tracks.
  */
 function FavoriteTracks(props: { size: number; className: string }) {
-  const { t } = useTranslation();
   const { isPending, error, data } = useFavoriteTracksCount();
 
   const trackCount = isPending || error ? "" : abbreviateNum(data);
@@ -127,7 +124,7 @@ function FavoriteTracks(props: { size: number; className: string }) {
       <AccentText className="text-[3rem] text-neutral100">
         {trackCount}
       </AccentText>
-      <StyledText className="text-neutral100">{t("common.tracks")}</StyledText>
+      <TStyledText textKey="common.tracks" className="text-neutral100" />
     </Button>
   );
 }

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -27,7 +27,7 @@ import {
 export default function HomeScreen() {
   const { t } = useTranslation();
   return (
-    <StickyActionScrollLayout title={t("header.home")}>
+    <StickyActionScrollLayout titleKey="header.home">
       <Em className="-mb-4">{t("home.playedRecent")}</Em>
       <RecentlyPlayed />
 

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -2,7 +2,6 @@ import { FlashList } from "@shopify/flash-list";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { useEffect, useRef, useState } from "react";
-import { View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 
 import {
@@ -74,12 +73,11 @@ function RecentlyPlayed() {
       data={recentlyPlayedData}
       keyExtractor={({ href }) => href}
       renderItem={({ item, index }) => (
-        <View
+        <MediaCard
           onLayout={(e) => setItemHeight(e.nativeEvent.layout.height)}
-          className={cn({ "pl-3": index !== 0 })}
-        >
-          <MediaCard {...item} size={width} />
-        </View>
+          {...{ ...item, size: width }}
+          className={index > 0 ? "ml-3" : undefined}
+        />
       )}
       ListEmptyComponent={
         <StyledText onLayout={() => setInitNoData(true)} className="my-4">
@@ -111,7 +109,7 @@ function Favorites() {
  * Displays the number of favorited tracks and opens up the playlist of
  * favorited tracks.
  */
-function FavoriteTracks({ size }: { size: number }) {
+function FavoriteTracks(props: { size: number; className: string }) {
   const { t } = useTranslation();
   const { isPending, error, data } = useFavoriteTracksCount();
 
@@ -122,8 +120,8 @@ function FavoriteTracks({ size }: { size: number }) {
       onPress={() =>
         router.navigate(`/playlist/${ReservedPlaylists.favorites}`)
       }
-      style={{ width: size, height: size }}
-      className="gap-0 rounded-lg bg-red"
+      style={{ width: props.size, height: props.size }}
+      className={cn("gap-0 rounded-lg bg-red", props.className)}
     >
       <AccentText className="text-[3rem] text-neutral100">
         {trackCount}

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -85,6 +85,7 @@ function RecentlyPlayed() {
         </StyledText>
       }
       renderScrollComponent={ScrollView}
+      overScrollMode="never"
       showsHorizontalScrollIndicator={false}
       className="-mx-4"
       contentContainerClassName="px-4"

--- a/mobile/src/app/(main)/(home)/playlist.tsx
+++ b/mobile/src/app/(main)/(home)/playlist.tsx
@@ -19,7 +19,7 @@ export default function PlaylistScreen() {
 
   return (
     <StickyActionListLayout
-      title={t("common.playlists")}
+      titleKey="common.playlists"
       StickyAction={<PlaylistActions />}
       estimatedActionSize={48}
       {...presets}

--- a/mobile/src/app/(main)/(home)/playlist.tsx
+++ b/mobile/src/app/(main)/(home)/playlist.tsx
@@ -10,11 +10,10 @@ import { useMediaCardListPreset } from "@/modules/media/components";
 
 /** Screen for `/playlist` route. */
 export default function PlaylistScreen() {
-  const { t } = useTranslation();
   const { isPending, data } = usePlaylistsForCards();
   const presets = useMediaCardListPreset({
     ...{ data, isPending },
-    emptyMessage: t("response.noPlaylists"),
+    emptyMsgKey: "response.noPlaylists",
   });
 
   return (

--- a/mobile/src/app/(main)/(home)/track.tsx
+++ b/mobile/src/app/(main)/(home)/track.tsx
@@ -23,7 +23,7 @@ export default function TrackScreen() {
 
   return (
     <StickyActionListLayout
-      title={t("common.tracks")}
+      titleKey="common.tracks"
       StickyAction={<TrackActions />}
       estimatedActionSize={48}
       {...TrackListPreset({

--- a/mobile/src/app/(main)/(home)/track.tsx
+++ b/mobile/src/app/(main)/(home)/track.tsx
@@ -8,7 +8,10 @@ import { StickyActionListLayout } from "@/layouts";
 
 import { IconButton } from "@/components/Form";
 import { ReservedPlaylists } from "@/modules/media/constants";
-import { MediaListControls, TrackListPreset } from "@/modules/media/components";
+import {
+  MediaListControls,
+  useTrackListPreset,
+} from "@/modules/media/components";
 
 // Information about this track list.
 const trackSource = {
@@ -18,18 +21,18 @@ const trackSource = {
 
 /** Screen for `/track` route. */
 export default function TrackScreen() {
-  const { t } = useTranslation();
   const { isPending, data } = useTracksForTrackCard();
+  const listPresets = useTrackListPreset({
+    ...{ data, trackSource, isPending },
+    emptyMsgKey: "response.noTracks",
+  });
 
   return (
     <StickyActionListLayout
       titleKey="common.tracks"
       StickyAction={<TrackActions />}
       estimatedActionSize={48}
-      {...TrackListPreset({
-        ...{ data, trackSource, isPending },
-        emptyMessage: t("response.noTracks"),
-      })}
+      {...listPresets}
     />
   );
 }

--- a/mobile/src/app/(main)/(home)/track.tsx
+++ b/mobile/src/app/(main)/(home)/track.tsx
@@ -46,7 +46,7 @@ function TrackActions() {
       <IconButton
         kind="ripple"
         accessibilityLabel={t("title.sort")}
-        onPress={() => SheetManager.show("track-sort-sheet")}
+        onPress={() => SheetManager.show("TrackSortSheet")}
       >
         <Sort />
       </IconButton>

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -143,6 +143,7 @@ function NavigationList() {
         // Suppresses error from `scrollToIndex` when we remount this layout
         // as a result of using the `push` navigation on the `/search` screen.
         onScrollToIndexFailed={() => {}}
+        overScrollMode="never"
         showsHorizontalScrollIndicator={false}
         contentContainerClassName="px-2"
       />

--- a/mobile/src/app/+not-found.tsx
+++ b/mobile/src/app/+not-found.tsx
@@ -1,6 +1,5 @@
 import { Stack, usePathname } from "expo-router";
 import { useAtomValue } from "jotai";
-import { useTranslation } from "react-i18next";
 
 import { prevRouteAtom } from "@/providers/RouteHandlers";
 import { IssueLayout } from "@/layouts";
@@ -9,7 +8,6 @@ import { List, ListItem } from "@/components/Containment";
 
 /** Screen for unmatched route. */
 export default function NotFoundScreen() {
-  const { t } = useTranslation();
   const pathname = usePathname();
   const prevRoute = useAtomValue(prevRouteAtom);
 
@@ -19,15 +17,11 @@ export default function NotFoundScreen() {
       <IssueLayout issueType="unmatched">
         <List>
           <ListItem
-            title={t("errorScreen.missing")}
+            titleKey="errorScreen.missing"
             description={pathname}
             first
           />
-          <ListItem
-            title={t("errorScreen.from")}
-            description={prevRoute}
-            last
-          />
+          <ListItem titleKey="errorScreen.from" description={prevRoute} last />
         </List>
       </IssueLayout>
     </>

--- a/mobile/src/app/current-track.tsx
+++ b/mobile/src/app/current-track.tsx
@@ -52,7 +52,7 @@ export default function CurrentTrackScreen() {
                 name: track.name,
               })}
               onPress={() =>
-                SheetManager.show("track-sheet", { payload: { id: track.id } })
+                SheetManager.show("TrackSheet", { payload: { id: track.id } })
               }
             >
               <MoreVert />
@@ -212,7 +212,7 @@ function BottomAppBar({ trackId }: { trackId: string }) {
       <IconButton
         kind="ripple"
         accessibilityLabel={t("title.upcoming")}
-        onPress={() => SheetManager.show("track-upcoming-sheet")}
+        onPress={() => SheetManager.show("TrackUpcomingSheet")}
         rippleRadius={24}
         className="p-2"
       >

--- a/mobile/src/app/setting/appearance.tsx
+++ b/mobile/src/app/setting/appearance.tsx
@@ -18,13 +18,13 @@ export default function AppearanceScreen() {
         <ListItem
           title={t("title.font")}
           description={accentFont}
-          onPress={() => SheetManager.show("font-sheet")}
+          onPress={() => SheetManager.show("FontSheet")}
           first
         />
         <ListItem
           title={t("title.theme")}
           description={t(`settings.related.${theme}`)}
-          onPress={() => SheetManager.show("theme-sheet")}
+          onPress={() => SheetManager.show("ThemeSheet")}
           last
         />
       </List>

--- a/mobile/src/app/setting/appearance.tsx
+++ b/mobile/src/app/setting/appearance.tsx
@@ -16,13 +16,13 @@ export default function AppearanceScreen() {
     <StandardScrollLayout>
       <List>
         <ListItem
-          title={t("title.font")}
+          titleKey="title.font"
           description={accentFont}
           onPress={() => SheetManager.show("FontSheet")}
           first
         />
         <ListItem
-          title={t("title.theme")}
+          titleKey="title.theme"
           description={t(`settings.related.${theme}`)}
           onPress={() => SheetManager.show("ThemeSheet")}
           last

--- a/mobile/src/app/setting/index.tsx
+++ b/mobile/src/app/setting/index.tsx
@@ -23,7 +23,7 @@ export default function SettingScreen() {
     <StandardScrollLayout>
       {hasNewUpdate && (
         <ListItem
-          title={t("header.appUpdate")}
+          titleKey="header.appUpdate"
           description={t("settings.brief.appUpdate")}
           onPress={() => router.navigate("/setting/update")}
           className="rounded-full bg-yellow"
@@ -33,13 +33,13 @@ export default function SettingScreen() {
 
       <List>
         <ListItem
-          title={t("header.appearance")}
+          titleKey="header.appearance"
           description={t("settings.brief.appearance")}
           onPress={() => router.navigate("/setting/appearance")}
           first
         />
         <ListItem
-          title={t("title.language")}
+          titleKey="title.language"
           description={currLang}
           onPress={() => SheetManager.show("LanguageSheet")}
           last
@@ -48,18 +48,18 @@ export default function SettingScreen() {
 
       <List>
         <ListItem
-          title={t("title.backup")}
+          titleKey="title.backup"
           description={t("settings.brief.backup")}
           onPress={() => SheetManager.show("BackupSheet")}
           first
         />
         <ListItem
-          title={t("header.insights")}
+          titleKey="header.insights"
           description={t("settings.brief.insights")}
           onPress={() => router.navigate("/setting/insights")}
         />
         <ListItem
-          title={t("settings.interactions")}
+          titleKey="settings.interactions"
           description={t("settings.brief.interactions")}
           icon={<OpenInNew />}
           onPress={() =>
@@ -67,7 +67,7 @@ export default function SettingScreen() {
           }
         />
         <ListItem
-          title={t("header.scanning")}
+          titleKey="header.scanning"
           description={t("settings.brief.scanning")}
           onPress={() => router.navigate("/setting/scanning")}
           last
@@ -76,38 +76,34 @@ export default function SettingScreen() {
 
       <List>
         <ListItem
-          title={t("settings.translate")}
+          titleKey="settings.translate"
           description={t("settings.brief.translate")}
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.TRANSLATIONS)}
           first
         />
         <ListItem
-          title={t("settings.code")}
+          titleKey="settings.code"
           description={t("settings.brief.code")}
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.GITHUB)}
         />
         <ListItem
-          title={t("settings.license")}
+          titleKey="settings.license"
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.LICENSE)}
         />
         <ListItem
-          title={t("settings.privacy")}
+          titleKey="settings.privacy"
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.PRIVACY_POLICY)}
         />
         <ListItem
-          title={t("header.thirdParty")}
+          titleKey="header.thirdParty"
           description={t("settings.brief.thirdParty")}
           onPress={() => router.navigate("/setting/third-party")}
         />
-        <ListItem
-          title={t("settings.version")}
-          description={APP_VERSION}
-          last
-        />
+        <ListItem titleKey="settings.version" description={APP_VERSION} last />
       </List>
     </StandardScrollLayout>
   );

--- a/mobile/src/app/setting/index.tsx
+++ b/mobile/src/app/setting/index.tsx
@@ -41,7 +41,7 @@ export default function SettingScreen() {
         <ListItem
           title={t("title.language")}
           description={currLang}
-          onPress={() => SheetManager.show("language-sheet")}
+          onPress={() => SheetManager.show("LanguageSheet")}
           last
         />
       </List>
@@ -50,7 +50,7 @@ export default function SettingScreen() {
         <ListItem
           title={t("title.backup")}
           description={t("settings.brief.backup")}
-          onPress={() => SheetManager.show("backup-sheet")}
+          onPress={() => SheetManager.show("BackupSheet")}
           first
         />
         <ListItem

--- a/mobile/src/app/setting/insights/index.tsx
+++ b/mobile/src/app/setting/insights/index.tsx
@@ -21,7 +21,7 @@ export default function InsightsScreen() {
       </List>
 
       <ListItem
-        title={t("header.saveErrors")}
+        titleKey="header.saveErrors"
         description={t("settings.brief.saveErrors")}
         onPress={() => router.navigate("/setting/insights/save-errors")}
         {...{ first: true, last: true }}
@@ -32,7 +32,6 @@ export default function InsightsScreen() {
 
 /** Breaks down what this app stores on the device. */
 function StorageWidget() {
-  const { t } = useTranslation();
   const { foreground } = useTheme();
   const { isPending, error, data } = useStorageSummary();
 
@@ -51,28 +50,28 @@ function StorageWidget() {
       />
       <Legend className="py-2">
         <LegendItem
-          name={t("settings.related.images")}
+          nameKey="settings.related.images"
           value={abbreviateSize(data.images)}
           color={Colors.red}
         />
         <LegendItem
-          name={t("settings.related.database")}
+          nameKey="settings.related.database"
           value={abbreviateSize(data.database)}
           color={Colors.yellow}
         />
         <LegendItem
-          name={t("settings.related.other")}
+          nameKey="settings.related.other"
           value={abbreviateSize(data.other)}
           color="#4142BE"
         />
         <LegendItem
-          name={t("settings.related.cache")}
+          nameKey="settings.related.cache"
           value={abbreviateSize(data.cache)}
           color={`${foreground}40`} // 25% Opacity
         />
       </Legend>
       <LegendItem
-        name={t("settings.related.total")}
+        nameKey="settings.related.total"
         value={abbreviateSize(data.total)}
       />
     </Card>
@@ -81,23 +80,20 @@ function StorageWidget() {
 
 /** Summarizes what is stored in the database. */
 function DBSummaryWidget() {
-  const { t } = useTranslation();
   const { isPending, error, data } = useDatabaseSummary();
-
   if (isPending || error) return null;
-
   return (
     <Card className="gap-2 rounded-t-sm">
       <Legend className="pb-2">
-        <LegendItem name={t("common.albums")} value={data.albums} />
-        <LegendItem name={t("common.artists")} value={data.artists} />
-        <LegendItem name={t("settings.related.images")} value={data.images} />
-        <LegendItem name={t("common.playlists")} value={data.playlists} />
-        <LegendItem name={t("common.tracks")} value={data.tracks} />
-        <LegendItem name={t("header.saveErrors")} value={data.saveErrors} />
+        <LegendItem nameKey="common.albums" value={data.albums} />
+        <LegendItem nameKey="common.artists" value={data.artists} />
+        <LegendItem nameKey="settings.related.images" value={data.images} />
+        <LegendItem nameKey="common.playlists" value={data.playlists} />
+        <LegendItem nameKey="common.tracks" value={data.tracks} />
+        <LegendItem nameKey="header.saveErrors" value={data.saveErrors} />
       </Legend>
       <LegendItem
-        name={t("settings.related.totalDuration")}
+        nameKey="settings.related.totalDuration"
         value={formatSeconds(data.totalDuration, {
           format: "duration",
           omitSeconds: true,

--- a/mobile/src/app/setting/insights/save-errors.tsx
+++ b/mobile/src/app/setting/insights/save-errors.tsx
@@ -1,16 +1,11 @@
-import { useTranslation } from "react-i18next";
-
 import { useSaveErrors } from "@/queries/setting";
 import { StandardScrollLayout } from "@/layouts";
 
 import { ListRenderer } from "@/components/Containment";
-import { StyledText } from "@/components/Typography";
 
 /** Screen for `/setting/insights/save-errors` route. */
 export default function SaveErrorsScreen() {
-  const { t } = useTranslation();
   const { data } = useSaveErrors();
-
   return (
     <StandardScrollLayout>
       <ListRenderer
@@ -20,9 +15,7 @@ export default function SaveErrorsScreen() {
           getTitle: (item) => item.uri,
           getDescription: (item) => `[${item.errorName}] ${item.errorMessage}`,
         }}
-        ListEmptyComponent={
-          <StyledText center>{t("response.noErrors")}</StyledText>
-        }
+        emptyMsgKey="response.noErrors"
       />
     </StandardScrollLayout>
   );

--- a/mobile/src/app/setting/scanning.tsx
+++ b/mobile/src/app/setting/scanning.tsx
@@ -19,7 +19,7 @@ export default function ScanningScreen() {
   return (
     <StandardScrollLayout>
       <ListItem
-        title={t("settings.rescan")}
+        titleKey="settings.rescan"
         description={t("settings.brief.rescan")}
         disabled={rescan.isPending}
         onPress={() => mutateGuard(rescan, undefined)}
@@ -28,7 +28,7 @@ export default function ScanningScreen() {
 
       <List>
         <ListItem
-          title={t("title.listAllow")}
+          titleKey="title.listAllow"
           description={t("plural.entry", { count: allowList.length })}
           onPress={() =>
             SheetManager.show("ScanFilterListSheet", {
@@ -38,7 +38,7 @@ export default function ScanningScreen() {
           first
         />
         <ListItem
-          title={t("title.listBlock")}
+          titleKey="title.listBlock"
           description={t("plural.entry", { count: blockList.length })}
           onPress={() =>
             SheetManager.show("ScanFilterListSheet", {
@@ -47,7 +47,7 @@ export default function ScanningScreen() {
           }
         />
         <ListItem
-          title={t("title.ignoreDuration")}
+          titleKey="title.ignoreDuration"
           description={t("plural.second", { count: ignoreDuration })}
           onPress={() => SheetManager.show("MinDurationSheet")}
           last

--- a/mobile/src/app/setting/scanning.tsx
+++ b/mobile/src/app/setting/scanning.tsx
@@ -31,7 +31,7 @@ export default function ScanningScreen() {
           title={t("title.listAllow")}
           description={t("plural.entry", { count: allowList.length })}
           onPress={() =>
-            SheetManager.show("scan-filter-list-sheet", {
+            SheetManager.show("ScanFilterListSheet", {
               payload: { listType: "listAllow" },
             })
           }
@@ -41,7 +41,7 @@ export default function ScanningScreen() {
           title={t("title.listBlock")}
           description={t("plural.entry", { count: blockList.length })}
           onPress={() =>
-            SheetManager.show("scan-filter-list-sheet", {
+            SheetManager.show("ScanFilterListSheet", {
               payload: { listType: "listBlock" },
             })
           }
@@ -49,7 +49,7 @@ export default function ScanningScreen() {
         <ListItem
           title={t("title.ignoreDuration")}
           description={t("plural.second", { count: ignoreDuration })}
-          onPress={() => SheetManager.show("min-duration-sheet")}
+          onPress={() => SheetManager.show("MinDurationSheet")}
           last
         />
       </List>

--- a/mobile/src/app/setting/third-party/[id].tsx
+++ b/mobile/src/app/setting/third-party/[id].tsx
@@ -1,13 +1,13 @@
 import { Stack, useLocalSearchParams } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { useTranslation } from "react-i18next";
-import { ScrollView } from "react-native";
 
 import { OpenInNew } from "@/icons";
 import LicensesList from "@/resources/licenses.json";
 import { StickyActionHeader } from "@/layouts";
 
 import { Card } from "@/components/Containment";
+import { ScrollView } from "@/components/Defaults";
 import { IconButton } from "@/components/Form";
 import { StyledText } from "@/components/Typography";
 
@@ -35,10 +35,7 @@ export default function PackageLicenseScreen() {
           ),
         }}
       />
-      <ScrollView
-        showsVerticalScrollIndicator={false}
-        contentContainerClassName="grow gap-6 p-4"
-      >
+      <ScrollView contentContainerClassName="grow gap-6 p-4">
         <StickyActionHeader noOffset originalText>
           {licenseInfo.name}
         </StickyActionHeader>

--- a/mobile/src/app/setting/update.tsx
+++ b/mobile/src/app/setting/update.tsx
@@ -1,6 +1,6 @@
 import * as WebBrowser from "expo-web-browser";
 import { useTranslation } from "react-i18next";
-import { ScrollView, Text, View } from "react-native";
+import { Text, View } from "react-native";
 import Markdown from "react-native-markdown-display";
 
 import { LogoGitHub, LogoPlayStore } from "@/icons";
@@ -11,6 +11,7 @@ import { StickyActionHeader } from "@/layouts";
 
 import * as LINKS from "@/constants/Links";
 import { FontFamily, FontSize } from "@/constants/Styles";
+import { ScrollView } from "@/components/Defaults";
 import { Button } from "@/components/Form";
 import { StyledText } from "@/components/Typography";
 
@@ -24,10 +25,7 @@ export default function AppUpdateScreen() {
   if (!release) return null;
 
   return (
-    <ScrollView
-      showsVerticalScrollIndicator={false}
-      contentContainerClassName="grow gap-6 p-4"
-    >
+    <ScrollView contentContainerClassName="grow gap-6 p-4">
       <StickyActionHeader noOffset>{release.version}</StickyActionHeader>
 
       <Markdown

--- a/mobile/src/app/setting/update.tsx
+++ b/mobile/src/app/setting/update.tsx
@@ -1,5 +1,4 @@
 import * as WebBrowser from "expo-web-browser";
-import { useTranslation } from "react-i18next";
 import { Text, View } from "react-native";
 import Markdown from "react-native-markdown-display";
 
@@ -13,11 +12,10 @@ import * as LINKS from "@/constants/Links";
 import { FontFamily, FontSize } from "@/constants/Styles";
 import { ScrollView } from "@/components/Defaults";
 import { Button } from "@/components/Form";
-import { StyledText } from "@/components/Typography";
+import { TStyledText } from "@/components/Typography";
 
 /** Screen for `/setting/update` route. */
 export default function AppUpdateScreen() {
-  const { t } = useTranslation();
   const { release, isRC } = useHasNewUpdate();
   const { foreground } = useTheme();
   const accentFont = useUserPreferencesStore((state) => state.accentFont);
@@ -90,9 +88,10 @@ export default function AppUpdateScreen() {
           className="flex-1 p-2"
         >
           <LogoGitHub />
-          <StyledText center className="text-xs">
-            {t("settings.related.appDownload")}
-          </StyledText>
+          <TStyledText
+            textKey="settings.related.appDownload"
+            className="text-center text-xs"
+          />
         </Button>
         {!isRC ? (
           <Button
@@ -100,9 +99,10 @@ export default function AppUpdateScreen() {
             className="flex-1 p-2"
           >
             <LogoPlayStore />
-            <StyledText center className="text-xs">
-              {t("settings.related.appUpdate")}
-            </StyledText>
+            <TStyledText
+              textKey="settings.related.appUpdate"
+              className="text-center text-xs"
+            />
           </Button>
         ) : null}
       </View>

--- a/mobile/src/components/Containment/List.tsx
+++ b/mobile/src/components/Containment/List.tsx
@@ -46,7 +46,7 @@ export function ListRenderer<TData extends Record<string, any>>({
             description={getDescription ? getDescription(item) : undefined}
             onPress={onPress ? onPress(item) : undefined}
             {...{ first, last }}
-            className={cn({ "mb-[3px]": !last })}
+            className={!last ? "mb-[3px]" : undefined}
           />
         );
       }}

--- a/mobile/src/components/Containment/List.tsx
+++ b/mobile/src/components/Containment/List.tsx
@@ -1,4 +1,6 @@
 import type { FlashListProps } from "@shopify/flash-list";
+import type { ParseKeys } from "i18next";
+import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 
 import type { TextColor } from "@/lib/style";
@@ -56,20 +58,26 @@ export function ListRenderer<TData extends Record<string, any>>({
 
 //#region List Item
 /** Static or pressable card themed after Nothing OS 3.0's setting page. */
-export function ListItem(props: {
-  // Interactivity props.
-  onPress?: () => void;
-  disabled?: boolean;
-  // Content props.
-  title: string;
-  description?: string;
-  icon?: React.ReactNode;
-  // Styling props.
-  first?: boolean;
-  last?: boolean;
-  textColor?: TextColor;
-  className?: string;
-}) {
+export function ListItem(
+  props: {
+    // Interactivity props.
+    onPress?: () => void;
+    disabled?: boolean;
+    // Content props.
+    description?: string;
+    icon?: React.ReactNode;
+    // Styling props.
+    first?: boolean;
+    last?: boolean;
+    textColor?: TextColor;
+    className?: string;
+  } & (
+    | { titleKey: ParseKeys; title?: never }
+    | { titleKey?: never; title: string }
+  ),
+) {
+  const { t } = useTranslation();
+
   const asButton = props.onPress !== undefined;
   const withIcon = !!props.icon;
   const usedColor = props.textColor ?? "text-foreground";
@@ -92,7 +100,7 @@ export function ListItem(props: {
     >
       <View className="shrink grow gap-0.5">
         <StyledText className={cn("text-sm", usedColor)}>
-          {props.title}
+          {props.titleKey ? t(props.titleKey) : props.title}
         </StyledText>
         {props.description ? (
           <StyledText className={cn("text-xs opacity-50", usedColor)}>

--- a/mobile/src/components/Containment/List.tsx
+++ b/mobile/src/components/Containment/List.tsx
@@ -1,9 +1,10 @@
 import type { FlashListProps } from "@shopify/flash-list";
-import { FlashList } from "@shopify/flash-list";
 import { Pressable, View } from "react-native";
 
 import type { TextColor } from "@/lib/style";
 import { cn } from "@/lib/style";
+import type { WithListEmptyProps } from "../Defaults";
+import { FlashList } from "../Defaults";
 import { StyledText } from "../Typography";
 
 //#region List
@@ -21,13 +22,15 @@ export function ListRenderer<TData extends Record<string, any>>({
   data,
   renderOptions: { getTitle, getDescription, onPress },
   ...props
-}: Omit<FlashListProps<TData>, "renderItem"> & {
-  renderOptions: {
-    getTitle: (item: TData) => string;
-    getDescription?: (item: TData) => string;
-    onPress?: (item: TData) => () => void;
-  };
-}) {
+}: WithListEmptyProps<
+  Omit<FlashListProps<TData>, "renderItem"> & {
+    renderOptions: {
+      getTitle: (item: TData) => string;
+      getDescription?: (item: TData) => string;
+      onPress?: (item: TData) => () => void;
+    };
+  }
+>) {
   return (
     <FlashList
       estimatedItemSize={70}
@@ -45,7 +48,6 @@ export function ListRenderer<TData extends Record<string, any>>({
           />
         );
       }}
-      showsVerticalScrollIndicator={false}
       {...props}
     />
   );

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,0 +1,86 @@
+import type { FlashListProps } from "@shopify/flash-list";
+import { FlashList as SFlashList } from "@shopify/flash-list";
+import type { ParseKeys } from "i18next";
+import { useMemo } from "react";
+import type { FlatListProps, ScrollViewProps } from "react-native";
+import {
+  FlatList as RNFlatList,
+  ScrollView as RNScrollView,
+} from "react-native";
+import { FlatList as RNASFlatList } from "react-native-actions-sheet";
+import { FlashList as RNASFlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
+
+import { ContentPlaceholder } from "./Transition";
+
+//#region Preset Values
+/** Presets for scrollview-like components. */
+export const ScrollPresets = {
+  overScrollMode: "never",
+  showsHorizontalScrollIndicator: false,
+  showsVerticalScrollIndicator: false,
+} satisfies ScrollViewProps;
+
+export type ListEmptyProps = { isPending?: boolean; emptyMsgKey?: ParseKeys };
+export type WithListEmptyProps<T> = T & ListEmptyProps;
+
+/** Presets for list-like components (ie: `Flatlist`, `FlashList`). */
+export function useListPresets(args?: ListEmptyProps) {
+  return useMemo(
+    () => ({
+      ...ScrollPresets,
+      ListEmptyComponent: (
+        <ContentPlaceholder
+          isPending={args?.isPending}
+          errMsgKey={args?.emptyMsgKey}
+        />
+      ),
+    }),
+    [args],
+  );
+}
+//#endregion
+
+//#region Preset Native Components
+/** `<FlatList />` with some defaults applied. */
+export function FlatList<TData>(
+  props: WithListEmptyProps<FlatListProps<TData>>,
+) {
+  const { isPending, emptyMsgKey, ...rest } = props;
+  const listPresets = useListPresets({ isPending, emptyMsgKey });
+  return <RNFlatList {...listPresets} {...rest} />;
+}
+
+/** `<ScrollView />` with some defaults applied. */
+export function ScrollView(props: ScrollViewProps) {
+  return <RNScrollView {...ScrollPresets} {...props} />;
+}
+//#endregion
+
+//#region Preset Alternate Components
+/** `<FlashList />` with some defaults applied. */
+export function FlashList<TData>(
+  props: WithListEmptyProps<FlashListProps<TData>>,
+) {
+  const { isPending, emptyMsgKey, ...rest } = props;
+  const listPresets = useListPresets({ isPending, emptyMsgKey });
+  return <SFlashList {...listPresets} {...rest} />;
+}
+
+/** `<FlatList />` from `react-native-actions-sheet` with some defaults applied. */
+export function SheetsFlatList<TData>(
+  props: WithListEmptyProps<FlatListProps<TData>>,
+) {
+  const { isPending, emptyMsgKey, ...rest } = props;
+  const listPresets = useListPresets({ isPending, emptyMsgKey });
+  return <RNASFlatList {...listPresets} {...rest} />;
+}
+
+/** `<FlashList />` from `react-native-actions-sheet` with some defaults applied. */
+export function SheetsFlashList<TData>(
+  props: WithListEmptyProps<FlashListProps<TData>>,
+) {
+  const { isPending, emptyMsgKey, ...rest } = props;
+  const listPresets = useListPresets({ isPending, emptyMsgKey });
+  return <RNASFlashList {...listPresets} {...rest} />;
+}
+//#endregion

--- a/mobile/src/components/Form/Legend.tsx
+++ b/mobile/src/components/Form/Legend.tsx
@@ -1,3 +1,5 @@
+import type { ParseKeys } from "i18next";
+import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { cn } from "@/lib/style";
@@ -16,10 +18,11 @@ export function Legend(props: {
 //#region Legend Item
 /** Help describe items represented in for example a `<ProgressBar />`. */
 export function LegendItem(props: {
-  name: string;
+  nameKey: ParseKeys;
   value: string | number;
   color?: string;
 }) {
+  const { t } = useTranslation();
   return (
     <View className="flex-row items-center justify-between gap-2">
       <View className="shrink flex-row items-center gap-2">
@@ -29,7 +32,7 @@ export function LegendItem(props: {
             className="size-[9px] rounded-full"
           />
         ) : null}
-        <StyledText className="shrink text-xs">{props.name}</StyledText>
+        <StyledText className="shrink text-xs">{t(props.nameKey)}</StyledText>
       </View>
       <StyledText preset="dimOnSurface">{props.value}</StyledText>
     </View>

--- a/mobile/src/components/Form/Legend.tsx
+++ b/mobile/src/components/Form/Legend.tsx
@@ -1,9 +1,8 @@
 import type { ParseKeys } from "i18next";
-import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { cn } from "@/lib/style";
-import { StyledText } from "../Typography";
+import { StyledText, TStyledText } from "../Typography";
 
 //#region Legend
 /** Wrapper for list of `<LegendItem />` for consistent gaps. */
@@ -22,7 +21,6 @@ export function LegendItem(props: {
   value: string | number;
   color?: string;
 }) {
-  const { t } = useTranslation();
   return (
     <View className="flex-row items-center justify-between gap-2">
       <View className="shrink flex-row items-center gap-2">
@@ -32,7 +30,7 @@ export function LegendItem(props: {
             className="size-[9px] rounded-full"
           />
         ) : null}
-        <StyledText className="shrink text-xs">{t(props.nameKey)}</StyledText>
+        <TStyledText textKey={props.nameKey} className="shrink text-xs" />
       </View>
       <StyledText preset="dimOnSurface">{props.value}</StyledText>
     </View>

--- a/mobile/src/components/Sheet/Sheet.tsx
+++ b/mobile/src/components/Sheet/Sheet.tsx
@@ -1,5 +1,7 @@
 import { Toasts } from "@backpackapp-io/react-native-toast";
+import type { ParseKeys } from "i18next";
 import { cssInterop } from "nativewind";
+import { useTranslation } from "react-i18next";
 import type { StyleProp, ViewStyle } from "react-native";
 import { View } from "react-native";
 import type { ActionSheetProps } from "react-native-actions-sheet";
@@ -16,24 +18,28 @@ const WrappedActionSheet = cssInterop(ActionSheet, {
 
 /** Pre-styled sheet. */
 export function Sheet({
-  title,
+  titleKey,
   snapTop,
   contentContainerClassName,
   contentContainerStyle,
   children,
   ...props
 }: ActionSheetProps & {
-  title?: string;
+  titleKey?: ParseKeys;
   /** If the sheet should open at max screen height. */
   snapTop?: boolean;
   contentContainerClassName?: string;
   contentContainerStyle?: StyleProp<ViewStyle>;
 }) {
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+
   return (
     <WrappedActionSheet
       gestureEnabled
-      CustomHeaderComponent={<SheetHeader title={title} />}
+      CustomHeaderComponent={
+        <SheetHeader title={titleKey ? t(titleKey) : undefined} />
+      }
       ExtraOverlayComponent={<Toasts />}
       containerClassName={cn("rounded-t-lg bg-canvas dark:bg-neutral5", {
         "h-full": snapTop,

--- a/mobile/src/components/Transition/Placeholder.tsx
+++ b/mobile/src/components/Transition/Placeholder.tsx
@@ -1,0 +1,26 @@
+import type { ParseKeys } from "i18next";
+import { useTranslation } from "react-i18next";
+import { View } from "react-native";
+
+import { Loading } from "./Loading";
+import { StyledText } from "../Typography";
+
+/** Placeholder to render while waiting for data from React Query. */
+export function PagePlaceholder(props: {
+  isPending: boolean;
+  /** Key to error messaeg in translations. */
+  errMsgKey?: ParseKeys;
+}) {
+  const { t } = useTranslation();
+  return (
+    <View className="w-full flex-1 p-4">
+      {props.isPending ? (
+        <Loading />
+      ) : (
+        <StyledText center>
+          {t(props.errMsgKey ?? "response.noContent")}
+        </StyledText>
+      )}
+    </View>
+  );
+}

--- a/mobile/src/components/Transition/Placeholder.tsx
+++ b/mobile/src/components/Transition/Placeholder.tsx
@@ -5,22 +5,29 @@ import { View } from "react-native";
 import { Loading } from "./Loading";
 import { StyledText } from "../Typography";
 
+/** Placeholder to render inside a list. */
+export function ContentPlaceholder(props: {
+  isPending?: boolean;
+  /** Key to error messaeg in translations. */
+  errMsgKey?: ParseKeys;
+}) {
+  const { t } = useTranslation();
+  return props.isPending ? (
+    <Loading />
+  ) : (
+    <StyledText center>{t(props.errMsgKey ?? "response.noContent")}</StyledText>
+  );
+}
+
 /** Placeholder to render while waiting for data from React Query. */
 export function PagePlaceholder(props: {
   isPending: boolean;
   /** Key to error messaeg in translations. */
   errMsgKey?: ParseKeys;
 }) {
-  const { t } = useTranslation();
   return (
     <View className="w-full flex-1 p-4">
-      {props.isPending ? (
-        <Loading />
-      ) : (
-        <StyledText center>
-          {t(props.errMsgKey ?? "response.noContent")}
-        </StyledText>
-      )}
+      <ContentPlaceholder {...props} />
     </View>
   );
 }

--- a/mobile/src/components/Transition/Placeholder.tsx
+++ b/mobile/src/components/Transition/Placeholder.tsx
@@ -1,9 +1,8 @@
 import type { ParseKeys } from "i18next";
-import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { Loading } from "./Loading";
-import { StyledText } from "../Typography";
+import { TStyledText } from "../Typography";
 
 /** Placeholder to render inside a list. */
 export function ContentPlaceholder(props: {
@@ -11,11 +10,10 @@ export function ContentPlaceholder(props: {
   /** Key to error messaeg in translations. */
   errMsgKey?: ParseKeys;
 }) {
-  const { t } = useTranslation();
   return props.isPending ? (
     <Loading />
   ) : (
-    <StyledText center>{t(props.errMsgKey ?? "response.noContent")}</StyledText>
+    <TStyledText textKey={props.errMsgKey ?? "response.noContent"} center />
   );
 }
 

--- a/mobile/src/components/Transition/index.ts
+++ b/mobile/src/components/Transition/index.ts
@@ -1,3 +1,3 @@
 export { Back } from "./Back";
 export { Loading } from "./Loading";
-export { PagePlaceholder } from "./Placeholder";
+export { ContentPlaceholder, PagePlaceholder } from "./Placeholder";

--- a/mobile/src/components/Transition/index.ts
+++ b/mobile/src/components/Transition/index.ts
@@ -1,2 +1,3 @@
 export { Back } from "./Back";
 export { Loading } from "./Loading";
+export { PagePlaceholder } from "./Placeholder";

--- a/mobile/src/components/Typography/AccentText.tsx
+++ b/mobile/src/components/Typography/AccentText.tsx
@@ -25,6 +25,7 @@ export function AccentText({
           "font-ntype": accentFont === "NType",
         },
         className,
+        "leading-normal",
       )}
       {...props}
     />

--- a/mobile/src/components/Typography/StyledText.tsx
+++ b/mobile/src/components/Typography/StyledText.tsx
@@ -1,3 +1,5 @@
+import type { ParseKeys } from "i18next";
+import { useTranslation } from "react-i18next";
 import type { TextProps } from "react-native";
 import { Text } from "react-native";
 
@@ -48,3 +50,27 @@ export function Em({
     </StyledText>
   );
 }
+
+//#region Translated Variants
+/** `<StyledText />` that accepts a translated key instead of children. */
+export function TStyledText({
+  textKey,
+  ...props
+}: Omit<React.ComponentProps<typeof StyledText>, "children"> & {
+  textKey: ParseKeys;
+}) {
+  const { t } = useTranslation();
+  return <StyledText {...props}>{t(textKey)}</StyledText>;
+}
+
+/** `<Em />` that accepts a translated key instead of children. */
+export function TEm({
+  textKey,
+  ...props
+}: Omit<React.ComponentProps<typeof Em>, "children"> & {
+  textKey: ParseKeys;
+}) {
+  const { t } = useTranslation();
+  return <Em {...props}>{t(textKey)}</Em>;
+}
+//#endregion

--- a/mobile/src/components/Typography/index.ts
+++ b/mobile/src/components/Typography/index.ts
@@ -1,3 +1,3 @@
 export { AccentText } from "./AccentText";
 export { Kbd } from "./Kbd";
-export { Em, StyledText } from "./StyledText";
+export { Em, StyledText, TEm, TStyledText } from "./StyledText";

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -42,18 +42,18 @@ type MediaData = Prettify<
 export function formatForMediaCard({ type, data, t }: MediaData) {
   let source = null;
   let href = `/${type}/${encodeURIComponent(data.name)}`;
-  let subtitle = t("plural.track", { count: data.tracks.length });
+  let description = t("plural.track", { count: data.tracks.length });
   if (type === "album") {
     source = data.artwork;
     href = `/album/${data.id}`;
-    subtitle = data.artistName;
+    description = data.artistName;
   } else if (type === "playlist") {
     source = getPlaylistCover(data);
     if (data.name === ReservedPlaylists.tracks) href = "/track";
   }
 
   return {
-    ...{ type, source, href, title: data.name, subtitle },
+    ...{ type, source, href, title: data.name, description },
   } as MediaCard.Content;
 }
 

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -1,5 +1,4 @@
 import { Link } from "expo-router";
-import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { Schedule } from "@/icons";
@@ -7,7 +6,7 @@ import { useTheme } from "@/hooks/useTheme";
 
 import { toLowerCase } from "@/utils/string";
 import { Divider, Marquee } from "@/components/Containment";
-import { Em, StyledText } from "@/components/Typography";
+import { StyledText, TEm } from "@/components/Typography";
 import { MediaImage, MediaListControls } from "@/modules/media/components";
 import type { PlayListSource } from "@/modules/media/types";
 
@@ -22,9 +21,7 @@ export function CurrentListLayout(props: {
   mediaSource: PlayListSource;
   children: React.ReactNode;
 }) {
-  const { t } = useTranslation();
   const { canvas, foreground } = useTheme();
-
   return (
     <>
       <View className="flex-row gap-2 px-4">
@@ -35,9 +32,11 @@ export function CurrentListLayout(props: {
           size={128}
         />
         <View className="shrink grow justify-end">
-          <Em preset="dimOnCanvas" style={{ fontSize: 8 }}>
-            {t(`common.${toLowerCase(props.mediaSource.type)}`)}
-          </Em>
+          <TEm
+            preset="dimOnCanvas"
+            textKey={`common.${toLowerCase(props.mediaSource.type)}`}
+            style={{ fontSize: 8 }}
+          />
           <Marquee color={canvas}>
             <StyledText>{props.title}</StyledText>
           </Marquee>

--- a/mobile/src/layouts/Issue.tsx
+++ b/mobile/src/layouts/Issue.tsx
@@ -9,7 +9,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { GITHUB } from "@/constants/Links";
 import { Button } from "@/components/Form";
-import { AccentText, StyledText } from "@/components/Typography";
+import { AccentText, TStyledText } from "@/components/Typography";
 
 /** Layout used for the "error" screens (route & unexpected errors). */
 export function IssueLayout(props: {
@@ -32,9 +32,11 @@ export function IssueLayout(props: {
         <AccentText style={{ paddingTop: top + 16 }} className="text-3xl">
           {t(`errorScreen.${props.issueType}`)}
         </AccentText>
-        <StyledText preset="dimOnCanvas" className="text-base">
-          {t(`errorScreen.${props.issueType}Brief`)}
-        </StyledText>
+        <TStyledText
+          preset="dimOnCanvas"
+          textKey={`errorScreen.${props.issueType}Brief`}
+          className="text-base"
+        />
 
         {props.children}
 
@@ -49,12 +51,16 @@ export function IssueLayout(props: {
         style={{ maxWidth: ScreenWidth - 32 }}
         className="absolute bottom-4 left-4 w-full gap-0.5 bg-red"
       >
-        <StyledText center className="text-neutral100">
-          {t("errorScreen.report")}
-        </StyledText>
-        <StyledText center className="text-xs text-neutral100/80">
-          {t("errorScreen.screenshot")}
-        </StyledText>
+        <TStyledText
+          textKey="errorScreen.report"
+          className="text-center text-neutral100"
+        />
+        /
+        <TStyledText
+          textKey="errorScreen.screenshot"
+          className="text-center text-xs text-neutral100/80"
+        />
+        /
       </Button>
     </>
   );

--- a/mobile/src/layouts/StandardScroll.tsx
+++ b/mobile/src/layouts/StandardScroll.tsx
@@ -1,12 +1,9 @@
-import { ScrollView } from "react-native";
+import { ScrollView } from "@/components/Defaults";
 
 /** Simple scroll container layout. */
 export function StandardScrollLayout(props: { children: React.ReactNode }) {
   return (
-    <ScrollView
-      showsVerticalScrollIndicator={false}
-      contentContainerClassName="grow gap-6 p-4"
-    >
+    <ScrollView contentContainerClassName="grow gap-6 p-4">
       {props.children}
     </ScrollView>
   );

--- a/mobile/src/layouts/StickyActionScroll.tsx
+++ b/mobile/src/layouts/StickyActionScroll.tsx
@@ -1,6 +1,8 @@
 import type { FlashListProps } from "@shopify/flash-list";
 import { FlashList } from "@shopify/flash-list";
+import type { ParseKeys } from "i18next";
 import { forwardRef, useCallback, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import type { LayoutChangeEvent, ScrollViewProps } from "react-native";
 import { View, useWindowDimensions } from "react-native";
 import Animated, {
@@ -22,17 +24,18 @@ import { AccentText } from "@/components/Typography";
 export const StickyActionScrollLayout = forwardRef<
   Animated.ScrollView,
   ScrollViewProps & {
-    /** Name of list. */
-    title: string;
+    /** Key to title in translations. */
+    titleKey: ParseKeys;
     /** Optional action displayed in layout. */
     StickyAction?: React.JSX.Element;
     /** Determines the bottom padding applied. */
     offsetType?: "withNav" | "onlyPlayer";
   }
 >(function StickyActionScrollLayout(
-  { title, StickyAction, offsetType = "withNav", children, ...rest },
+  { titleKey, StickyAction, offsetType = "withNav", children, ...rest },
   ref,
 ) {
+  const { t } = useTranslation();
   const { top } = useSafeAreaInsets();
   const { bottomInset } = useBottomActionsContext();
 
@@ -82,7 +85,7 @@ export const StickyActionScrollLayout = forwardRef<
       }}
       contentContainerClassName="grow gap-6"
     >
-      <StickyActionHeader>{title}</StickyActionHeader>
+      <StickyActionHeader>{t(titleKey)}</StickyActionHeader>
 
       <View
         onLayout={calcInitStartPos}
@@ -112,15 +115,15 @@ export const StickyActionScrollLayout = forwardRef<
  * after scrolling.
  */
 export function StickyActionListLayout<TData>({
-  title,
+  titleKey,
   StickyAction,
   estimatedActionSize = 0,
   listRef,
   offsetType = "withNav",
   ...flashListProps
 }: FlashListProps<TData> & {
-  /** Name of list. */
-  title: string;
+  /** Key to title in translations. */
+  titleKey: ParseKeys;
   /** Optional action displayed in layout. */
   StickyAction?: React.JSX.Element;
   /** Height of the StickyAction. */
@@ -130,6 +133,7 @@ export function StickyActionListLayout<TData>({
   /** Determines the bottom padding applied. */
   offsetType?: "withNav" | "onlyPlayer";
 }) {
+  const { t } = useTranslation();
   const { top } = useSafeAreaInsets();
   const { width: ScreenWidth } = useWindowDimensions();
   const { bottomInset } = useBottomActionsContext();
@@ -182,7 +186,7 @@ export function StickyActionListLayout<TData>({
             ]}
             className="pb-6"
           >
-            {title}
+            {t(titleKey)}
           </StickyActionHeader>
         }
         overScrollMode="never"

--- a/mobile/src/layouts/StickyActionScroll.tsx
+++ b/mobile/src/layouts/StickyActionScroll.tsx
@@ -90,7 +90,7 @@ export const StickyActionScrollLayout = forwardRef<
       <View
         onLayout={calcInitStartPos}
         pointerEvents="box-none"
-        className={cn({ hidden: !StickyAction })}
+        className={!StickyAction ? "hidden" : undefined}
       >
         <Animated.View
           pointerEvents="box-none"

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -10,7 +10,8 @@ import { useGetColumn } from "@/hooks/useGetColumn";
 
 import { cn } from "@/lib/style";
 import type { Maybe, Prettify } from "@/utils/types";
-import { Loading } from "@/components/Transition";
+import type { WithListEmptyProps } from "@/components/Defaults";
+import { useListPresets } from "@/components/Defaults";
 import { StyledText } from "@/components/Typography";
 import { MediaImage } from "./MediaImage";
 
@@ -81,10 +82,8 @@ export const MediaCardPlaceholderContent: MediaCard.Content = {
 //#endregion
 
 //#region Media Card List
-type MediaCardListProps = {
+type MediaCardListProps = WithListEmptyProps<{
   data: Maybe<readonly MediaCard.Content[]>;
-  emptyMessage?: string;
-  isPending?: boolean;
   /**
    * Renders a special entry before all other data. This assumes at `data[0]`,
    * we have a `MediaCardPlaceholderContent`.
@@ -93,16 +92,21 @@ type MediaCardListProps = {
     size: number;
     className: string;
   }) => React.JSX.Element;
-};
+}>;
 
 /** Hook for getting the presets used in the FlashList for `<MediaCardList />`. */
 export function useMediaCardListPreset(props: MediaCardListProps) {
   const { count, width } = useGetColumn({
     ...{ cols: 2, gap: 12, gutters: 32, minWidth: 175 },
   });
+  const listPresets = useListPresets({
+    isPending: props.isPending,
+    emptyMsgKey: props.emptyMsgKey,
+  });
 
   return useMemo(
     () => ({
+      ...listPresets,
       numColumns: count,
       // ~40px for text content under `<MediaImage />` + 16px Margin Bottom
       estimatedItemSize: width + 40 + 12,
@@ -118,21 +122,16 @@ export function useMediaCardListPreset(props: MediaCardListProps) {
         ) : (
           <MediaCard {...item} size={width} className="mx-1.5 mb-3" />
         ),
-      ListEmptyComponent: props.isPending ? (
-        <Loading />
-      ) : (
-        <StyledText center>{props.emptyMessage}</StyledText>
-      ),
       ListHeaderComponentStyle: { paddingHorizontal: 8 },
       className: "-mx-1.5 -mb-3",
     }),
-    [count, width, props],
+    [count, width, props, listPresets],
   ) satisfies FlashListProps<MediaCard.Content>;
 }
 
 /** Lists out `<MediaCard />` in a grid. */
 export function MediaCardList(props: MediaCardListProps) {
   const presets = useMediaCardListPreset(props);
-  return <FlashList {...presets} showsVerticalScrollIndicator={false} />;
+  return <FlashList {...presets} />;
 }
 //#endregion

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -3,10 +3,12 @@ import { FlashList } from "@shopify/flash-list";
 import type { Href } from "expo-router";
 import { router } from "expo-router";
 import { useMemo } from "react";
-import { Pressable, View } from "react-native";
+import type { LayoutChangeEvent } from "react-native";
+import { Pressable } from "react-native";
 
 import { useGetColumn } from "@/hooks/useGetColumn";
 
+import { cn } from "@/lib/style";
 import type { Maybe, Prettify } from "@/utils/types";
 import { Loading } from "@/components/Transition";
 import { StyledText } from "@/components/Typography";
@@ -18,11 +20,17 @@ export namespace MediaCard {
     MediaImage.ImageContent & {
       href: string;
       title: string;
-      subtitle: string;
+      description: string;
     }
   >;
 
-  export type Props = Prettify<Content & { size: number }>;
+  export type Props = Prettify<
+    Content & {
+      size: number;
+      className?: string;
+      onLayout?: (e: LayoutChangeEvent) => void;
+    }
+  >;
 }
 
 /**
@@ -32,23 +40,26 @@ export namespace MediaCard {
 export function MediaCard({
   href,
   title,
-  subtitle,
+  description,
+  className,
+  onLayout,
   ...imgProps
 }: MediaCard.Props) {
   return (
     <Pressable
+      onLayout={onLayout}
       onPress={() => router.navigate(href as Href)}
       style={{ maxWidth: imgProps.size }}
       // The `w-full` is to ensure the component takes up all the space
       // specified by `maxWidth`.
-      className="w-full active:opacity-75"
+      className={cn("w-full active:opacity-75", className)}
     >
       <MediaImage {...imgProps} />
       <StyledText numberOfLines={1} className="mt-1 text-sm">
         {title}
       </StyledText>
       <StyledText preset="dimOnCanvas" numberOfLines={1}>
-        {subtitle}
+        {description}
       </StyledText>
     </Pressable>
   );
@@ -64,7 +75,7 @@ export const MediaCardPlaceholderContent: MediaCard.Content = {
   href: "invalid-href",
   source: null,
   title: "",
-  subtitle: "",
+  description: "",
   type: "album",
 };
 //#endregion
@@ -78,7 +89,10 @@ type MediaCardListProps = {
    * Renders a special entry before all other data. This assumes at `data[0]`,
    * we have a `MediaCardPlaceholderContent`.
    */
-  RenderFirst?: (props: { size: number }) => React.JSX.Element;
+  RenderFirst?: (props: {
+    size: number;
+    className: string;
+  }) => React.JSX.Element;
 };
 
 /** Hook for getting the presets used in the FlashList for `<MediaCardList />`. */
@@ -98,15 +112,12 @@ export function useMediaCardListPreset(props: MediaCardListProps) {
         Utilized janky margin method to implement gaps in FlashList with columns.
           - https://github.com/shopify/flash-list/discussions/804#discussioncomment-5509022
       */
-      renderItem: ({ item, index }) => (
-        <View className="mx-1.5 mb-3">
-          {props.RenderFirst && index === 0 ? (
-            <props.RenderFirst size={width} />
-          ) : (
-            <MediaCard {...item} size={width} />
-          )}
-        </View>
-      ),
+      renderItem: ({ item, index }) =>
+        props.RenderFirst && index === 0 ? (
+          <props.RenderFirst size={width} className="mx-1.5 mb-3" />
+        ) : (
+          <MediaCard {...item} size={width} className="mx-1.5 mb-3" />
+        ),
       ListEmptyComponent: props.isPending ? (
         <Loading />
       ) : (

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -1,5 +1,4 @@
 import type { FlashListProps } from "@shopify/flash-list";
-import { FlashList } from "@shopify/flash-list";
 import { useTranslation } from "react-i18next";
 import { SheetManager } from "react-native-actions-sheet";
 
@@ -65,7 +64,7 @@ type TrackListProps = {
   trackSource: PlayListSource;
 };
 
-/** Presets used in the FlashList for `<TrackList />`. */
+/** Presets used in the FlashList containing a list of `<Track />`. */
 export const TrackListPreset = (props: TrackListProps) =>
   ({
     estimatedItemSize: 56, // 48px Height + 8px Margin Top
@@ -83,14 +82,4 @@ export const TrackListPreset = (props: TrackListProps) =>
       <StyledText center>{props.emptyMessage}</StyledText>
     ),
   }) satisfies FlashListProps<Track.Content>;
-
-/** Lists out tracks. */
-export function TrackList(props: TrackListProps) {
-  return (
-    <FlashList
-      {...TrackListPreset(props)}
-      showsVerticalScrollIndicator={false}
-    />
-  );
-}
 //#endregion

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -1,4 +1,5 @@
 import type { FlashListProps } from "@shopify/flash-list";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { SheetManager } from "react-native-actions-sheet";
 
@@ -8,9 +9,9 @@ import type { PlayListSource } from "../types";
 
 import { cn } from "@/lib/style";
 import type { Maybe, Prettify } from "@/utils/types";
+import type { WithListEmptyProps } from "@/components/Defaults";
+import { useListPresets } from "@/components/Defaults";
 import { IconButton } from "@/components/Form";
-import { Loading } from "@/components/Transition";
-import { StyledText } from "@/components/Typography";
 import { SearchResult } from "@/modules/search/components";
 
 //#region Track
@@ -57,29 +58,31 @@ export function Track({ id, trackSource, className, ...props }: Track.Props) {
 //#endregion
 
 //#region Track List
-type TrackListProps = {
+type TrackListProps = WithListEmptyProps<{
   data: Maybe<readonly Track.Content[]>;
-  emptyMessage?: string;
-  isPending?: boolean;
   trackSource: PlayListSource;
-};
+}>;
 
 /** Presets used in the FlashList containing a list of `<Track />`. */
-export const TrackListPreset = (props: TrackListProps) =>
-  ({
-    estimatedItemSize: 56, // 48px Height + 8px Margin Top
-    data: props.data,
-    keyExtractor: ({ id }) => id,
-    renderItem: ({ item, index }) => (
-      <Track
-        {...{ ...item, trackSource: props.trackSource }}
-        className={index > 0 ? "mt-2" : undefined}
-      />
-    ),
-    ListEmptyComponent: props.isPending ? (
-      <Loading />
-    ) : (
-      <StyledText center>{props.emptyMessage}</StyledText>
-    ),
-  }) satisfies FlashListProps<Track.Content>;
+export function useTrackListPreset(props: TrackListProps) {
+  const listPresets = useListPresets({
+    isPending: props.isPending,
+    emptyMsgKey: props.emptyMsgKey,
+  });
+  return useMemo(
+    () => ({
+      ...listPresets,
+      estimatedItemSize: 56, // 48px Height + 8px Margin Top
+      data: props.data,
+      keyExtractor: ({ id }) => id,
+      renderItem: ({ item, index }) => (
+        <Track
+          {...{ ...item, trackSource: props.trackSource }}
+          className={index > 0 ? "mt-2" : undefined}
+        />
+      ),
+    }),
+    [props, listPresets],
+  ) satisfies FlashListProps<Track.Content>;
+}
 //#endregion

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -45,7 +45,7 @@ export function Track({ id, trackSource, className, ...props }: Track.Props) {
         <IconButton
           kind="ripple"
           accessibilityLabel={t("template.entrySeeMore", { name: props.title })}
-          onPress={() => SheetManager.show("track-sheet", { payload: { id } })}
+          onPress={() => SheetManager.show("TrackSheet", { payload: { id } })}
         >
           <MoreVert />
         </IconButton>

--- a/mobile/src/modules/media/components/index.ts
+++ b/mobile/src/modules/media/components/index.ts
@@ -14,4 +14,4 @@ export {
 export { MediaImage } from "./MediaImage";
 export { MediaListControls } from "./MediaListControls";
 export { MiniPlayer } from "./MiniPlayer";
-export { Track, TrackListPreset } from "./Track";
+export { Track, useTrackListPreset } from "./Track";

--- a/mobile/src/modules/media/components/index.ts
+++ b/mobile/src/modules/media/components/index.ts
@@ -14,4 +14,4 @@ export {
 export { MediaImage } from "./MediaImage";
 export { MediaListControls } from "./MediaListControls";
 export { MiniPlayer } from "./MiniPlayer";
-export { Track, TrackList, TrackListPreset } from "./Track";
+export { Track, TrackListPreset } from "./Track";

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -17,7 +17,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { cn } from "@/lib/style";
 import { FlashList } from "@/components/Defaults";
 import { TextInput } from "@/components/Form";
-import { Em, StyledText } from "@/components/Typography";
+import { TEm, TStyledText } from "@/components/Typography";
 import { SearchResult } from "./SearchResult";
 import { useSearch } from "../hooks/useSearch";
 import type {
@@ -68,9 +68,10 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
           renderItem={({ item, index }) => {
             if (typeof item === "string") {
               return (
-                <Em className={index > 0 ? "mt-4" : undefined}>
-                  {t(`common.${item}`)}
-                </Em>
+                <TEm
+                  textKey={`common.${item}`}
+                  className={index > 0 ? "mt-4" : undefined}
+                />
               );
             }
             const { entry, ...rest } = item;
@@ -90,7 +91,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
           }}
           ListEmptyComponent={
             query.length > 0 ? (
-              <StyledText center>{t("response.noResults")}</StyledText>
+              <TStyledText textKey="response.noResults" center />
             ) : undefined
           }
           contentContainerClassName="pb-4 pt-6"

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -1,4 +1,3 @@
-import { FlashList } from "@shopify/flash-list";
 import { LinearGradient } from "expo-linear-gradient";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,6 +15,7 @@ import { Search } from "@/icons";
 import { useTheme } from "@/hooks/useTheme";
 
 import { cn } from "@/lib/style";
+import { FlashList } from "@/components/Defaults";
 import { TextInput } from "@/components/Form";
 import { Em, StyledText } from "@/components/Typography";
 import { SearchResult } from "./SearchResult";
@@ -93,7 +93,6 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
               <StyledText center>{t("response.noResults")}</StyledText>
             ) : undefined
           }
-          showsVerticalScrollIndicator={false}
           contentContainerClassName="pb-4 pt-6"
         />
 

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -16,7 +16,7 @@ import { Search } from "@/icons";
 import { useTheme } from "@/hooks/useTheme";
 
 import { cn } from "@/lib/style";
-import { Ripple, TextInput } from "@/components/Form";
+import { TextInput } from "@/components/Form";
 import { Em, StyledText } from "@/components/Typography";
 import { SearchResult } from "./SearchResult";
 import { useSearch } from "../hooks/useSearch";
@@ -76,16 +76,15 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
             const { entry, ...rest } = item;
 
             return (
-              <Ripple
+              <SearchResult
+                as="ripple"
                 /* @ts-expect-error - `type` should be limited to our scope. */
                 onPress={() => props.callbacks[rest.type](entry)}
                 wrapperClassName={cn("mt-2", {
                   "rounded-full": rest.type === "artist",
                 })}
-              >
-                {/* @ts-expect-error - Values are of correct types. */}
-                <SearchResult {...rest} />
-              </Ripple>
+                {...rest}
+              />
             );
           }}
           ListEmptyComponent={
@@ -126,7 +125,7 @@ function formatResults(results: Partial<SearchResults>) {
       ...data.map((item) => ({
         type: key as SearchCategories[number],
         // @ts-expect-error - Values are of correct types.
-        source: getArtwork({ type: key, data: item }),
+        imageSource: getArtwork({ type: key, data: item }),
         title: item.name,
         // prettier-ignore
         // @ts-expect-error - `artistName` should be present in these cases.

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -68,7 +68,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
           renderItem={({ item, index }) => {
             if (typeof item === "string") {
               return (
-                <Em className={cn({ "mt-4": index !== 0 })}>
+                <Em className={index > 0 ? "mt-4" : undefined}>
                   {t(`common.${item}`)}
                 </Em>
               );
@@ -83,6 +83,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
                 wrapperClassName={cn("mt-2", {
                   "rounded-full": rest.type === "artist",
                 })}
+                className="pr-4"
                 {...rest}
               />
             );

--- a/mobile/src/modules/search/components/SearchResult.tsx
+++ b/mobile/src/modules/search/components/SearchResult.tsx
@@ -1,40 +1,84 @@
 import { View } from "react-native";
 
 import { cn } from "@/lib/style";
-import type { Prettify } from "@/utils/types";
+import { omitKeys } from "@/utils/object";
+import { Ripple } from "@/components/Form";
 import { Kbd, StyledText } from "@/components/Typography";
 import { MediaImage } from "@/modules/media/components";
+import type { MediaType } from "@/modules/media/types";
+
+export namespace SearchResult {
+  export type Content = {
+    title: string;
+    description?: string;
+    type: MediaType;
+    imageSource?: MediaImage.ImageSource | Array<string | null>;
+    /** Renders this instead of the image if provided. */
+    LeftElement?: React.JSX.Element;
+    className?: string;
+  };
+
+  export type Variations =
+    | { as?: "default"; onPress?: never; wrapperClassName?: never }
+    | { as: "ripple"; onPress: () => void; wrapperClassName?: string };
+
+  export type Props = Content &
+    Variations & {
+      /** Letter that's placed next to the title. */
+      contentLabel?: string;
+      RightElement?: React.JSX.Element;
+    };
+}
+
+const wrapperPropsKeys = [
+  ...["as", "onPress", "className", "wrapperClassName"],
+] as const;
 
 /** Displays information about a media item. */
-export function SearchResult(
-  props: Prettify<
-    MediaImage.ImageContent & {
-      title: string;
-      description?: string;
-      /** Element that's placed next to the title. */
-      kbdLetter?: string;
-      className?: string;
-    }
-  >,
-) {
+export function SearchResult(props: SearchResult.Props) {
+  const { as, onPress, className, wrapperClassName } = props;
+  const contentProps = omitKeys(props, wrapperPropsKeys);
+
+  if (as === "ripple") {
+    return (
+      <Ripple
+        {...{ onPress, wrapperClassName }}
+        className={cn("pr-4", className)}
+      >
+        <SearchResultContent {...contentProps} />
+      </Ripple>
+    );
+  }
   return (
     <View
-      className={cn(
-        "min-h-12 flex-row items-center gap-2 pr-4",
-        props.className,
-      )}
+      className={cn("min-h-12 flex-row items-center gap-2 pr-4", className)}
     >
-      {/* @ts-expect-error - These props are type-safe.*/}
-      <MediaImage
-        type={props.type}
-        size={48}
-        source={props.source}
-        radius="sm"
-      />
+      <SearchResultContent {...contentProps} />
+    </View>
+  );
+}
+
+/** Content rendered in either variant of `<SearchResult />`. */
+function SearchResultContent(
+  props: Omit<SearchResult.Props, keyof SearchResult.Variations | "className">,
+) {
+  return (
+    <>
+      {props.LeftElement ? (
+        props.LeftElement
+      ) : (
+        /* @ts-expect-error Things should be fine with proper usage. */
+        <MediaImage
+          type={props.type}
+          size={48}
+          source={props.imageSource ?? null}
+          radius="sm"
+        />
+      )}
       <View className="shrink grow">
         <View className="shrink flex-row items-end gap-1">
-          {props.kbdLetter ? (
-            <Kbd text={props.kbdLetter} className="mb-0.5" />
+          {props.contentLabel ? (
+            <Kbd text={props.contentLabel} className="mb-0.5" />
           ) : undefined}
           <StyledText
             numberOfLines={1}
@@ -49,6 +93,7 @@ export function SearchResult(
           </StyledText>
         )}
       </View>
-    </View>
+      {props.RightElement}
+    </>
   );
 }

--- a/mobile/src/modules/search/components/SearchResult.tsx
+++ b/mobile/src/modules/search/components/SearchResult.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/style";
 import { omitKeys } from "@/utils/object";
 import { Ripple } from "@/components/Form";
 import { Kbd, StyledText } from "@/components/Typography";
-import { MediaImage } from "@/modules/media/components";
+import { MediaImage } from "@/modules/media/components/MediaImage";
 import type { MediaType } from "@/modules/media/types";
 
 export namespace SearchResult {
@@ -41,18 +41,13 @@ export function SearchResult(props: SearchResult.Props) {
 
   if (as === "ripple") {
     return (
-      <Ripple
-        {...{ onPress, wrapperClassName }}
-        className={cn("pr-4", className)}
-      >
+      <Ripple {...{ onPress, wrapperClassName, className }}>
         <SearchResultContent {...contentProps} />
       </Ripple>
     );
   }
   return (
-    <View
-      className={cn("min-h-12 flex-row items-center gap-2 pr-4", className)}
-    >
+    <View className={cn("min-h-12 flex-row items-center gap-2", className)}>
       <SearchResultContent {...contentProps} />
     </View>
   );

--- a/mobile/src/screens/Onboarding.tsx
+++ b/mobile/src/screens/Onboarding.tsx
@@ -14,7 +14,7 @@ import { useOnboardingStore } from "@/modules/scanning/services/Onboarding";
 
 import { cn } from "@/lib/style";
 import { SafeContainer, cardStyles } from "@/components/Containment";
-import { StyledText } from "@/components/Typography";
+import { StyledText, TStyledText } from "@/components/Typography";
 
 /**
  * Informs user with what's being done while displaying the app icon. This
@@ -58,16 +58,17 @@ function OnboardingPhase() {
   if (store.phase === "preprocess") {
     return (
       <>
-        <StyledText>{t("onboardingScreen.preprocess")}</StyledText>
-        <StyledText preset="dimOnSurface">
-          {t("onboardingScreen.preprocessBrief")}
-        </StyledText>
+        <TStyledText textKey="onboardingScreen.preprocess" />
+        <TStyledText
+          preset="dimOnSurface"
+          textKey="onboardingScreen.preprocessBrief"
+        />
       </>
     );
   } else if (store.phase === "tracks") {
     return (
       <>
-        <StyledText>{t("onboardingScreen.track")}</StyledText>
+        <TStyledText textKey="onboardingScreen.track" />
         <StyledText preset="dimOnSurface">
           {`${t("onboardingScreen.prevSaved", { amount: store.prevSaved })}\n\n`}
           {`${t("onboardingScreen.saved", { amount: store.staged, total: store.unstaged })}\n`}
@@ -79,7 +80,7 @@ function OnboardingPhase() {
 
   return (
     <>
-      <StyledText>{t("onboardingScreen.image")}</StyledText>
+      <TStyledText textKey="onboardingScreen.image" />
       <StyledText preset="dimOnSurface">
         {`${t("onboardingScreen.checked", { amount: store.checked, total: store.unchecked })}\n`}
         {`${t("onboardingScreen.found", { amount: store.found })}`}

--- a/mobile/src/screens/Sheets/Backup/index.tsx
+++ b/mobile/src/screens/Sheets/Backup/index.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { useExportBackup, useImportBackup } from "./data";
@@ -6,11 +5,10 @@ import { useExportBackup, useImportBackup } from "./data";
 import { mutateGuard } from "@/lib/react-query";
 import { Button } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
-import { StyledText } from "@/components/Typography";
+import { TStyledText } from "@/components/Typography";
 
 /** Sheet allowing us to utilize the "backup" feature of this app. */
 export default function BackupSheet() {
-  const { t } = useTranslation();
   const exportBackup = useExportBackup();
   const importBackup = useImportBackup();
 
@@ -22,9 +20,11 @@ export default function BackupSheet() {
       titleKey="title.backup"
       contentContainerClassName="gap-4"
     >
-      <StyledText preset="dimOnCanvas" center className="text-sm">
-        {t("settings.description.backup")}
-      </StyledText>
+      <TStyledText
+        preset="dimOnCanvas"
+        textKey="settings.description.backup"
+        className="text-center text-sm"
+      />
 
       <View className="mt-2 flex-row gap-2">
         <Button
@@ -32,18 +32,22 @@ export default function BackupSheet() {
           disabled={inProgress}
           className="flex-1"
         >
-          <StyledText bold center className="text-sm">
-            {t("settings.related.export")}
-          </StyledText>
+          <TStyledText
+            textKey="settings.related.export"
+            bold
+            className="text-center text-sm"
+          />
         </Button>
         <Button
           onPress={() => mutateGuard(importBackup, undefined)}
           disabled={inProgress}
           className="flex-1"
         >
-          <StyledText bold center className="text-sm">
-            {t("settings.related.import")}
-          </StyledText>
+          <TStyledText
+            textKey="settings.related.import"
+            bold
+            className="text-center text-sm"
+          />
         </Button>
       </View>
     </Sheet>

--- a/mobile/src/screens/Sheets/Backup/index.tsx
+++ b/mobile/src/screens/Sheets/Backup/index.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import { useExportBackup, useImportBackup } from "./data";
 
@@ -10,7 +9,7 @@ import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet allowing us to utilize the "backup" feature of this app. */
-export default function BackupSheet(props: SheetProps<"backup-sheet">) {
+export default function BackupSheet() {
   const { t } = useTranslation();
   const exportBackup = useExportBackup();
   const importBackup = useImportBackup();
@@ -19,8 +18,8 @@ export default function BackupSheet(props: SheetProps<"backup-sheet">) {
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("title.backup")}
+      id="BackupSheet"
+      titleKey="title.backup"
       contentContainerClassName="gap-4"
     >
       <StyledText preset="dimOnCanvas" center className="text-sm">

--- a/mobile/src/screens/Sheets/Font.tsx
+++ b/mobile/src/screens/Sheets/Font.tsx
@@ -1,6 +1,4 @@
-import { useTranslation } from "react-i18next";
 import { Text } from "react-native";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 
@@ -8,15 +6,14 @@ import { Radio } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 
 /** Sheet allowing us to change the app's accent font. */
-export default function FontSheet(props: SheetProps<"font-sheet">) {
-  const { t } = useTranslation();
+export default function FontSheet() {
   const accentFont = useUserPreferencesStore((state) => state.accentFont);
   const setAccentFont = useUserPreferencesStore((state) => state.setAccentFont);
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("title.font")}
+      id="FontSheet"
+      titleKey="title.font"
       contentContainerClassName="gap-1"
     >
       <Radio

--- a/mobile/src/screens/Sheets/Language.tsx
+++ b/mobile/src/screens/Sheets/Language.tsx
@@ -1,6 +1,3 @@
-import { useTranslation } from "react-i18next";
-import type { SheetProps } from "react-native-actions-sheet";
-
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 import { LANGUAGES } from "@/modules/i18n/constants";
 
@@ -10,15 +7,14 @@ import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet allowing us to change the app's language. */
-export default function LanguageSheet(props: SheetProps<"language-sheet">) {
-  const { t } = useTranslation();
+export default function LanguageSheet() {
   const languageCode = useUserPreferencesStore((state) => state.language);
   const setLanguage = useUserPreferencesStore((state) => state.setLanguage);
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("title.language")}
+      id="LanguageSheet"
+      titleKey="title.language"
       contentContainerClassName="pb-0"
     >
       <SheetsFlatList

--- a/mobile/src/screens/Sheets/Language.tsx
+++ b/mobile/src/screens/Sheets/Language.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from "react-i18next";
 import type { SheetProps } from "react-native-actions-sheet";
-import { FlatList } from "react-native-actions-sheet";
 
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 import { LANGUAGES } from "@/modules/i18n/constants";
 
+import { SheetsFlatList } from "@/components/Defaults";
 import { Radio } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
@@ -21,7 +21,7 @@ export default function LanguageSheet(props: SheetProps<"language-sheet">) {
       title={t("title.language")}
       contentContainerClassName="pb-0"
     >
-      <FlatList
+      <SheetsFlatList
         data={LANGUAGES}
         keyExtractor={({ code }) => code}
         renderItem={({ item }) => (
@@ -32,8 +32,6 @@ export default function LanguageSheet(props: SheetProps<"language-sheet">) {
             <StyledText>{item.name}</StyledText>
           </Radio>
         )}
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="gap-1 pb-4"
       />
     </Sheet>

--- a/mobile/src/screens/Sheets/MinDuration.tsx
+++ b/mobile/src/screens/Sheets/MinDuration.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard } from "react-native";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import {
   useUserPreferencesStore,
@@ -13,9 +12,7 @@ import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet used to specify the minimum track duration we want to save. */
-export default function MinDurationSheet(
-  props: SheetProps<"min-duration-sheet">,
-) {
+export default function MinDurationSheet() {
   const { t } = useTranslation();
   const minSeconds = useUserPreferencesStore((state) => state.minSeconds);
   const [newMin, setNewMin] = useState<string | undefined>();
@@ -32,8 +29,8 @@ export default function MinDurationSheet(
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("title.ignoreDuration")}
+      id="MinDurationSheet"
+      titleKey="title.ignoreDuration"
       contentContainerClassName="gap-4"
     >
       <StyledText preset="dimOnCanvas" center className="text-sm">

--- a/mobile/src/screens/Sheets/MinDuration.tsx
+++ b/mobile/src/screens/Sheets/MinDuration.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { Keyboard } from "react-native";
 
 import {
@@ -9,11 +8,10 @@ import {
 
 import { NumericInput } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
-import { StyledText } from "@/components/Typography";
+import { TStyledText } from "@/components/Typography";
 
 /** Sheet used to specify the minimum track duration we want to save. */
 export default function MinDurationSheet() {
-  const { t } = useTranslation();
   const minSeconds = useUserPreferencesStore((state) => state.minSeconds);
   const [newMin, setNewMin] = useState<string | undefined>();
 
@@ -33,9 +31,11 @@ export default function MinDurationSheet() {
       titleKey="title.ignoreDuration"
       contentContainerClassName="gap-4"
     >
-      <StyledText preset="dimOnCanvas" center className="text-sm">
-        {t("settings.description.ignoreDuration")}
-      </StyledText>
+      <TStyledText
+        preset="dimOnCanvas"
+        textKey="settings.description.ignoreDuration"
+        className="text-center text-sm"
+      />
       <NumericInput
         defaultValue={`${minSeconds}`}
         onChangeText={(text) => setNewMin(text)}

--- a/mobile/src/screens/Sheets/ScanFilterList/index.tsx
+++ b/mobile/src/screens/Sheets/ScanFilterList/index.tsx
@@ -6,7 +6,6 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard, View } from "react-native";
 import type { SheetProps } from "react-native-actions-sheet";
-import { FlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
 
 import { Add, CreateNewFolder, Remove } from "@/icons";
 import { useUserPreferencesStore } from "@/services/UserPreferences";
@@ -17,6 +16,7 @@ import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
 import { cn } from "@/lib/style";
 import { Marquee, cardStyles } from "@/components/Containment";
+import { SheetsFlashList } from "@/components/Defaults";
 import { IconButton, TextInput } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { Swipeable } from "@/components/Swipeable";
@@ -51,13 +51,13 @@ export default function ScanFilterListSheet(
       </StyledText>
       <FilterForm {...{ listType, listEntries }} />
 
-      <FlashList
+      <SheetsFlashList
         estimatedItemSize={58} // 54px Height + 4px Margin Top
         data={listEntries}
         keyExtractor={(item) => item}
         renderItem={({ item, index }) => (
           <Swipeable
-            containerClassName={cn("px-4", { "mt-1": index !== 0 })}
+            containerClassName={cn("px-4", { "mt-1": index > 0 })}
             renderRightActions={() => (
               <View className="pr-4">
                 <IconButton
@@ -79,12 +79,8 @@ export default function ScanFilterListSheet(
             </Marquee>
           </Swipeable>
         )}
-        ListEmptyComponent={
-          <StyledText center>{t("response.noFilters")}</StyledText>
-        }
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="pb-4"
+        emptyMsgKey="response.noFilters"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/ScanFilterList/index.tsx
+++ b/mobile/src/screens/Sheets/ScanFilterList/index.tsx
@@ -5,7 +5,6 @@ import {
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard, View } from "react-native";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import { Add, CreateNewFolder, Remove } from "@/icons";
 import { useUserPreferencesStore } from "@/services/UserPreferences";
@@ -24,10 +23,10 @@ import { StyledText } from "@/components/Typography";
 
 //#region Sheet
 /** Sheet used to edit the paths in the allowlist or blocklist. */
-export default function ScanFilterListSheet(
-  props: SheetProps<"scan-filter-list-sheet">,
-) {
-  const listType = props.payload!.listType;
+export default function ScanFilterListSheet(props: {
+  payload: { listType: "listAllow" | "listBlock" };
+}) {
+  const listType = props.payload.listType;
 
   const { t } = useTranslation();
   const { surface } = useTheme();
@@ -35,8 +34,8 @@ export default function ScanFilterListSheet(
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t(`title.${listType}`)}
+      id="ScanFilterListSheet"
+      titleKey={`title.${listType}`}
       contentContainerClassName="gap-4 px-0"
       snapTop
     >

--- a/mobile/src/screens/Sheets/Theme.tsx
+++ b/mobile/src/screens/Sheets/Theme.tsx
@@ -1,5 +1,4 @@
 import { useColorScheme } from "nativewind";
-import { useTranslation } from "react-i18next";
 
 import {
   ThemeOptions,
@@ -9,11 +8,10 @@ import {
 import { FlatList } from "@/components/Defaults";
 import { Radio } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
-import { StyledText } from "@/components/Typography";
+import { TStyledText } from "@/components/Typography";
 
 /** Sheet allowing us to change the app's theme. */
 export default function ThemeSheet() {
-  const { t } = useTranslation();
   const { setColorScheme } = useColorScheme();
   const theme = useUserPreferencesStore((state) => state.theme);
   const setTheme = useUserPreferencesStore((state) => state.setTheme);
@@ -31,7 +29,7 @@ export default function ThemeSheet() {
               setTheme(item);
             }}
           >
-            <StyledText>{t(`settings.related.${item}`)}</StyledText>
+            <TStyledText textKey={`settings.related.${item}`} />
           </Radio>
         )}
         contentContainerClassName="gap-1"

--- a/mobile/src/screens/Sheets/Theme.tsx
+++ b/mobile/src/screens/Sheets/Theme.tsx
@@ -1,6 +1,5 @@
 import { useColorScheme } from "nativewind";
 import { useTranslation } from "react-i18next";
-import { FlatList } from "react-native";
 import type { SheetProps } from "react-native-actions-sheet";
 
 import {
@@ -8,6 +7,7 @@ import {
   useUserPreferencesStore,
 } from "@/services/UserPreferences";
 
+import { FlatList } from "@/components/Defaults";
 import { Radio } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
@@ -35,7 +35,6 @@ export default function ThemeSheet(props: SheetProps<"theme-sheet">) {
             <StyledText>{t(`settings.related.${item}`)}</StyledText>
           </Radio>
         )}
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="gap-1"
       />
     </Sheet>

--- a/mobile/src/screens/Sheets/Theme.tsx
+++ b/mobile/src/screens/Sheets/Theme.tsx
@@ -1,6 +1,5 @@
 import { useColorScheme } from "nativewind";
 import { useTranslation } from "react-i18next";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import {
   ThemeOptions,
@@ -13,14 +12,14 @@ import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet allowing us to change the app's theme. */
-export default function ThemeSheet(props: SheetProps<"theme-sheet">) {
+export default function ThemeSheet() {
   const { t } = useTranslation();
   const { setColorScheme } = useColorScheme();
   const theme = useUserPreferencesStore((state) => state.theme);
   const setTheme = useUserPreferencesStore((state) => state.setTheme);
 
   return (
-    <Sheet id={props.sheetId} title={t("title.theme")}>
+    <Sheet id="ThemeSheet" titleKey="title.theme">
       <FlatList
         data={ThemeOptions}
         keyExtractor={(item) => item}

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -1,6 +1,5 @@
 import { router, usePathname } from "expo-router";
 import type { ParseKeys } from "i18next";
-import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
 
@@ -31,7 +30,7 @@ import {
 import { Divider, Marquee } from "@/components/Containment";
 import { IconButton } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
-import { Em, StyledText } from "@/components/Typography";
+import { StyledText, TEm, TStyledText } from "@/components/Typography";
 import { ReservedPlaylists } from "@/modules/media/constants";
 import { MediaImage } from "@/modules/media/components";
 
@@ -226,11 +225,10 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
 //#region Stat Item
 /** Represents a statistical piece of information about the file. */
 function StatItem(props: { titleKey: ParseKeys; description: string }) {
-  const { t } = useTranslation();
   return (
     <View className="flex-1">
       <Marquee>
-        <Em preset="dimOnCanvas">{t(props.titleKey)}</Em>
+        <TEm preset="dimOnCanvas" textKey={props.titleKey} />
       </Marquee>
       <Marquee>
         <StyledText className="text-xs">{props.description}</StyledText>
@@ -248,9 +246,7 @@ function SheetButton(props: {
   textKey: ParseKeys;
   preventClose?: boolean;
 }) {
-  const { t } = useTranslation();
   const { width } = useGetColumn({ cols: 2, gap: 8, gutters: 32 });
-
   return (
     <IconButton
       kind="extended"
@@ -262,7 +258,7 @@ function SheetButton(props: {
       className="p-2"
     >
       {props.Icon}
-      <StyledText className="shrink text-xs">{t(props.textKey)}</StyledText>
+      <TStyledText textKey={props.textKey} className="shrink text-xs" />
     </IconButton>
   );
 }

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -1,4 +1,5 @@
 import { router, usePathname } from "expo-router";
+import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
@@ -113,33 +114,32 @@ function TrackIntro({ data }: { data: TrackWithAlbum }) {
 //#region Stats
 /** Display stats about the file. */
 function Stats({ data }: { data: TrackWithAlbum }) {
-  const { t } = useTranslation();
   return (
     <View className="gap-2">
       <View className="flex-row gap-2">
         <StatItem
-          title={t("trackModal.bitrate")}
+          titleKey="trackModal.bitrate"
           description={
             data.bitrate !== null ? abbreviateBitRate(data.bitrate) : "—"
           }
         />
         <StatItem
-          title={t("trackModal.sampleRate")}
+          titleKey="trackModal.sampleRate"
           description={data.sampleRate !== null ? `${data.sampleRate} Hz` : "—"}
         />
       </View>
       <View className="flex-row gap-2">
         <StatItem
-          title={t("trackModal.size")}
+          titleKey="trackModal.size"
           description={abbreviateSize(data.size)}
         />
         <StatItem
-          title={t("trackModal.modified")}
+          titleKey="trackModal.modified"
           description={formatEpoch(data.modificationTime)}
         />
       </View>
       <View className="flex-row">
-        <StatItem title={t("trackModal.filePath")} description={data.uri} />
+        <StatItem titleKey="trackModal.filePath" description={data.uri} />
       </View>
     </View>
   );
@@ -149,7 +149,6 @@ function Stats({ data }: { data: TrackWithAlbum }) {
 //#region Add Actions
 /** Add track to a playlist or queue. */
 function AddActions({ data }: { data: TrackWithAlbum }) {
-  const { t } = useTranslation();
   return (
     <View className="flex-row gap-2">
       <SheetButton
@@ -159,13 +158,13 @@ function AddActions({ data }: { data: TrackWithAlbum }) {
           })
         }
         Icon={<PlaylistAdd />}
-        text={t("playlist.add")}
+        textKey="playlist.add"
         preventClose
       />
       <SheetButton
         onPress={() => Queue.add({ id: data.id, name: data.name })}
         Icon={<QueueMusic />}
-        text={t("trackModal.queueAdd")}
+        textKey="trackModal.queueAdd"
       />
     </View>
   );
@@ -174,7 +173,6 @@ function AddActions({ data }: { data: TrackWithAlbum }) {
 
 //#region Track Links
 function TrackLinks({ data }: { data: TrackWithAlbum }) {
-  const { t } = useTranslation();
   const pathname = usePathname();
   const playingSource = useMusicStore((state) => state.playingSource);
   const playingList = useMusicStore((state) => state.playingList);
@@ -196,14 +194,14 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
           <SheetButton
             onPress={() => router.navigate(`/artist/${data.artistName}`)}
             Icon={<Artist />}
-            text={t("common.artist")}
+            textKey="common.artist"
           />
         ) : null}
         {data.album ? (
           <SheetButton
             onPress={() => router.navigate(`/album/${data.album?.id}`)}
             Icon={<Album />}
-            text={t("common.album")}
+            textKey="common.album"
           />
         ) : null}
         {canShowPlaylistBtn && isInList ? (
@@ -216,7 +214,7 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
               )
             }
             Icon={<List />}
-            text={t("common.playlist")}
+            textKey="common.playlist"
           />
         ) : null}
       </View>
@@ -227,11 +225,12 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
 
 //#region Stat Item
 /** Represents a statistical piece of information about the file. */
-function StatItem(props: { title: string; description: string }) {
+function StatItem(props: { titleKey: ParseKeys; description: string }) {
+  const { t } = useTranslation();
   return (
     <View className="flex-1">
       <Marquee>
-        <Em preset="dimOnCanvas">{props.title}</Em>
+        <Em preset="dimOnCanvas">{t(props.titleKey)}</Em>
       </Marquee>
       <Marquee>
         <StyledText className="text-xs">{props.description}</StyledText>
@@ -246,10 +245,12 @@ function StatItem(props: { title: string; description: string }) {
 function SheetButton(props: {
   onPress: () => void;
   Icon: React.JSX.Element;
-  text: string;
+  textKey: ParseKeys;
   preventClose?: boolean;
 }) {
+  const { t } = useTranslation();
   const { width } = useGetColumn({ cols: 2, gap: 8, gutters: 32 });
+
   return (
     <IconButton
       kind="extended"
@@ -261,7 +262,7 @@ function SheetButton(props: {
       className="p-2"
     >
       {props.Icon}
-      <StyledText className="shrink text-xs">{props.text}</StyledText>
+      <StyledText className="shrink text-xs">{t(props.textKey)}</StyledText>
     </IconButton>
   );
 }

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -1,7 +1,7 @@
 import { router, usePathname } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
-import { SheetManager, type SheetProps } from "react-native-actions-sheet";
+import { SheetManager } from "react-native-actions-sheet";
 
 import type { TrackWithAlbum } from "@/db/schema";
 
@@ -35,10 +35,10 @@ import { ReservedPlaylists } from "@/modules/media/constants";
 import { MediaImage } from "@/modules/media/components";
 
 /** Sheet containing information and actions for a track. */
-export default function TrackSheet(props: SheetProps<"track-sheet">) {
-  const { isPending, error, data } = useTrack(props.payload!.id);
+export default function TrackSheet(props: { payload: { id: string } }) {
+  const { isPending, error, data } = useTrack(props.payload.id);
   return (
-    <Sheet id={props.sheetId} contentContainerClassName="gap-4">
+    <Sheet id="TrackSheet" contentContainerClassName="gap-4">
       {isPending || error ? null : (
         <>
           <TrackIntro data={data} />
@@ -154,7 +154,7 @@ function AddActions({ data }: { data: TrackWithAlbum }) {
     <View className="flex-row gap-2">
       <SheetButton
         onPress={() =>
-          SheetManager.show("track-to-playlist-sheet", {
+          SheetManager.show("TrackToPlaylistSheet", {
             payload: { id: data.id },
           })
         }
@@ -254,7 +254,7 @@ function SheetButton(props: {
     <IconButton
       kind="extended"
       onPress={() => {
-        if (!props.preventClose) SheetManager.hide("track-sheet");
+        if (!props.preventClose) SheetManager.hide("TrackSheet");
         props.onPress();
       }}
       style={{ width }}

--- a/mobile/src/screens/Sheets/TrackSort.tsx
+++ b/mobile/src/screens/Sheets/TrackSort.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import { FlatList } from "react-native";
 import type { SheetProps } from "react-native-actions-sheet";
 
 import {
@@ -7,6 +6,7 @@ import {
   useSortPreferencesStore,
 } from "@/modules/media/services/SortPreferences";
 
+import { FlatList } from "@/components/Defaults";
 import { Button, Radio, Switch } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
@@ -40,7 +40,6 @@ export default function TrackSortSheet(props: SheetProps<"track-sort-sheet">) {
             <StyledText>{t(`sortModal.${item}`)}</StyledText>
           </Radio>
         )}
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="gap-1"
       />
     </Sheet>

--- a/mobile/src/screens/Sheets/TrackSort.tsx
+++ b/mobile/src/screens/Sheets/TrackSort.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from "react-i18next";
-
 import {
   OrderedByOptions,
   useSortPreferencesStore,
@@ -8,11 +6,10 @@ import {
 import { FlatList } from "@/components/Defaults";
 import { Button, Radio, Switch } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
-import { StyledText } from "@/components/Typography";
+import { TStyledText } from "@/components/Typography";
 
 /** Sheet allowing us visually change the sort order on the `/track` screen. */
 export default function TrackSortSheet() {
-  const { t } = useTranslation();
   const isAsc = useSortPreferencesStore((state) => state.isAsc);
   const toggleIsAsc = useSortPreferencesStore((state) => state.toggleIsAsc);
   const orderedBy = useSortPreferencesStore((state) => state.orderedBy);
@@ -25,7 +22,7 @@ export default function TrackSortSheet() {
       contentContainerClassName="gap-4"
     >
       <Button onPress={toggleIsAsc} className="flex-row justify-between">
-        <StyledText className="shrink">{t("sortModal.asc")}</StyledText>
+        <TStyledText textKey="sortModal.asc" className="shrink" />
         <Switch enabled={isAsc} />
       </Button>
       <FlatList
@@ -36,7 +33,7 @@ export default function TrackSortSheet() {
             selected={item === orderedBy}
             onSelect={() => setOrderedBy(item)}
           >
-            <StyledText>{t(`sortModal.${item}`)}</StyledText>
+            <TStyledText textKey={`sortModal.${item}`} />
           </Radio>
         )}
         contentContainerClassName="gap-1"

--- a/mobile/src/screens/Sheets/TrackSort.tsx
+++ b/mobile/src/screens/Sheets/TrackSort.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import {
   OrderedByOptions,
@@ -12,7 +11,7 @@ import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet allowing us visually change the sort order on the `/track` screen. */
-export default function TrackSortSheet(props: SheetProps<"track-sort-sheet">) {
+export default function TrackSortSheet() {
   const { t } = useTranslation();
   const isAsc = useSortPreferencesStore((state) => state.isAsc);
   const toggleIsAsc = useSortPreferencesStore((state) => state.toggleIsAsc);
@@ -21,8 +20,8 @@ export default function TrackSortSheet(props: SheetProps<"track-sort-sheet">) {
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("title.sort")}
+      id="TrackSortSheet"
+      titleKey="title.sort"
       contentContainerClassName="gap-4"
     >
       <Button onPress={toggleIsAsc} className="flex-row justify-between">

--- a/mobile/src/screens/Sheets/TrackToPlaylist.tsx
+++ b/mobile/src/screens/Sheets/TrackToPlaylist.tsx
@@ -9,7 +9,6 @@ import {
 import { useTheme } from "@/hooks/useTheme";
 
 import { mutateGuard } from "@/lib/react-query";
-import { cn } from "@/lib/style";
 import { Marquee } from "@/components/Containment";
 import { SheetsFlashList } from "@/components/Defaults";
 import { Checkbox } from "@/components/Form";
@@ -49,7 +48,7 @@ export default function TrackToPlaylistSheet(props: {
                   item.name,
                 )
               }
-              wrapperClassName={cn({ "mt-1": index > 0 })}
+              wrapperClassName={index > 0 ? "mt-1" : undefined}
             >
               <Marquee color={selected ? surface : canvasAlt}>
                 <StyledText>{item.name}</StyledText>

--- a/mobile/src/screens/Sheets/TrackToPlaylist.tsx
+++ b/mobile/src/screens/Sheets/TrackToPlaylist.tsx
@@ -1,5 +1,3 @@
-import { useTranslation } from "react-i18next";
-import type { SheetProps } from "react-native-actions-sheet";
 import { SheetManager } from "react-native-actions-sheet";
 
 import { usePlaylists } from "@/queries/playlist";
@@ -19,22 +17,21 @@ import { Sheet } from "@/components/Sheet";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet allowing us to select which playlists the track belongs to. */
-export default function TrackToPlaylistSheet(
-  props: SheetProps<"track-to-playlist-sheet">,
-) {
-  const { t } = useTranslation();
+export default function TrackToPlaylistSheet(props: {
+  payload: { id: string };
+}) {
   const { canvasAlt, surface } = useTheme();
   const { data } = usePlaylists();
-  const { data: inList } = useTrackPlaylists(props.payload!.id);
-  const addToPlaylist = useAddToPlaylist(props.payload!.id);
-  const removeFromPlaylist = useRemoveFromPlaylist(props.payload!.id);
+  const { data: inList } = useTrackPlaylists(props.payload.id);
+  const addToPlaylist = useAddToPlaylist(props.payload.id);
+  const removeFromPlaylist = useRemoveFromPlaylist(props.payload.id);
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("playlist.add")}
+      id="TrackToPlaylistSheet"
+      titleKey="playlist.add"
       // Hide the Track sheet when we close this sheet since it's still open.
-      onBeforeClose={() => SheetManager.hide("track-sheet")}
+      onBeforeClose={() => SheetManager.hide("TrackSheet")}
       snapTop
     >
       <SheetsFlashList

--- a/mobile/src/screens/Sheets/TrackToPlaylist.tsx
+++ b/mobile/src/screens/Sheets/TrackToPlaylist.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import type { SheetProps } from "react-native-actions-sheet";
 import { SheetManager } from "react-native-actions-sheet";
-import { FlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
 
 import { usePlaylists } from "@/queries/playlist";
 import {
@@ -14,9 +13,9 @@ import { useTheme } from "@/hooks/useTheme";
 import { mutateGuard } from "@/lib/react-query";
 import { cn } from "@/lib/style";
 import { Marquee } from "@/components/Containment";
+import { SheetsFlashList } from "@/components/Defaults";
 import { Checkbox } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
-import { Loading } from "@/components/Transition";
 import { StyledText } from "@/components/Typography";
 
 /** Sheet allowing us to select which playlists the track belongs to. */
@@ -25,7 +24,7 @@ export default function TrackToPlaylistSheet(
 ) {
   const { t } = useTranslation();
   const { canvasAlt, surface } = useTheme();
-  const { isPending, data } = usePlaylists();
+  const { data } = usePlaylists();
   const { data: inList } = useTrackPlaylists(props.payload!.id);
   const addToPlaylist = useAddToPlaylist(props.payload!.id);
   const removeFromPlaylist = useRemoveFromPlaylist(props.payload!.id);
@@ -38,7 +37,7 @@ export default function TrackToPlaylistSheet(
       onBeforeClose={() => SheetManager.hide("track-sheet")}
       snapTop
     >
-      <FlashList
+      <SheetsFlashList
         estimatedItemSize={58} // 54px Height + 4px Margin Top
         data={data}
         keyExtractor={({ name }) => name}
@@ -53,7 +52,7 @@ export default function TrackToPlaylistSheet(
                   item.name,
                 )
               }
-              wrapperClassName={cn({ "mt-1": index !== 0 })}
+              wrapperClassName={cn({ "mt-1": index > 0 })}
             >
               <Marquee color={selected ? surface : canvasAlt}>
                 <StyledText>{item.name}</StyledText>
@@ -61,16 +60,8 @@ export default function TrackToPlaylistSheet(
             </Checkbox>
           );
         }}
-        ListEmptyComponent={
-          isPending ? (
-            <Loading />
-          ) : (
-            <StyledText center>{t("response.noPlaylists")}</StyledText>
-          )
-        }
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="pb-4"
+        emptyMsgKey="response.noPlaylists"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next";
 import type { SheetProps } from "react-native-actions-sheet";
-import { FlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
 
 import { getTrackCover } from "@/db/utils";
 
@@ -9,6 +8,7 @@ import { Queue, useMusicStore } from "@/modules/media/services/Music";
 
 import { Colors } from "@/constants/Styles";
 import { cn } from "@/lib/style";
+import { SheetsFlashList } from "@/components/Defaults";
 import { IconButton } from "@/components/Form";
 import { Sheet } from "@/components/Sheet";
 import { Swipeable } from "@/components/Swipeable";
@@ -45,7 +45,7 @@ export default function TrackUpcomingSheet(
       snapTop
       contentContainerClassName="px-0"
     >
-      <FlashList
+      <SheetsFlashList
         estimatedItemSize={52} // 48px Height + 4px Margin Top
         data={data}
         keyExtractor={({ name }, index) => `${name}_${index}`}
@@ -58,7 +58,7 @@ export default function TrackUpcomingSheet(
 
           const wrapperStyle = cn("px-4", {
             "opacity-25": index >= disableIndex,
-            "mt-1": index !== 0,
+            "mt-1": index > 0,
           });
 
           if (index < queueList.length) {
@@ -84,8 +84,6 @@ export default function TrackUpcomingSheet(
 
           return <TrackItem {...itemContent} className={wrapperStyle} />;
         }}
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
         contentContainerClassName="pb-4"
       />
     </Sheet>

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import type { SheetProps } from "react-native-actions-sheet";
 
 import { getTrackCover } from "@/db/utils";
 
@@ -18,9 +17,7 @@ import { SearchResult } from "@/modules/search/components";
  * Sheet allowing us to see the upcoming tracks and remove tracks from
  * the queue.
  */
-export default function TrackUpcomingSheet(
-  props: SheetProps<"track-upcoming-sheet">,
-) {
+export default function TrackUpcomingSheet() {
   const { t } = useTranslation();
   const trackList = useMusicStore((state) => state.currentTrackList);
   const queueList = useMusicStore((state) => state.queuedTrackList);
@@ -40,8 +37,8 @@ export default function TrackUpcomingSheet(
 
   return (
     <Sheet
-      id={props.sheetId}
-      title={t("title.upcoming")}
+      id="TrackUpcomingSheet"
+      titleKey="title.upcoming"
       snapTop
       contentContainerClassName="px-0"
     >

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
 import type { SheetProps } from "react-native-actions-sheet";
 import { FlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
 
@@ -54,7 +53,7 @@ export default function TrackUpcomingSheet(
           const itemContent = {
             title: item.name,
             description: item.artistName ?? "—",
-            source: getTrackCover(item),
+            imageSource: getTrackCover(item),
           };
 
           const wrapperStyle = cn("px-4", {
@@ -67,17 +66,15 @@ export default function TrackUpcomingSheet(
               <Swipeable
                 containerClassName={wrapperStyle}
                 renderRightActions={() => (
-                  <View className="pr-4">
-                    <IconButton
-                      accessibilityLabel={t("template.entryRemove", {
-                        name: item.name,
-                      })}
-                      onPress={() => Queue.removeAtIndex(index)}
-                      className="bg-red"
-                    >
-                      <Remove color={Colors.neutral100} />
-                    </IconButton>
-                  </View>
+                  <IconButton
+                    accessibilityLabel={t("template.entryRemove", {
+                      name: item.name,
+                    })}
+                    onPress={() => Queue.removeAtIndex(index)}
+                    className="mr-4 bg-red"
+                  >
+                    <Remove color={Colors.neutral100} />
+                  </IconButton>
                 )}
               >
                 <TrackItem {...itemContent} inQueue />
@@ -85,11 +82,7 @@ export default function TrackUpcomingSheet(
             );
           }
 
-          return (
-            <View className={wrapperStyle}>
-              <TrackItem {...itemContent} />
-            </View>
-          );
+          return <TrackItem {...itemContent} className={wrapperStyle} />;
         }}
         overScrollMode="never"
         showsVerticalScrollIndicator={false}
@@ -106,18 +99,18 @@ export default function TrackUpcomingSheet(
 function TrackItem({
   inQueue,
   ...props
-}: {
-  title: string;
-  description: string;
-  source: string | null;
-  inQueue?: boolean;
-}) {
+}: Pick<
+  SearchResult.Content,
+  "title" | "description" | "imageSource" | "className"
+> & { inQueue?: boolean }) {
   return (
     <SearchResult
       type="track"
       {...props}
-      kbdLetter={inQueue ? "Q" : undefined}
-      className="bg-canvas pr-2 dark:bg-neutral5"
+      contentLabel={inQueue ? "Q" : undefined}
+      className={cn(props.className, "bg-canvas pr-2 dark:bg-neutral5", {
+        "pr-6": !inQueue,
+      })}
     />
   );
 }

--- a/mobile/src/screens/Sheets/index.ts
+++ b/mobile/src/screens/Sheets/index.ts
@@ -17,33 +17,33 @@ import TrackUpcomingSheet from "./TrackUpcoming";
   return `null` due waiting for data (ie: React Query), when the data
   appears, the sheet won't render as it expects a sheet on initial render.
 */
-registerSheet("backup-sheet", BackupSheet);
-registerSheet("font-sheet", FontSheet);
-registerSheet("language-sheet", LanguageSheet);
-registerSheet("min-duration-sheet", MinDurationSheet);
-registerSheet("scan-filter-list-sheet", ScanFilterListSheet);
-registerSheet("theme-sheet", ThemeSheet);
-registerSheet("track-sheet", TrackSheet);
-registerSheet("track-sort-sheet", TrackSortSheet);
-registerSheet("track-to-playlist-sheet", TrackToPlaylistSheet);
-registerSheet("track-upcoming-sheet", TrackUpcomingSheet);
+registerSheet("BackupSheet", BackupSheet);
+registerSheet("FontSheet", FontSheet);
+registerSheet("LanguageSheet", LanguageSheet);
+registerSheet("MinDurationSheet", MinDurationSheet);
+registerSheet("ScanFilterListSheet", ScanFilterListSheet);
+registerSheet("ThemeSheet", ThemeSheet);
+registerSheet("TrackSheet", TrackSheet);
+registerSheet("TrackSortSheet", TrackSortSheet);
+registerSheet("TrackToPlaylistSheet", TrackToPlaylistSheet);
+registerSheet("TrackUpcomingSheet", TrackUpcomingSheet);
 
 // We extend some of the types here to give us great intellisense
 // across the app for all registered sheets.
 declare module "react-native-actions-sheet" {
   interface Sheets {
-    "backup-sheet": SheetDefinition;
-    "font-sheet": SheetDefinition;
-    "language-sheet": SheetDefinition;
-    "min-duration-sheet": SheetDefinition;
-    "scan-filter-list-sheet": SheetDefinition<{
+    BackupSheet: SheetDefinition;
+    FontSheet: SheetDefinition;
+    LanguageSheet: SheetDefinition;
+    MinDurationSheet: SheetDefinition;
+    ScanFilterListSheet: SheetDefinition<{
       payload: { listType: "listAllow" | "listBlock" };
     }>;
-    "theme-sheet": SheetDefinition;
-    "track-sheet": SheetDefinition<{ payload: { id: string } }>;
-    "track-sort-sheet": SheetDefinition;
-    "track-to-playlist-sheet": SheetDefinition<{ payload: { id: string } }>;
-    "track-upcoming-sheet": SheetDefinition;
+    ThemeSheet: SheetDefinition;
+    TrackSheet: SheetDefinition<{ payload: { id: string } }>;
+    TrackSortSheet: SheetDefinition;
+    TrackToPlaylistSheet: SheetDefinition<{ payload: { id: string } }>;
+    TrackUpcomingSheet: SheetDefinition;
   }
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Primarily under-the-hood stuff with components, props, and translations.

- Updated `<SearchResult />` implementation to be similar to the old `<ActionButton />` - `<Track />` now uses this component.
- Removed list "presets" that were one-offs as it added some unnecessary complexity.
- Create placeholder components (empty list, waiting for page to load / if page errored).
- Created "default" scroll components (the different variants of `ScrollView`, `FlatList`, and `FlashList`) with common defaults (`overScrollMode="never"`, `showsVerticalScrollIndicator={false}`).
- Some components now accept a `*Key` prop which is a translation key as we typically pass a translated value down.
- Fixed issue I noticed where the title on the home screens would be cut off on the bottom on some devices (probably due to missing line height for the text).
- Registered sheets with simpler id value (just sheet component name).

> [!NOTE]  
> I've noticed that the track sheet is a bit slower to open compared to before. When comparing the speeds when opening with & without the "stats" section, we see that we see a speed degradation with the addition of the section. I believe that it might be related to the `<Marquee />` component as we've added 10 marquees (so it might be a performance issue on that part).

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [ ] This diff will work correctly for `pnpm android:prod`.
