### PR TITLE
feat: Artwork sheet & support artist artwork

### DIFF
--- a/docs/supported-gestures.md
+++ b/docs/supported-gestures.md
@@ -32,3 +32,9 @@ This involves swiping left on some content to reveal actions related to that con
     </tr>
   </tbody>
 </table>
+
+## Long-Press for Action
+
+This involves long-pressing an item to reveal some action. It's currently present in the following features.
+
+- **`Artist & Playlist Artwork`:** You can long-press on the artist or playlist artwork on their respective screens to reveal a modal to change or remove the specified artwork.

--- a/mobile/src/api/playlist.ts
+++ b/mobile/src/api/playlist.ts
@@ -9,7 +9,7 @@ import i18next from "@/modules/i18n";
 import { sortTracks } from "@/modules/media/services/SortPreferences";
 
 import { iAsc } from "@/lib/drizzle";
-import { deleteFile } from "@/lib/file-system";
+import { deleteImage } from "@/lib/file-system";
 import type { ReservedPlaylistName } from "@/modules/media/constants";
 import { ReservedPlaylists } from "@/modules/media/constants";
 import type { DrizzleFilter, QuerySingleFn } from "./types";
@@ -116,7 +116,7 @@ export async function updatePlaylist(
         .where(eq(tracksToPlaylists.playlistName, id));
     }
     // Delete the old artwork if we changed it (`null` means we've removed it).
-    if (rest.artwork !== undefined) await deleteFile(oldValue.artwork);
+    if (rest.artwork !== undefined) await deleteImage(oldValue.artwork);
   });
 }
 //#endregion
@@ -132,7 +132,7 @@ export async function deletePlaylist(id: string) {
       .where(eq(tracksToPlaylists.playlistName, id));
     await tx.delete(playlists).where(eq(playlists.name, id));
     // If the deletions were fine, delete the artwork.
-    await deleteFile(artwork);
+    await deleteImage(artwork);
   });
 }
 //#endregion

--- a/mobile/src/api/track.ts
+++ b/mobile/src/api/track.ts
@@ -7,7 +7,7 @@ import { getTrackCover } from "@/db/utils";
 
 import i18next from "@/modules/i18n";
 
-import { deleteFile } from "@/lib/file-system";
+import { deleteImage } from "@/lib/file-system";
 import type { DrizzleFilter, QuerySingleFn } from "./types";
 
 //#region GET Methods
