### PR TITLE
feat: Add "Repeat One" mode

### DIFF
--- a/mobile/src/icons/RepeatOne.tsx
+++ b/mobile/src/icons/RepeatOne.tsx
@@ -1,0 +1,43 @@
+import Svg, { Path } from "react-native-svg";
+
+import { useTheme } from "@/hooks/useTheme";
+import type { Icon } from "./type";
+
+// Custom icon based on ionicons' "Repeat" and "Calendar Number".
+export function RepeatOne({ size = 24, color }: Icon) {
+  const { foreground } = useTheme();
+  const usedColor = color ?? foreground;
+  return (
+    <Svg width={size} height={size} viewBox="0 0 512 512">
+      <Path
+        fill="none"
+        stroke={usedColor}
+        strokeLinecap="square"
+        strokeMiterlimit="10"
+        strokeWidth="32"
+        d="M320 120L368 168L320 216"
+      />
+      <Path
+        fill="none"
+        stroke={usedColor}
+        strokeLinecap="square"
+        strokeMiterlimit="10"
+        strokeWidth="32"
+        d="M352 168H64V264M192 392L144 344L192 296"
+      />
+      <Path
+        fill="none"
+        stroke={usedColor}
+        strokeLinecap="square"
+        strokeMiterlimit="10"
+        strokeWidth="32"
+        d="M160 344H352H376"
+      />
+      <Path
+        fill={usedColor}
+        stroke={usedColor}
+        d="M438.334 215.13H463.5V359.5H432.5V258.919V257.929L431.703 258.516L396.715 284.301L378.299 259.336L438.334 215.13Z"
+      />
+    </Svg>
+  );
+}

--- a/mobile/src/icons/index.ts
+++ b/mobile/src/icons/index.ts
@@ -21,6 +21,7 @@ export { PlaylistAdd } from "./PlaylistAdd";
 export { QueueMusic } from "./QueueMusic";
 export { Remove } from "./Remove";
 export { Repeat } from "./Repeat";
+export { RepeatOne } from "./RepeatOne";
 export { Schedule } from "./Schedule";
 export { Search } from "./Search";
 export { Settings } from "./Settings";

