### PR TITLE
chore: Re-add ability to edit & delete playlists

### DIFF
--- a/mobile/src/app/(main)/(current)/_layout.tsx
+++ b/mobile/src/app/(main)/(current)/_layout.tsx
@@ -7,8 +7,9 @@ export default function CurrentLayout() {
     <Stack
       screenOptions={{ animation: "fade", header: TopAppBar, headerTitle: "" }}
     >
-      <Stack.Screen name="playlist/create" />
       <Stack.Screen name="playlist/Favorite Tracks" />
+      <Stack.Screen name="playlist/create" />
+      <Stack.Screen name="playlist/modify" />
       <Stack.Screen name="playlist/[id]" />
       <Stack.Screen name="album/[id]" />
       <Stack.Screen name="artist/[id]" />

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -1,4 +1,4 @@
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
@@ -53,7 +53,11 @@ export default function CurrentPlaylistScreen() {
               <IconButton
                 kind="ripple"
                 accessibilityLabel={t("playlist.edit")}
-                onPress={() => console.log("Configuring playlist...")}
+                onPress={() =>
+                  router.navigate(
+                    `/playlist/modify?id=${encodeURIComponent(id)}`,
+                  )
+                }
               >
                 <Edit />
               </IconButton>

--- a/mobile/src/app/(main)/(current)/playlist/modify.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/modify.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { getTrackCover } from "@/db/utils";
 
-import { usePlaylist } from "@/queries/playlist";
+import { usePlaylist, useUpdatePlaylist } from "@/queries/playlist";
 import { ModifyPlaylist } from "@/screens/ModifyPlaylist";
 
 import { mutateGuardAsync } from "@/lib/react-query";
@@ -16,8 +16,9 @@ export default function ModifyPlaylistScreen() {
   const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
   const { data } = usePlaylist(id);
+  const updatePlaylist = useUpdatePlaylist(id);
 
-  const tracks = useMemo(() => {
+  const initialTracks = useMemo(() => {
     if (!data?.tracks) return [];
     return data.tracks.map((t) => ({ ...t, artwork: getTrackCover(t) }));
   }, [data?.tracks]);
@@ -26,21 +27,31 @@ export default function ModifyPlaylistScreen() {
     <ModifyPlaylist
       mode="edit"
       initialName={id}
-      initialTracks={tracks}
+      initialTracks={initialTracks}
       onSubmit={async (playlistName, tracks) => {
-        console.log("Editing:", playlistName);
-        // await mutateGuardAsync(
-        //   createPlaylist,
-        //   { playlistName, tracks },
-        //   {
-        //     onSuccess: () => {
-        //       router.replace(`/playlist/${encodeURIComponent(playlistName)}`);
-        //     },
-        //     onError: () => {
-        //       toast.error(t("errorScreen.generic"), ToastOptions);
-        //     },
-        //   },
-        // );
+        // Don't update playlist name if it hasn't changed.
+        const newName = id === playlistName ? undefined : playlistName;
+        // Don't update tracks if they didn't change.
+        const tracksUnchanged =
+          initialTracks.length === tracks.length &&
+          initialTracks.every((t, index) => t.id === tracks[index]?.id);
+
+        await mutateGuardAsync(
+          updatePlaylist,
+          { name: newName, tracks: tracksUnchanged ? undefined : tracks },
+          {
+            onSuccess: () => {
+              router.back();
+              // If playlist name changed, see the new playlist page.
+              if (newName !== undefined) {
+                router.replace(`/playlist/${encodeURIComponent(newName)}`);
+              }
+            },
+            onError: () => {
+              toast.error(t("errorScreen.generic"), ToastOptions);
+            },
+          },
+        );
       }}
     />
   );

--- a/mobile/src/app/(main)/(current)/playlist/modify.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/modify.tsx
@@ -1,0 +1,47 @@
+import { toast } from "@backpackapp-io/react-native-toast";
+import { router, useLocalSearchParams } from "expo-router";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getTrackCover } from "@/db/utils";
+
+import { usePlaylist } from "@/queries/playlist";
+import { ModifyPlaylist } from "@/screens/ModifyPlaylist";
+
+import { mutateGuardAsync } from "@/lib/react-query";
+import { ToastOptions } from "@/lib/toast";
+
+/** Screen for modifying a playlist. */
+export default function ModifyPlaylistScreen() {
+  const { t } = useTranslation();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { data } = usePlaylist(id);
+
+  const tracks = useMemo(() => {
+    if (!data?.tracks) return [];
+    return data.tracks.map((t) => ({ ...t, artwork: getTrackCover(t) }));
+  }, [data?.tracks]);
+
+  return (
+    <ModifyPlaylist
+      mode="edit"
+      initialName={id}
+      initialTracks={tracks}
+      onSubmit={async (playlistName, tracks) => {
+        console.log("Editing:", playlistName);
+        // await mutateGuardAsync(
+        //   createPlaylist,
+        //   { playlistName, tracks },
+        //   {
+        //     onSuccess: () => {
+        //       router.replace(`/playlist/${encodeURIComponent(playlistName)}`);
+        //     },
+        //     onError: () => {
+        //       toast.error(t("errorScreen.generic"), ToastOptions);
+        //     },
+        //   },
+        // );
+      }}
+    />
+  );
+}

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -360,22 +360,21 @@ export class RNTPManager {
     // Only update the RNTP queue if its defined.
     if (!(await RNTPManager.isLoaded())) return;
     const currTrack = musicStore.getState().activeTrack;
+    // Return early if we're not playing anything.
+    if (!currTrack) return;
     const nextTrack = RNTPManager.getNextTrack();
     await TrackPlayer.removeUpcomingTracks();
-    // Return if we have no tracks (ie: when we removed a track from
-    // the current list).
-    if (!nextTrack.activeTrack || !currTrack) return;
     // If the next track is `undefined`, then we should run `reset()`
     // after the current track finishes.
-    if (nextTrack.activeId === undefined) {
+    if (!nextTrack.activeId || !nextTrack.activeTrack) {
       await TrackPlayer.add({
-        ...formatTrackforPlayer(currTrack!),
+        ...formatTrackforPlayer(currTrack),
         // Field read in `PlaybackActiveTrackChanged` event to fire `reset()`.
         "music::status": "END" satisfies TrackStatus,
       });
     } else {
       await TrackPlayer.add({
-        ...formatTrackforPlayer(nextTrack.activeTrack!),
+        ...formatTrackforPlayer(nextTrack.activeTrack),
         "music::status": (nextTrack.isInQueue
           ? "QUEUE"
           : undefined) satisfies TrackStatus,

--- a/mobile/src/modules/media/services/Playback.ts
+++ b/mobile/src/modules/media/services/Playback.ts
@@ -66,6 +66,8 @@ export class MusicControls {
   static async next() {
     const shouldRepeat = musicStore.getState().repeat;
     const { listIdx, ...nextTrack } = RNTPManager.getNextTrack();
+    // Make sure we reset if we're play from a source with no tracks left.
+    if (!nextTrack.activeId) return await musicStore.getState().reset();
     musicStore.setState({
       ...nextTrack,
       ...(!nextTrack.isInQueue ? { listIdx } : {}),

--- a/mobile/src/modules/media/services/Playback.ts
+++ b/mobile/src/modules/media/services/Playback.ts
@@ -66,7 +66,7 @@ export class MusicControls {
   static async next() {
     const shouldRepeat = musicStore.getState().repeat;
     const { listIdx, ...nextTrack } = RNTPManager.getNextTrack();
-    // Make sure we reset if we're play from a source with no tracks left.
+    // Make sure we reset if we play from a source with no tracks left.
     if (!nextTrack.activeId) return await musicStore.getState().reset();
     musicStore.setState({
       ...nextTrack,

--- a/mobile/src/modules/media/services/Resynchronize.ts
+++ b/mobile/src/modules/media/services/Resynchronize.ts
@@ -33,7 +33,7 @@ export class Resynchronize {
   }
 
   /** Resynchronize when we rename a playlist. */
-  static onRename({
+  static async onRename({
     oldSource,
     newSource,
   }: Record<"oldSource" | "newSource", PlayListSource>) {
@@ -43,9 +43,8 @@ export class Resynchronize {
     const isPlayingRef = arePlaybackSourceEqual(currSource, oldSource);
     // Update `playingSource` if we renamed that source.
     if (isPlayingRef) {
-      getSourceName(newSource).then((newName) =>
-        musicStore.setState({ playingSource: newSource, sourceName: newName }),
-      );
+      const newName = await getSourceName(newSource);
+      musicStore.setState({ playingSource: newSource, sourceName: newName });
     }
   }
 

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 
 import type { TrackWithAlbum, playlists } from "@/db/schema";
@@ -83,8 +82,6 @@ export function useDeletePlaylist(playlistName: string) {
       // Invalidate all playlist queries and the favorite lists query.
       queryClient.invalidateQueries({ queryKey: q.playlists._def });
       queryClient.invalidateQueries({ queryKey: q.favorites.lists.queryKey });
-      // Go back a page as this current page (deleted playlist) isn't valid.
-      router.back();
     },
   });
 }

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -127,8 +127,8 @@ export function useUpdatePlaylist(playlistName: string) {
           newSource: { type: "playlist", id: sanitizedName },
         });
       }
-      // Do this after checking for `name` as the tracks will be referenced
-      // on the new list name instead of `playlistName`.
+      // Do this after checking for `sanitizedName` as the tracks will be
+      // referenced on the new list name instead of `playlistName`.
       if (tracks !== undefined) {
         await Resynchronize.onTracks({
           type: "playlist",

--- a/mobile/src/screens/ModifyPlaylist.tsx
+++ b/mobile/src/screens/ModifyPlaylist.tsx
@@ -318,11 +318,11 @@ const DeleteWorkflow = memo(function DeleteWorkflow(props: {
   };
 
   const buttonClass =
-    "min-h-12 min-w-12 shrink items-center justify-center p-4 active:opacity-50";
+    "min-h-12 min-w-12 shrink items-center justify-center px-2 py-4 active:opacity-50";
 
   return (
     <View
-      className={cn("flex-row bg-surface", {
+      className={cn("flex-row gap-2 bg-surface px-4", {
         "opacity-25": props.isSubmitting,
       })}
     >

--- a/mobile/src/screens/ModifyPlaylist.tsx
+++ b/mobile/src/screens/ModifyPlaylist.tsx
@@ -40,7 +40,9 @@ export function ModifyPlaylist(props: ScreenOptions) {
 
   const isUnchanged = useMemo(() => {
     let nameUnchanged = !playlistName; // `true` if empty.
-    if (!!props.initialName) nameUnchanged = props.initialName === playlistName;
+    if (!!props.initialName) {
+      nameUnchanged = props.initialName === playlistName.trim();
+    }
     let tracksUnchanged = tracks.length === 0;
     if (props.initialTracks) {
       tracksUnchanged =
@@ -114,7 +116,7 @@ export function ModifyPlaylist(props: ScreenOptions) {
             <IconButton
               kind="ripple"
               accessibilityLabel={t("form.apply")}
-              disabled={!isUnique || isSubmitting}
+              disabled={isUnchanged || !isUnique || isSubmitting}
               onPress={async () => {
                 try {
                   const sanitized = sanitizePlaylistName(playlistName);

--- a/mobile/src/screens/ModifyPlaylist.tsx
+++ b/mobile/src/screens/ModifyPlaylist.tsx
@@ -35,7 +35,7 @@ export function ModifyPlaylist(props: ScreenOptions) {
   const { data } = usePlaylists();
   const [unsavedDialog, setUnsavedDialog] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [playlistName, setPlaylistName] = useState("");
+  const [playlistName, setPlaylistName] = useState(props.initialName ?? "");
   const [tracks, setTracks] = useState(props.initialTracks ?? []);
 
   const isUnchanged = useMemo(() => {
@@ -157,7 +157,9 @@ export function ModifyPlaylist(props: ScreenOptions) {
               containerClassName={index > 0 ? "mt-2" : undefined}
             >
               <SearchResult
-                {...{ type: "track", title: item.name }}
+                type="track"
+                title={item.name}
+                description={item.artistName ?? "—"}
                 imageSource={item.artwork}
               />
             </Swipeable>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

With this PR, we'll reach "feature parity" with what we have prior as we've previously removed the logic for creating, editing, and deleting playlists (which the features have been re-added with recent PRs).

**Other Changes:**
- Fixed issue where our playback logic didn't properly handle the case when we're playing a list with no tracks remaining (as we couldn't really simulate this behavior prior).

> [!NOTE]  
> We initially want to add some sort of animation with the delete sequence, but that's a bit extra and it works without it (plus I want to get this update out as soon as possible).
>
> We've also tested to see if anything would get cut off if we disabled the Android navigation bar and everything seemed fine enough (this mainly depends on the radius of the screen, which is different for every device).

> [!NOTE]  
> The performance issue with the `<FlashList />` and `<Swipeable />` I see is only limited to my OnePlus 6 and not my Nothing 2a.
>
> Also related to this issue, I've noticed that when exiting the edit playlist screen through the unsaved modal instead of backing with no changes, we didn't have a choppy unmount, which was interesting.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

There's a couple of scenarios we need to test while editing playlists:

- [x] When we rename a playlist:
  - [x] We should appear on the route for that newly named playlist.
  - [x] When playing that playlist, we should still be playing the list.
    - [x] The displayed name for the list on the current media screen should be this new name.
    - [x] The order of the currently playing tracks shouldn't change.
- [x] When we change the list of tracks (adding or removing tracks) **excluding** the currently playing one:
  - [x] The sound shouldn't be interrupted.
  - [x] The order of the current playing tracks should have changed.
- [x] When we remove the current playing track in the playlist:
  - [x] The removed track should still be playing (it's now part of the queue).
- [x] Removing all tracks from the playlist should finish up the current playing track and any tracks left in the queue before closing itself.
- [x] Deleting the currently playing playlist should quit playback.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
