### PR TITLE
feat: Add edge-to-edge support for dark mode navigation bar

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -39,6 +39,7 @@
 | react-native-actions-sheet | MIT | https://github.com/ammarahm-ed/react-native-actions-sheet |
 | react-native-bootsplash | MIT | https://github.com/zoontek/react-native-bootsplash |
 | react-native-draglist | MIT | https://github.com/fivecar/react-native-draglist |
+| react-native-edge-to-edge | MIT | https://github.com/zoontek/react-native-edge-to-edge |
 | react-native-gesture-handler | MIT | https://github.com/software-mansion/react-native-gesture-handler |
 | react-native-markdown-display | MIT | https://github.com/iamacup/react-native-markdown-display |
 | react-native-pager-view | MIT | https://github.com/callstack/react-native-pager-view |

--- a/mobile/android/app/src/main/res/values-night/colors.xml
+++ b/mobile/android/app/src/main/res/values-night/colors.xml
@@ -1,3 +1,5 @@
 <resources>
+  <color name="splashscreen_background">#000000</color>
+  <color name="activityBackground">#000000</color>
   <color name="bootsplash_background">#000000</color>
 </resources>

--- a/mobile/android/app/src/main/res/values/colors.xml
+++ b/mobile/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <resources>
-  <color name="splashscreen_background">#FFFFFF</color>
+  <color name="splashscreen_background">#F2F2F2</color>
   <color name="iconBackground">#000000</color>
-  <color name="colorPrimary">#023c69</color>
+  <color name="colorPrimary">#C8102E</color>
   <color name="activityBackground">#F2F2F2</color>
   <color name="bootsplash_background">#f2f2f2</color>
 </resources>

--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="android:windowBackground">@color/activityBackground</item>
-    <item name="enforceNavigationBarContrast">true</item>
+    <item name="enforceNavigationBarContrast">false</item>
   </style>
   <style name="ResetEditText" parent="@android:style/Widget.EditText">
     <item name="android:padding">0dp</item>

--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -1,10 +1,11 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+  <style name="AppTheme" parent="Theme.EdgeToEdge">
     <item name="android:textColor">@android:color/black</item>
     <item name="android:editTextStyle">@style/ResetEditText</item>
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="android:windowBackground">@color/activityBackground</item>
+    <item name="enforceNavigationBarContrast">true</item>
   </style>
   <style name="ResetEditText" parent="@android:style/Widget.EditText">
     <item name="android:padding">0dp</item>

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -51,6 +51,7 @@ export default (): ExpoConfig => ({
         android: { parentTheme: "EdgeToEdge" },
       },
     ],
