### PR TITLE
perf: Optimized SQL queries for indexing logic

### DIFF
--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -13,7 +13,7 @@ import { onboardingStore } from "../services/Onboarding";
 import { ImageDirectory, deleteImage, saveImage } from "@/lib/file-system";
 import { clearAllQueries } from "@/lib/react-query";
 import { Stopwatch } from "@/utils/debug";
-import { batch } from "@/utils/promise";
+import { BATCH_PRESETS, batch } from "@/utils/promise";
 
 //#region Saving Function
 /** Save artwork for albums & tracks. */
@@ -65,9 +65,9 @@ export async function findAndSaveArtwork() {
     );
     // Prevent excessive `setState` on Zustand store which may cause an
     // "Warning: Maximum update depth exceeded.".
-    prevRemainder = checkedFiles % 25;
+    prevRemainder = checkedFiles % BATCH_PRESETS.PROGRESS;
     checkedFiles += values.length;
-    if (checkedFiles % 25 < prevRemainder) {
+    if (checkedFiles % BATCH_PRESETS.PROGRESS < prevRemainder) {
       onboardingStore.setState({ checked: checkedFiles });
     }
   }
@@ -82,7 +82,7 @@ export async function findAndSaveArtwork() {
     {
       onEndIteration: () => {
         checkedFiles++;
-        if (checkedFiles % 25 === 0) {
+        if (checkedFiles % BATCH_PRESETS.PROGRESS === 0) {
           onboardingStore.setState({ checked: checkedFiles });
         }
       },

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -97,11 +97,8 @@ export async function findAndSaveAudio() {
     // The logic below makes sure that if the file has the same id and is
     // detected in 2 different locations, we make sure the track is marked
     // as being "modified".
-    if (isDifferentUri && unmodifiedTracks.has(id)) {
-      unmodifiedTracks.delete(id);
-    } else if (!isDifferentUri && modifiedTracks.has(id)) {
-      isDifferentUri = true;
-    }
+    if (isDifferentUri && unmodifiedTracks.has(id)) unmodifiedTracks.delete(id);
+    else if (!isDifferentUri && modifiedTracks.has(id)) isDifferentUri = true;
 
     // Retry indexing if modification time or uri is different.
     if (modificationTime !== lastModified || isDifferentUri) {

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -12,7 +12,7 @@ import { Resynchronize } from "@/modules/media/services/Resynchronize";
 
 import { ToastOptions } from "@/lib/toast";
 import { batch, wait } from "@/utils/promise";
-import { findAndSaveArtwork, cleanupImages } from "../helpers/artwork";
+import { findAndSaveArtwork, cleanupImages } from "./artwork";
 import { cleanupDatabase, findAndSaveAudio } from "./audio";
 import { savePathComponents } from "./folder";
 

--- a/mobile/src/utils/promise.ts
+++ b/mobile/src/utils/promise.ts
@@ -44,8 +44,8 @@ export async function batch<TData, TResult>({
    * results of `Promise.allSettled()`.
    */
   onBatchComplete?: (
-    fulfilled: Array<PromiseSettledResult<TResult>>,
-    rejected: PromiseRejectedResult[],
+    fulfilled: TResult[],
+    rejected: any[],
   ) => Promise<void> | void;
 }) {
   for (let i = 0; i < data.length; i += batchAmount) {
@@ -56,7 +56,10 @@ export async function batch<TData, TResult>({
         .map(callback),
     );
     if (onBatchComplete) {
-      await onBatchComplete(res.filter(isFulfilled), res.filter(isRejected));
+      await onBatchComplete(
+        res.filter(isFulfilled).map(({ value }) => value),
+        res.filter(isRejected).map(({ reason }) => reason),
+      );
     }
   }
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Around a week ago, we applied some SQL optimizations to the import feature where we did bulk insertion of values instead of inserting an entry one-by-one in a loop. From that experiment, we saw a decent improvement in the time it takes from reading the file to the saving those values in the database (we went from ~2.7s to ~1.3s). One of the places this idea can also be applied to is the indexing logic, or the logic which is run to find and save the metadata of the various tracks found on the device.

Some observations from applying these optimizations include:
- A ~2.4s reduction (~9.6s to ~7.2s) in the time it takes to save the 25 artwork/covers found from the 238 tracks available in **development** mode.
- We saw no impactful improvement from optimization tests for the main indexing (getting the metadata excluding the artwork and saving those values into the database).
  - For my 238 tracks, in **development** mode, it takes around ~11s to finish this task. Around ~10s is used exclusively for getting the metadata of all the tracks. So essentially, we have it pretty optimized already.
- As a test, since I never actually done this, I timed how long it takes for a fresh install in production to reach the home screen of the app (from the time we click the permissions to where we see the home screen).
  - It took ~19s in **development** mode and ~16.5s in **production** mode.

**Other Changes:**
- Removed the batching logic used in the function for removing albums and artists with no content.
- Fixed the type signature for `onBatchComplete` in our `batch()` function.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [ ] Add new dependencies into `THIRD_PARTY.md`.
- [x] This diff will work correctly for `pnpm android:prod`.