@@ -86,7 +86,7 @@ export async function deleteTrack(id: string) {
     await tx.delete(tracksToPlaylists).where(eq(tracksToPlaylists.trackId, id));
     await tx.delete(tracks).where(eq(tracks.id, id));
     // If the deletions were fine, delete the artwork.
-    await deleteFile(artwork);
+    await deleteImage(artwork);
   });
 }
 

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -28,7 +28,7 @@ export default function CurrentArtistScreen() {
     <CurrentListLayout
       title={data.name}
       metadata={data.metadata}
-      imageSource={null}
+      imageSource={data.imageSource}
       mediaSource={trackSource}
     >
       <FlashList

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -27,6 +27,7 @@ export default function ArtistScreen() {
         ) : (
           <SearchResult
             {...{ as: "ripple", type: "artist", title: item.name }}
+            imageSource={item.artwork}
             onPress={() =>
               router.navigate(`/artist/${encodeURIComponent(item.name)}`)
             }

--- a/mobile/src/db/drizzle/0006_slow_deathstrike.sql
+++ b/mobile/src/db/drizzle/0006_slow_deathstrike.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `artists` ADD `artwork` text;

--- a/mobile/src/db/drizzle/meta/0006_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,451 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "47e60f11-1f0b-4c8e-ba99-25121f4b3657",
+  "prevId": "0e52e805-e00f-4877-8094-75569a74888b",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "albums_name_artist_name_release_year_unique": {
+          "name": "albums_name_artist_name_release_year_unique",
+          "columns": [
+            "name",
+            "artist_name",
+            "release_year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1733689925630,
       "tag": "0005_nappy_talon",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1734495259538,
+      "tag": "0006_slow_deathstrike",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -7,6 +7,7 @@ import m0002 from "./0002_third_giant_man.sql";
 import m0003 from "./0003_breezy_wolverine.sql";
 import m0004 from "./0004_past_starfox.sql";
 import m0005 from "./0005_nappy_talon.sql";
+import m0006 from "./0006_slow_deathstrike.sql";
 
 export default {
   journal,
@@ -17,5 +18,6 @@ export default {
     m0003,
     m0004,
     m0005,
+    m0006,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -14,6 +14,7 @@ import type { Prettify } from "@/utils/types";
 
 export const artists = sqliteTable("artists", {
   name: text().primaryKey(),
+  artwork: text(),
 });
 
 export const artistsRelations = relations(artists, ({ many }) => ({
@@ -36,9 +37,7 @@ export const albums = sqliteTable(
     artwork: text(),
     isFavorite: integer({ mode: "boolean" }).notNull().default(false),
   },
-  (t) => ({
-    unq: unique().on(t.name, t.artistName, t.releaseYear),
-  }),
+  (t) => [unique().on(t.name, t.artistName, t.releaseYear)],
 );
 
 export const albumsRelations = relations(albums, ({ one, many }) => ({
@@ -108,9 +107,7 @@ export const tracksToPlaylists = sqliteTable(
       .notNull()
       .references(() => playlists.name),
   },
-  (t) => ({
-    pk: primaryKey({ columns: [t.trackId, t.playlistName] }),
-  }),
+  (t) => [primaryKey({ columns: [t.trackId, t.playlistName] })],
 );
 
 export const tracksToPlaylistsRelations = relations(

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -40,11 +40,10 @@ type MediaData = Prettify<
 //#region Format for Component
 /** Format data to be used in `<MediaCard />`. */
 export function formatForMediaCard({ type, data, t }: MediaData) {
-  let source = null;
+  let source: string | string[] | null = data.artwork;
   let href = `/${type}/${encodeURIComponent(data.name)}`;
   let description = t("plural.track", { count: data.tracks.length });
   if (type === "album") {
-    source = data.artwork;
     href = `/album/${data.id}`;
     description = data.artistName;
   } else if (type === "playlist") {
@@ -92,6 +91,7 @@ export function formatForCurrentScreen({ type, data, t }: MediaData) {
 
   return {
     name: data.name,
+    imageSource: type === "playlist" ? getPlaylistCover(data) : data.artwork,
     metadata,
     tracks: data.tracks.map((track) => ({
       ...formatForTrack(

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -35,6 +35,7 @@ export function CurrentListLayout(props: {
             props.title === ReservedPlaylists.favorites ||
             !SupportedArtwork.has(props.mediaSource.type)
           }
+          delayLongPress={150}
           onLongPress={() => {
             switch (props.mediaSource.type) {
               case "playlist":

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -5,7 +5,7 @@ import { SheetManager } from "react-native-actions-sheet";
 import { Schedule } from "@/icons";
 import { useTheme } from "@/hooks/useTheme";
 
-import { toLowerCase } from "@/utils/string";
+import { capitalize, toLowerCase } from "@/utils/string";
 import { Divider, Marquee } from "@/components/Containment";
 import { StyledText, TEm } from "@/components/Typography";
 import { ReservedPlaylists } from "@/modules/media/constants";
@@ -13,7 +13,7 @@ import { MediaImage, MediaListControls } from "@/modules/media/components";
 import type { MediaType, PlayListSource } from "@/modules/media/types";
 
 /** List of media that we can change artwork for. */
-const SupportedArtwork = new Set<MediaType>(["playlist"]);
+const SupportedArtwork = new Set<MediaType>(["artist", "playlist"]);
 
 /** Layout for displaying a list of tracks for the specified media. */
 export function CurrentListLayout(props: {
@@ -37,12 +37,11 @@ export function CurrentListLayout(props: {
           }
           delayLongPress={150}
           onLongPress={() => {
-            switch (props.mediaSource.type) {
-              case "playlist":
-                SheetManager.show("PlaylistArtworkSheet", {
-                  payload: { id: props.title },
-                });
-            }
+            if (!SupportedArtwork.has(props.mediaSource.type)) return;
+            SheetManager.show(
+              `${capitalize(props.mediaSource.type)}ArtworkSheet`,
+              { payload: { id: props.title } },
+            );
           }}
           className="active:opacity-75"
         >

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -37,7 +37,6 @@ export function CurrentListLayout(props: {
           }
           delayLongPress={150}
           onLongPress={() => {
-            if (!SupportedArtwork.has(props.mediaSource.type)) return;
             SheetManager.show(
               `${capitalize(props.mediaSource.type)}ArtworkSheet`,
               { payload: { id: props.title } },

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -1,5 +1,6 @@
 import { Link } from "expo-router";
-import { View } from "react-native";
+import { Pressable, View } from "react-native";
+import { SheetManager } from "react-native-actions-sheet";
 
 import { Schedule } from "@/icons";
 import { useTheme } from "@/hooks/useTheme";
@@ -7,8 +8,12 @@ import { useTheme } from "@/hooks/useTheme";
 import { toLowerCase } from "@/utils/string";
 import { Divider, Marquee } from "@/components/Containment";
 import { StyledText, TEm } from "@/components/Typography";
+import { ReservedPlaylists } from "@/modules/media/constants";
 import { MediaImage, MediaListControls } from "@/modules/media/components";
-import type { PlayListSource } from "@/modules/media/types";
+import type { MediaType, PlayListSource } from "@/modules/media/types";
+
+/** List of media that we can change artwork for. */
+const SupportedArtwork = new Set<MediaType>(["playlist"]);
 
 /** Layout for displaying a list of tracks for the specified media. */
 export function CurrentListLayout(props: {
@@ -25,12 +30,28 @@ export function CurrentListLayout(props: {
   return (
     <>
       <View className="flex-row gap-2 px-4">
-        {/* @ts-expect-error Things should be fine with proper usage. */}
-        <MediaImage
-          type={props.mediaSource.type}
-          source={props.imageSource}
-          size={128}
-        />
+        <Pressable
+          disabled={
+            props.title === ReservedPlaylists.favorites ||
+            !SupportedArtwork.has(props.mediaSource.type)
+          }
+          onLongPress={() => {
+            switch (props.mediaSource.type) {
+              case "playlist":
+                SheetManager.show("PlaylistArtworkSheet", {
+                  payload: { id: props.title },
+                });
+            }
+          }}
+          className="active:opacity-75"
+        >
+          {/* @ts-expect-error Things should be fine with proper usage. */}
+          <MediaImage
+            type={props.mediaSource.type}
+            source={props.imageSource}
+            size={128}
+          />
+        </Pressable>
         <View className="shrink grow justify-end">
           <TEm
             preset="dimOnCanvas"

--- a/mobile/src/lib/file-system.ts
+++ b/mobile/src/lib/file-system.ts
@@ -5,12 +5,14 @@ import * as ImagePicker from "expo-image-picker";
 
 import type { Maybe } from "@/utils/types";
 
+/** Internal app directory where we store images. */
+export const ImageDirectory = FileSystem.documentDirectory + "images";
+
 /** Creates "image" directory if it doesn't already exist. */
 export async function createImageDirectory() {
   try {
-    const imgDir = FileSystem.documentDirectory + "images";
-    const dir = await FileSystem.getInfoAsync(imgDir);
-    if (!dir.exists) await FileSystem.makeDirectoryAsync(imgDir);
+    const dir = await FileSystem.getInfoAsync(ImageDirectory);
+    if (!dir.exists) await FileSystem.makeDirectoryAsync(ImageDirectory);
   } catch {
     // Silently catch `Directory <> could not be created or already exists`
     // error from `FileSystem.makeDirectoryAsync()` in case it occurs. This
@@ -18,9 +20,9 @@ export async function createImageDirectory() {
   }
 }
 
-/** Helper to delete a file if it's defined. */
-export async function deleteFile(uri: Maybe<string>) {
-  if (uri) await FileSystem.deleteAsync(uri);
+/** Helper to delete an internal image file if it's defined. */
+export async function deleteImage(uri: Maybe<string>) {
+  if (uri && uri.startsWith(ImageDirectory)) await FileSystem.deleteAsync(uri);
 }
 
 /**

--- a/mobile/src/modules/media/services/Playback.ts
+++ b/mobile/src/modules/media/services/Playback.ts
@@ -121,6 +121,7 @@ export async function playFromMediaList({
   // 3. Handle case when the media list is new.
   const newPlayingList = (await getTrackList(source)).map(({ id }) => id);
   if (newPlayingList.length === 0) return; // Don't do anything if list is empty.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { isInQueue: _, ...newListsInfo } = RNTPManager.getUpdatedLists(
     newPlayingList,
     { startTrackId: trackId ?? activeId },

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -3,7 +3,7 @@ import { eq, isNotNull } from "drizzle-orm";
 import * as FileSystem from "expo-file-system";
 
 import { db } from "@/db";
-import { albums, playlists, tracks } from "@/db/schema";
+import { albums, artists, playlists, tracks } from "@/db/schema";
 
 import { getAlbums, updateAlbum } from "@/api/album";
 import { getTracks, updateTrack } from "@/api/track";
@@ -82,7 +82,7 @@ export async function cleanupImages() {
   // Get all the uris of images saved in the database.
   const usedUris = (
     await Promise.all(
-      [albums, playlists, tracks].map((schema) =>
+      [albums, artists, playlists, tracks].map((schema) =>
         db
           .select({ artwork: schema.artwork })
           .from(schema)

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -9,7 +9,7 @@ import { getAlbums, updateAlbum } from "@/api/album";
 import { getTracks, updateTrack } from "@/api/track";
 import { onboardingStore } from "../services/Onboarding";
 
-import { deleteFile, saveBase64Img } from "@/lib/file-system";
+import { ImageDirectory, deleteImage, saveBase64Img } from "@/lib/file-system";
 import { clearAllQueries } from "@/lib/react-query";
 import { Stopwatch } from "@/utils/debug";
 import { batch } from "@/utils/promise";
@@ -93,16 +93,13 @@ export async function cleanupImages() {
     .flat()
     .map(({ artwork }) => artwork!);
 
-  // Where we store images on this device.
-  const imageDir = FileSystem.documentDirectory + "images";
-
   // Get & delete all unused images.
   let deletedCount = 0;
   await batch({
-    data: (await FileSystem.readDirectoryAsync(imageDir)).filter(
+    data: (await FileSystem.readDirectoryAsync(ImageDirectory)).filter(
       (imageName) => !usedUris.some((uri) => uri.endsWith(imageName)),
     ),
-    callback: (imageName) => deleteFile(`${imageDir}/${imageName}`),
+    callback: (imageName) => deleteImage(`${ImageDirectory}/${imageName}`),
     onBatchComplete: (isFulfilled) => {
       deletedCount += isFulfilled.length;
     },

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -9,7 +9,7 @@ import { getAlbums, updateAlbum } from "@/api/album";
 import { getTracks, updateTrack } from "@/api/track";
 import { onboardingStore } from "../services/Onboarding";
 
-import { ImageDirectory, deleteImage, saveBase64Img } from "@/lib/file-system";
+import { ImageDirectory, deleteImage, saveImage } from "@/lib/file-system";
 import { clearAllQueries } from "@/lib/react-query";
 import { Stopwatch } from "@/utils/debug";
 import { batch } from "@/utils/promise";
@@ -53,7 +53,7 @@ export async function findAndSaveArtwork() {
       try {
         const base64Artwork = await getArtwork(uri);
         if (base64Artwork) {
-          const artwork = await saveBase64Img(base64Artwork);
+          const artwork = await saveImage(base64Artwork);
           if (albumId) {
             await updateAlbum(albumId, { artwork });
             albumsWithCovers.add(albumId);

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -146,7 +146,7 @@ type MediaRelations =
 /** Get the artwork of the media that'll be displayed. */
 function getArtwork(props: MediaRelations) {
   if (props.type === "album") return props.data.artwork;
-  if (props.type === "artist") return null;
+  if (props.type === "artist") return props.data.artwork;
   if (props.type === "playlist") return getPlaylistCover(props.data);
   return getTrackCover(props.data);
 }

--- a/mobile/src/queries/album.ts
+++ b/mobile/src/queries/album.ts
@@ -17,7 +17,6 @@ export function useAlbumForScreen(albumId: string) {
     select: (data) => ({
       ...formatForCurrentScreen({ type: "album", data, t }),
       ...pickKeys(data, ["artistName", "isFavorite"]),
-      imageSource: data.artwork,
     }),
   });
 }

--- a/mobile/src/queries/artist.ts
+++ b/mobile/src/queries/artist.ts
@@ -9,6 +9,11 @@ import { Resynchronize } from "@/modules/media/services/Resynchronize";
 import { queries as q } from "./keyStore";
 
 //#region Queries
+/** Get specified artist. */
+export function useArtist(artistName: string) {
+  return useQuery({ ...q.artists.detail(artistName) });
+}
+
 /** Format artist information for artist's `(current)` screen. */
 export function useArtistForScreen(artistName: string) {
   const { t } = useTranslation();

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -35,7 +35,6 @@ export function usePlaylistForScreen(playlistName: string) {
     ...q.playlists.detail(playlistName),
     select: (data) => ({
       ...formatForCurrentScreen({ type: "playlist", data, t }),
-      imageSource: getPlaylistCover(data),
       isFavorite: data.isFavorite,
     }),
   });

--- a/mobile/src/screens/Sheets/Artwork.tsx
+++ b/mobile/src/screens/Sheets/Artwork.tsx
@@ -1,0 +1,84 @@
+import { View, useWindowDimensions } from "react-native";
+
+import { usePlaylist, useUpdatePlaylist } from "@/queries/playlist";
+
+import { pickImage } from "@/lib/file-system";
+import { mutateGuard } from "@/lib/react-query";
+import { Marquee } from "@/components/Containment";
+import { Button } from "@/components/Form";
+import { Sheet } from "@/components/Sheet";
+import { StyledText, TStyledText } from "@/components/Typography";
+import { MediaImage } from "@/modules/media/components";
+import type { MediaType } from "@/modules/media/types";
+
+/** Sheet allowing us to change the artwork of a playlist. */
+export function PlaylistArtworkSheet(props: { payload: { id: string } }) {
+  const { data } = usePlaylist(props.payload.id);
+  const updatePlaylist = useUpdatePlaylist(props.payload.id);
+
+  return (
+    <BaseArtworkSheet
+      id="PlaylistArtworkSheet"
+      type="playlist"
+      imageSource={data?.imageSource ?? null}
+      onChange={async (artwork) => mutateGuard(updatePlaylist, { artwork })}
+      onRemove={async () => mutateGuard(updatePlaylist, { artwork: null })}
+    />
+  );
+}
+
+/** Reusable sheet for changing the artwork of some media. */
+function BaseArtworkSheet(props: {
+  id: string;
+  type: MediaType;
+  imageSource: MediaImage.ImageSource | Array<string | null>;
+  onChange: (newUri: string) => Promise<void>;
+  onRemove: () => Promise<void>;
+}) {
+  const { height, width } = useWindowDimensions();
+  return (
+    <Sheet id={props.id} contentContainerClassName="items-center gap-6">
+      <View className="items-center gap-3">
+        {/* @ts-expect-error Things should be fine with proper usage. */}
+        <MediaImage
+          type={props.type}
+          source={props.imageSource ?? null}
+          size={width - 64 > height - 256 ? height - 256 : width - 64}
+        />
+        {typeof props.imageSource === "string" ? (
+          <Marquee center>
+            <StyledText preset="dimOnCanvas">{props.imageSource}</StyledText>
+          </Marquee>
+        ) : undefined}
+      </View>
+
+      <View className="flex-row gap-2">
+        <Button
+          onPress={props.onRemove}
+          disabled={
+            props.imageSource === null || Array.isArray(props.imageSource)
+          }
+        >
+          <TStyledText
+            textKey="playlist.artworkRemove"
+            bold
+            className="text-center text-sm"
+          />
+        </Button>
+        <Button
+          onPress={async () => {
+            try {
+              await props.onChange(await pickImage());
+            } catch {}
+          }}
+        >
+          <TStyledText
+            textKey="playlist.artworkChange"
+            bold
+            className="text-center text-sm"
+          />
+        </Button>
+      </View>
+    </Sheet>
+  );
+}

--- a/mobile/src/screens/Sheets/Artwork.tsx
+++ b/mobile/src/screens/Sheets/Artwork.tsx
@@ -2,6 +2,7 @@ import type { UseMutationResult } from "@tanstack/react-query";
 import { useState } from "react";
 import { View, useWindowDimensions } from "react-native";
 
+import { useArtist, useUpdateArtist } from "@/queries/artist";
 import { usePlaylist, useUpdatePlaylist } from "@/queries/playlist";
 
 import { pickImage } from "@/lib/file-system";
@@ -11,6 +12,25 @@ import { Sheet } from "@/components/Sheet";
 import { TStyledText } from "@/components/Typography";
 import { MediaImage } from "@/modules/media/components";
 import type { MediaType } from "@/modules/media/types";
+
+/** Sheet allowing us to change the artwork of a artist. */
+export function ArtistArtworkSheet(props: { payload: { id: string } }) {
+  const { data } = useArtist(props.payload.id);
+  const updateArtist = useUpdateArtist(props.payload.id);
+
+  return (
+    <Sheet
+      id="ArtistArtworkSheet"
+      contentContainerClassName="items-center gap-6"
+    >
+      <BaseArtworkSheetContent
+        type="artist"
+        imageSource={data?.artwork ?? null}
+        mutationResult={updateArtist}
+      />
+    </Sheet>
+  );
+}
 
 /** Sheet allowing us to change the artwork of a playlist. */
 export function PlaylistArtworkSheet(props: { payload: { id: string } }) {

--- a/mobile/src/screens/Sheets/index.ts
+++ b/mobile/src/screens/Sheets/index.ts
@@ -1,6 +1,7 @@
 import type { SheetDefinition } from "react-native-actions-sheet";
 import { registerSheet } from "react-native-actions-sheet";
 
+import { PlaylistArtworkSheet } from "./Artwork";
 import BackupSheet from "./Backup";
 import FontSheet from "./Font";
 import LanguageSheet from "./Language";
@@ -21,6 +22,7 @@ registerSheet("BackupSheet", BackupSheet);
 registerSheet("FontSheet", FontSheet);
 registerSheet("LanguageSheet", LanguageSheet);
 registerSheet("MinDurationSheet", MinDurationSheet);
+registerSheet("PlaylistArtworkSheet", PlaylistArtworkSheet);
 registerSheet("ScanFilterListSheet", ScanFilterListSheet);
 registerSheet("ThemeSheet", ThemeSheet);
 registerSheet("TrackSheet", TrackSheet);
@@ -36,6 +38,7 @@ declare module "react-native-actions-sheet" {
     FontSheet: SheetDefinition;
     LanguageSheet: SheetDefinition;
     MinDurationSheet: SheetDefinition;
+    PlaylistArtworkSheet: SheetDefinition<{ payload: { id: string } }>;
     ScanFilterListSheet: SheetDefinition<{
       payload: { listType: "listAllow" | "listBlock" };
     }>;

--- a/mobile/src/screens/Sheets/index.ts
+++ b/mobile/src/screens/Sheets/index.ts
@@ -1,7 +1,7 @@
 import type { SheetDefinition } from "react-native-actions-sheet";
 import { registerSheet } from "react-native-actions-sheet";
 
-import { PlaylistArtworkSheet } from "./Artwork";
+import { ArtistArtworkSheet, PlaylistArtworkSheet } from "./Artwork";
 import BackupSheet from "./Backup";
 import FontSheet from "./Font";
 import LanguageSheet from "./Language";
@@ -18,6 +18,7 @@ import TrackUpcomingSheet from "./TrackUpcoming";
   return `null` due waiting for data (ie: React Query), when the data
   appears, the sheet won't render as it expects a sheet on initial render.
 */
+registerSheet("ArtistArtworkSheet", ArtistArtworkSheet);
 registerSheet("BackupSheet", BackupSheet);
 registerSheet("FontSheet", FontSheet);
 registerSheet("LanguageSheet", LanguageSheet);
@@ -34,6 +35,7 @@ registerSheet("TrackUpcomingSheet", TrackUpcomingSheet);
 // across the app for all registered sheets.
 declare module "react-native-actions-sheet" {
   interface Sheets {
+    ArtistArtworkSheet: SheetDefinition<{ payload: { id: string } }>;
     BackupSheet: SheetDefinition;
     FontSheet: SheetDefinition;
     LanguageSheet: SheetDefinition;

--- a/mobile/src/utils/string.ts
+++ b/mobile/src/utils/string.ts
@@ -17,6 +17,11 @@ export function removeFileExtension(filename: string) {
   return filename.split(".").slice(0, -1).join(".");
 }
 
+/** @description Capitalize first letter of string. */
+export function capitalize<T extends string>(str: T) {
+  return (str.charAt(0).toUpperCase() + str.slice(1)) as Capitalize<T>;
+}
+
 /** Type-safe `String.prototype.toLowerCase()`. */
 export function toLowerCase<T extends string>(str: T) {
   return str.toLowerCase() as Lowercase<T>;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

- Support artwork for artists.
- Updated how we define extra configs in schema (use array instead of object as object method is deprecated).
- Create sheet for changing artwork for artist & playlists by long-pressing on that image on their respective screens.
- Add documentation for long-press gesture.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [ ] This diff will work correctly for `pnpm android:prod`.