+    "react-native-edge-to-edge",
   ],
   experiments: {
     typedRoutes: true,

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -8,6 +8,7 @@ export default (): ExpoConfig => ({
   platforms: ["android"],
   githubUrl: "https://github.com/MissingCore/Music",
   orientation: "portrait",
+  primaryColor: "#C8102E",
   icon: "./assets/icon.png",
   scheme: "music",
   backgroundColor: "#F2F2F2",
@@ -51,7 +52,10 @@ export default (): ExpoConfig => ({
         android: { parentTheme: "EdgeToEdge" },
       },
     ],
-    "react-native-edge-to-edge",
+    [
+      "react-native-edge-to-edge",
+      { android: { enforceNavigationBarContrast: false } },
+    ],
   ],
   experiments: {
     typedRoutes: true,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -59,6 +59,7 @@
     "react-native-actions-sheet": "^0.9.7",
     "react-native-bootsplash": "^6.3.2",
     "react-native-draglist": "github:MissingCore/react-native-draglist#30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71",
+    "react-native-edge-to-edge": "^1.3.1",
     "react-native-gesture-handler": "~2.21.2",
     "react-native-markdown-display": "^7.0.2",
     "react-native-pager-view": "^6.6.1",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       react-native-draglist:
         specifier: github:MissingCore/react-native-draglist#30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71
         version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
+      react-native-edge-to-edge:
+        specifier: ^1.3.1
+        version: 1.3.1(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-gesture-handler:
         specifier: ~2.21.2
         version: 2.21.2(patch_hash=bh4ckg75hvy7pf4jc45bgdz2jy)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
@@ -4181,48 +4184,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.22.0:
     resolution: {integrity: sha512-AArGtKSY4DGTA8xP8SDyNyKtpsUl1Rzq6FW4JomeyUQ4nBrR71uPChksTpj3gmWuGhZeRKLeCUI1DBid/zhChg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.19.0:
     resolution: {integrity: sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.22.0:
     resolution: {integrity: sha512-RRraNgP8hnBPhInTTUdlFm+z16C/ghbxBG51Sw00hd7HUyKmEUKRozyc5od+/N6pOrX/bIh5vIbtMXIxsos0lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.19.0:
     resolution: {integrity: sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.22.0:
     resolution: {integrity: sha512-grdrhYGRi2KrR+bsXJVI0myRADqyA7ekprGxiuK5QRNkv7kj3Yq1fERDNyzZvjisHwKUi29sYMClscbtl+/Zpw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.19.0:
     resolution: {integrity: sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.22.0:
     resolution: {integrity: sha512-t5f90X+iQUtIyR56oXIHMBUyQFX/zwmPt72E6Dane3P8KNGlkijTg2I75XVQS860gNoEFzV7Mm5ArRRA7u5CAQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.19.0:
     resolution: {integrity: sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==}
@@ -5186,6 +5197,12 @@ packages:
       '@shopify/flash-list': '*'
       react: '>=17.0.1'
       react-native: '>=0.64.0'
+
+  react-native-edge-to-edge@1.3.1:
+    resolution: {integrity: sha512-zJF5LyRgXY2Rery/BTMVzlwysVztTKJeyocidIuGt+LbWznMps+QtBSru4sZGoC9Yfs7SEvukZoZVz7/+j6Xtw==}
+    peerDependencies:
+      react: '>=18.2.0'
+      react-native: '>=0.74.0'
 
   react-native-fit-image@1.5.5:
     resolution: {integrity: sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==}
@@ -12258,6 +12275,11 @@ snapshots:
   react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
     dependencies:
       '@shopify/flash-list': 1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
+      react: 18.3.1
+      react-native: 0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3)
+
+  react-native-edge-to-edge@1.3.1(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
+    dependencies:
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3)
 

--- a/mobile/src/app/setting/third-party/[id].tsx
+++ b/mobile/src/app/setting/third-party/[id].tsx
@@ -4,10 +4,10 @@ import { useTranslation } from "react-i18next";
 
 import { OpenInNew } from "@/icons/OpenInNew";
 import LicensesList from "@/resources/licenses.json";
+import { StandardScrollLayout } from "@/layouts/StandardScroll";
 import { StickyActionHeader } from "@/layouts/StickyActionScroll";
 
 import { Card } from "@/components/Containment/Card";
-import { ScrollView } from "@/components/Defaults";
 import { IconButton } from "@/components/Form/Button";
 import { StyledText } from "@/components/Typography/StyledText";
 
@@ -35,7 +35,7 @@ export default function PackageLicenseScreen() {
           ),
         }}
       />
-      <ScrollView contentContainerClassName="grow gap-6 p-4 pt-2">
+      <StandardScrollLayout contentContainerClassName="pt-2">
         <StickyActionHeader noOffset originalText>
           {licenseInfo.name}
         </StickyActionHeader>
@@ -48,7 +48,7 @@ export default function PackageLicenseScreen() {
           </StyledText>
         </Card>
         <StyledText dim>{licenseInfo.licenseText}</StyledText>
-      </ScrollView>
+      </StandardScrollLayout>
     </>
   );
 }

--- a/mobile/src/app/setting/update.tsx
+++ b/mobile/src/app/setting/update.tsx
@@ -7,12 +7,12 @@ import { LogoPlayStore } from "@/icons/LogoPlayStore";
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 import { useHasNewUpdate } from "@/hooks/useHasNewUpdate";
 import { useTheme } from "@/hooks/useTheme";
+import { StandardScrollLayout } from "@/layouts/StandardScroll";
 import { StickyActionHeader } from "@/layouts/StickyActionScroll";
 
 import * as LINKS from "@/constants/Links";
 import { FontFamily, FontSize } from "@/constants/Styles";
 import { getAccentFont } from "@/lib/style";
-import { ScrollView } from "@/components/Defaults";
 import { Button } from "@/components/Form/Button";
 import { TStyledText } from "@/components/Typography/StyledText";
 
@@ -25,7 +25,7 @@ export default function AppUpdateScreen() {
   if (!release) return null;
 
   return (
-    <ScrollView contentContainerClassName="grow gap-6 p-4">
+    <StandardScrollLayout>
       <StickyActionHeader noOffset originalText>
         {release.version}
       </StickyActionHeader>
@@ -119,6 +119,6 @@ export default function AppUpdateScreen() {
           </Button>
         ) : null}
       </View>
-    </ScrollView>
+    </StandardScrollLayout>
   );
 }

--- a/mobile/src/components/Sheet.tsx
+++ b/mobile/src/components/Sheet.tsx
@@ -49,8 +49,12 @@ export function Sheet({
       //  - Note 1: We've patched the package as it only relies on the top
       //  insets for IOS
       //  - Note 2: The recommended way is to set a `maxHeight`, but that doesn't
-      //  work as mentioned: https://github.com/ammarahm-ed/react-native-actions-sheet/issues/322#issuecomment-2029560154
-      safeAreaInsets={{ ...insets, top: insets.top + 56 }}
+      //  work as mentioned:
+      //    - https://github.com/ammarahm-ed/react-native-actions-sheet/issues/322#issuecomment-2029560154
+      //  - Note 3: With edge-to-edge mode, having the `bottom` was adding
+      //  extra bottom padding. This might be related to:
+      //    - https://github.com/facebook/react-native/pull/47254
+      safeAreaInsets={{ ...insets, top: insets.top + 56, bottom: 0 }}
       {...props}
     >
       <View

--- a/mobile/src/layouts/Issue.tsx
+++ b/mobile/src/layouts/Issue.tsx
@@ -8,6 +8,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { GITHUB } from "@/constants/Links";
+import { ScrollPresets } from "@/components/Defaults";
 import { Button } from "@/components/Form/Button";
 import { AccentText } from "@/components/Typography/AccentText";
 import { TStyledText } from "@/components/Typography/StyledText";
@@ -29,7 +30,10 @@ export function IssueLayout(props: {
 
   return (
     <>
-      <Animated.ScrollView contentContainerClassName="grow gap-6 p-4">
+      <Animated.ScrollView
+        contentContainerClassName="grow gap-6 p-4"
+        {...ScrollPresets}
+      >
         <AccentText style={{ paddingTop: top + 16 }} className="text-4xl">
           {t(`errorScreen.${props.issueType}`)}
         </AccentText>

--- a/mobile/src/layouts/StandardScroll.tsx
+++ b/mobile/src/layouts/StandardScroll.tsx
@@ -1,9 +1,18 @@
+import { cn } from "@/lib/style";
 import { ScrollView } from "@/components/Defaults";
 
 /** Simple scroll container layout. */
-export function StandardScrollLayout(props: { children: React.ReactNode }) {
+export function StandardScrollLayout(props: {
+  children: React.ReactNode;
+  contentContainerClassName?: string;
+}) {
   return (
-    <ScrollView contentContainerClassName="grow gap-6 p-4">
+    <ScrollView
+      contentContainerClassName={cn(
+        "grow gap-6 p-4",
+        props.contentContainerClassName,
+      )}
+    >
       {props.children}
     </ScrollView>
   );

--- a/mobile/src/modules/i18n/translations/zh-Hans.json
+++ b/mobile/src/modules/i18n/translations/zh-Hans.json
@@ -37,7 +37,7 @@
     "appearance": "外观",
     "insights": "使用统计",
     "saveErrors": "保存错误",
-    "scanning": "扫描中",
+    "scanning": "扫描",
     "thirdParty": "第三方软件"
   },
   "title": {
@@ -47,10 +47,10 @@
     "theme": "主题",
     "listAllow": "允许列表",
     "listBlock": "阻止列表",
-    "ignoreDuration": "忽略短音频",
+    "ignoreDuration": "忽略较短的音频",
     "sort": "排序方式",
     "musicAdd": "添加音乐",
-    "upcoming": "即将推出"
+    "upcoming": "即将播放"
   },
 
   "playlist": {
@@ -100,7 +100,7 @@
     },
 
     "related": {
-      "appDownload": "下载最新 APK",
+      "appDownload": "下载最新版本的 APK",
       "appUpdate": "从 Play Store 更新",
 
       "light": "浅色",

--- a/mobile/src/providers/ThemeProvider.tsx
+++ b/mobile/src/providers/ThemeProvider.tsx
@@ -3,7 +3,6 @@ import { ThemeProvider as NavigationThemeProvider } from "@react-navigation/nati
 import { vars } from "nativewind";
 import { View, useColorScheme } from "react-native";
 import { SystemBars } from "react-native-edge-to-edge";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 
@@ -30,7 +29,6 @@ const Themes = {
  * text color and the React Navigation theme colors.
  */
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const { bottom } = useSafeAreaInsets();
   const deviceTheme = useColorScheme();
   const savedTheme = useUserPreferencesStore((state) => state.theme);
 
@@ -43,10 +41,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       value={currentTheme === "light" ? LightNavTheme : DarkNavTheme}
     >
       <SystemBars style={{ statusBar: iconColor, navigationBar: iconColor }} />
-      <View
-        style={[Themes[currentTheme], { paddingBottom: bottom }]}
-        className="flex-1 bg-canvas"
-      >
+      <View style={Themes[currentTheme]} className="flex-1 bg-canvas">
         {children}
       </View>
     </NavigationThemeProvider>

--- a/mobile/src/providers/ThemeProvider.tsx
+++ b/mobile/src/providers/ThemeProvider.tsx
@@ -30,6 +30,7 @@ const Themes = {
  * text color and the React Navigation theme colors.
  */
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const { bottom } = useSafeAreaInsets();
   const deviceTheme = useColorScheme();
   const savedTheme = useUserPreferencesStore((state) => state.theme);
 
@@ -37,7 +38,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     savedTheme === "system" ? (deviceTheme ?? "light") : savedTheme;
   const iconColor = currentTheme === "light" ? "dark" : "light";
 
-  const { bottom } = useSafeAreaInsets();
   return (
     <NavigationThemeProvider
       value={currentTheme === "light" ? LightNavTheme : DarkNavTheme}

--- a/mobile/src/providers/ThemeProvider.tsx
+++ b/mobile/src/providers/ThemeProvider.tsx
@@ -1,7 +1,8 @@
 import type { Theme } from "@react-navigation/native";
 import { ThemeProvider as NavigationThemeProvider } from "@react-navigation/native";
 import { vars } from "nativewind";
-import { StatusBar, View, useColorScheme } from "react-native";
+import { View, useColorScheme } from "react-native";
+import { SystemBars } from "react-native-edge-to-edge";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useUserPreferencesStore } from "@/services/UserPreferences";
@@ -34,15 +35,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   const currentTheme =
     savedTheme === "system" ? (deviceTheme ?? "light") : savedTheme;
+  const iconColor = currentTheme === "light" ? "dark" : "light";
 
   const { bottom } = useSafeAreaInsets();
   return (
     <NavigationThemeProvider
       value={currentTheme === "light" ? LightNavTheme : DarkNavTheme}
     >
-      <StatusBar
-        barStyle={currentTheme === "light" ? "dark-content" : "light-content"}
-      />
+      <SystemBars style={{ statusBar: iconColor, navigationBar: iconColor }} />
       <View
         style={[Themes[currentTheme], { paddingBottom: bottom }]}
         className="flex-1 bg-canvas"

--- a/mobile/src/providers/ThemeProvider.tsx
+++ b/mobile/src/providers/ThemeProvider.tsx
@@ -2,6 +2,7 @@ import type { Theme } from "@react-navigation/native";
 import { ThemeProvider as NavigationThemeProvider } from "@react-navigation/native";
 import { vars } from "nativewind";
 import { StatusBar, View, useColorScheme } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 
@@ -34,6 +35,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const currentTheme =
     savedTheme === "system" ? (deviceTheme ?? "light") : savedTheme;
 
+  const { bottom } = useSafeAreaInsets();
   return (
     <NavigationThemeProvider
       value={currentTheme === "light" ? LightNavTheme : DarkNavTheme}
@@ -41,7 +43,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       <StatusBar
         barStyle={currentTheme === "light" ? "dark-content" : "light-content"}
       />
-      <View style={Themes[currentTheme]} className="flex-1 bg-canvas">
+      <View
+        style={[Themes[currentTheme], { paddingBottom: bottom }]}
+        className="flex-1 bg-canvas"
+      >
         {children}
       </View>
     </NavigationThemeProvider>

--- a/mobile/src/providers/index.tsx
+++ b/mobile/src/providers/index.tsx
@@ -1,7 +1,9 @@
 import { Toasts } from "@backpackapp-io/react-native-toast";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { View } from "react-native";
 import { SheetProvider } from "react-native-actions-sheet";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import "@/screens/Sheets";
 import { RouteHandlers } from "./RouteHandlers";
@@ -10,7 +12,7 @@ import { ThemeProvider } from "./ThemeProvider";
 import { queryClient } from "@/lib/react-query";
 
 /** All providers used by the app. */
-export function AppProvider({ children }: { children: React.ReactNode }) {
+export function AppProvider(props: { children: React.ReactNode }) {
   // NOTE: `expo-router` automatically adds `<SafeAreaProvider />`
   //  - https://docs.expo.dev/router/migrate/from-react-navigation/#delete-unused-or-managed-code
   return (
@@ -19,11 +21,18 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         <QueryClientProvider client={queryClient}>
           <RouteHandlers />
           <SheetProvider context="global">
-            {children}
+            <ChildrenWrapper {...props} />
             <Toasts />
           </SheetProvider>
         </QueryClientProvider>
       </GestureHandlerRootView>
     </ThemeProvider>
+  );
+}
+
+function ChildrenWrapper(props: { children: React.ReactNode }) {
+  const { bottom } = useSafeAreaInsets();
+  return (
+    <View style={{ paddingBottom: bottom }} className="flex-1" {...props} />
   );
 }

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -311,6 +311,14 @@
     "license": "MIT",
     "licenseText": "MIT License\n\nCopyright (c) 2022 fivecar\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
+  "react-native-edge-to-edge": {
+    "name": "react-native-edge-to-edge",
+    "version": "1.3.1",
+    "copyright": "Copyright (c) 2024 Mathieu Acthernoene",
+    "source": "https://github.com/zoontek/react-native-edge-to-edge",
+    "license": "MIT",
+    "licenseText": "MIT License\n\nCopyright (c) 2024 Mathieu Acthernoene\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+  },
   "react-native-gesture-handler": {
     "name": "react-native-gesture-handler",
     "version": "2.21.2",


### PR DESCRIPTION
# Why

- Integrated react-native-edge-to-edge to enable edge-to-edge layout, ensuring a fully immersive experience
- Refined and optimized some Simplified Chinese translations for better clarity and consistency

<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td>
<img src="https://github.com/user-attachments/assets/27876432-b82c-4dcd-a55d-2c5c526474fd"   alt="Before" width="300"  >
</td>
    <td>
<img src="https://github.com/user-attachments/assets/c971cbd5-d20d-4e78-9f79-c67b73f5b31e" alt="After" width="300"></td>
  </tr>
</table>




<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [ ] This diff will work correctly for `pnpm android:prod`.