--- a/mobile/src/modules/i18n/CHANGELOG.md
+++ b/mobile/src/modules/i18n/CHANGELOG.md
@@ -5,6 +5,10 @@ This file will document any changes made to the master translation file (`en.jso
 > [!NOTE]  
 > Any missing translations will fallback to the values in `en.json`.
 
+## December 27, 2024
+
+- Add `common.repeatOne` key (used as an accessibility label).
+
 ## December 19, 2024
 
 - Add `common.favoriteTracks` key.

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -19,6 +19,7 @@
     "next": "Next",
     "shuffle": "Shuffle",
     "repeat": "Repeat",
+    "repeatOne": "Repeat One",
 
     "favorite": "Favorite",
     "unFavorite": "Unfavorite",

--- a/mobile/src/modules/media/components/MediaControls.tsx
+++ b/mobile/src/modules/media/components/MediaControls.tsx
@@ -4,6 +4,7 @@ import {
   Pause,
   PlayArrow,
   Repeat,
+  RepeatOne,
   Shuffle,
   SkipNext,
   SkipPrevious,
@@ -20,17 +21,25 @@ type MediaControlProps = { size?: number };
 /** Toggles the repeat status. */
 export function RepeatButton({ size = 32 }: MediaControlProps) {
   const { t } = useTranslation();
-  const isActive = useMusicStore((state) => state.repeat);
-  const setRepeat = useMusicStore((state) => state.setRepeat);
+  const repeatMode = useMusicStore((state) => state.repeat);
+  const cycleRepeat = useMusicStore((state) => state.cycleRepeat);
+
+  const RepeatIcon = repeatMode === "repeat-one" ? RepeatOne : Repeat;
+
   return (
     <IconButton
       kind="ripple"
-      accessibilityLabel={t("common.repeat")}
-      onPress={() => setRepeat(!isActive)}
+      accessibilityLabel={t(
+        `common.repeat${repeatMode === "repeat-one" ? "One" : ""}`,
+      )}
+      onPress={cycleRepeat}
       rippleRadius={size * 0.75}
       className="p-2"
     >
-      <Repeat size={size} {...(isActive ? { color: Colors.red } : {})} />
+      <RepeatIcon
+        size={size}
+        {...(repeatMode !== "no-repeat" ? { color: Colors.red } : {})}
+      />
     </IconButton>
   );
 }

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -385,17 +385,13 @@ export class RNTPManager {
     const nextTrack = RNTPManager.getNextTrack();
     await TrackPlayer.removeUpcomingTracks();
     // If the next track is `undefined`, then we should run `reset()`
-    // after the current track finishes.
-    if (!nextTrack.activeId || !nextTrack.activeTrack) {
+    // after the current track finishes. If we're in "repeat-one" mode,
+    // then we'll repeat the current track.
+    if (repeat === "repeat-one" || !nextTrack.activeTrack) {
       await TrackPlayer.add({
         ...formatTrackforPlayer(currTrack),
-        // Field read in `PlaybackActiveTrackChanged` event to fire `reset()`.
-        "music::status": "END" satisfies TrackStatus,
-      });
-    } else if (repeat === "repeat-one") {
-      await TrackPlayer.add({
-        ...formatTrackforPlayer(currTrack),
-        "music::status": "REPEAT" satisfies TrackStatus,
+        "music::status":
+          repeat === "repeat-one" ? "REPEAT" : ("END" satisfies TrackStatus),
       });
     } else {
       await TrackPlayer.add({

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -17,6 +17,9 @@ import {
 } from "../helpers/data";
 import type { PlayListSource } from "../types";
 
+/** Options for repeat status. */
+export const RepeatModes = ["no-repeat", "repeat", "repeat-one"] as const;
+
 //#region Store
 interface MusicStore {
   /** Determines if the store has been hydrated from AsyncStorage. */
@@ -29,13 +32,10 @@ interface MusicStore {
   /** If we're currently playing a track. */
   isPlaying: boolean;
 
-  /**
-   * If we should continue playing from the beginning of the queue after
-   * finishing the last track.
-   */
-  repeat: boolean;
-  /** Update the `repeat` field. */
-  setRepeat: (status: boolean) => void;
+  /** Behavior of how we'll loop in this list of tracks. */
+  repeat: (typeof RepeatModes)[number];
+  /** Switch to the next repeat mode. */
+  cycleRepeat: () => void;
   /**
    * If we should use `shuffledPlayingList` instead of `playingList` for
    * the order of the tracks played.
@@ -117,8 +117,14 @@ export const musicStore = createPersistedSubscribedStore<MusicStore>(
 
     isPlaying: false as boolean,
 
-    repeat: false as boolean,
-    setRepeat: (status) => set({ repeat: status }),
+    repeat: "no-repeat",
+    cycleRepeat: () => {
+      const { repeat } = get();
+      let newMode: MusicStore["repeat"] = "repeat";
+      if (repeat === "repeat") newMode = "repeat-one";
+      else if (repeat === "repeat-one") newMode = "no-repeat";
+      set({ repeat: newMode });
+    },
     shuffle: false as boolean,
     setShuffle: async (status) => {
       const { currentTrackList, listIdx, trackList, shuffledTrackList } = get();

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -388,10 +388,10 @@ export class RNTPManager {
     // after the current track finishes. If we're in "repeat-one" mode,
     // then we'll repeat the current track.
     if (repeat === "repeat-one" || !nextTrack.activeTrack) {
+      const status: TrackStatus = repeat === "repeat-one" ? "REPEAT" : "END";
       await TrackPlayer.add({
         ...formatTrackforPlayer(currTrack),
-        "music::status":
-          repeat === "repeat-one" ? "REPEAT" : ("END" satisfies TrackStatus),
+        "music::status": status,
       });
     } else {
       await TrackPlayer.add({

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -31,9 +31,10 @@ export default function TrackUpcomingSheet() {
     ...trackList.slice(0, listIndex + 1),
   ];
   // Index where the tracks won't be played.
-  const disableIndex = repeat
-    ? trackList.length + queueList.length
-    : trackList.length - 1 - listIndex + queueList.length;
+  const disableIndex =
+    repeat !== "no-repeat"
+      ? trackList.length + queueList.length
+      : trackList.length - 1 - listIndex + queueList.length;
 
   return (
     <Sheet

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -73,7 +73,7 @@ export async function PlaybackService() {
       } else {
         musicStore.setState({ isInQueue: true });
       }
-    } else if (trackStatus === undefined) {
+    } else if (repeat !== "repeat-one" && trackStatus === undefined) {
       // If `trackStatus = undefined`, it means the player naturally played
       // the next track (which isn't part of `queueList`).
 
@@ -83,7 +83,7 @@ export async function PlaybackService() {
       musicStore.setState(nextTrack);
 
       // Check if we should pause after looping logic.
-      if (nextTrack.listIdx === 0 && !repeat) {
+      if (nextTrack.listIdx === 0 && repeat === "no-repeat") {
         await MusicControls.pause();
         await TrackPlayer.seekTo(0);
       }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This enables the ability to repeat the current playing track.
- Created custom SVG to represent the "Repeat One" button based on ionicon's "Repeat" and "Calendar Number" icons (sharp variants).
- We've added a `common.repeatOne` translation key that's used for the accessibility label for the button.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The functionality is what I've briefly observed with Spotify's implementation:

- [x] If we explicitly hit the "next" button, we play the next track and the repeat mode goes to `"repeat"` from `"repeat-one"`.
  - [x] The same is applied to when we hit the "prev" button unless we've played more than 10 seconds.
- [x] When the current playing track naturally finishes, it'll play back from the beginning.
  - [x] This works for tracks in the queue as well.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
