### PR TITLE
feat: Updated vinyl design (Part 1)

### DIFF
--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -70,7 +70,7 @@ function RootLayoutNav() {
       <Stack screenOptions={{ header: TopAppBar, headerShown: false }}>
         <Stack.Screen name="(main)" />
         <Stack.Screen
-          name="current-track"
+          name="now-playing"
           options={{
             animation: "slide_from_bottom",
             header: TopAppBarMarquee,

--- a/mobile/src/app/current-track.tsx
+++ b/mobile/src/app/current-track.tsx
@@ -30,6 +30,7 @@ import {
   ShuffleButton,
 } from "@/modules/media/components/MediaControls";
 import { MediaImage } from "@/modules/media/components/MediaImage";
+import { Vinyl } from "@/modules/media/components/Vinyl";
 
 /** Screen for `/current-track` route. */
 export default function CurrentTrackScreen() {
@@ -90,8 +91,11 @@ function Artwork(props: { artwork: string | null }) {
       className="flex-1 items-center pt-8"
     >
       {maxImageHeight !== undefined && (
-        <MediaImage type="track" source={props.artwork} size={maxImageHeight} />
+        <Vinyl source={props.artwork} size={maxImageHeight} />
       )}
+      {/* {maxImageHeight !== undefined && (
+        <MediaImage type="track" source={props.artwork} size={maxImageHeight} />
+      )} */}
     </View>
   );
 }

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -32,8 +32,8 @@ import {
 import { MediaImage } from "@/modules/media/components/MediaImage";
 import { Vinyl } from "@/modules/media/components/Vinyl";
 
-/** Screen for `/current-track` route. */
-export default function CurrentTrackScreen() {
+/** Screen for `/now-playing` route. */
+export default function NowPlayingScreen() {
   const { t } = useTranslation();
   const track = useMusicStore((state) => state.activeTrack);
   const listName = useMusicStore((state) => state.sourceName);

--- a/mobile/src/hooks/useBottomActionsContext.ts
+++ b/mobile/src/hooks/useBottomActionsContext.ts
@@ -15,7 +15,7 @@ const hideNavRoutes = [
   "/album/",
   "/artist/",
   "/playlist/",
-  "/current-track",
+  "/now-playing",
 ] satisfies Partial<Href[]>;
 
 /**

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -1,9 +1,20 @@
 import { Link } from "expo-router";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
+import Animated, {
+  Easing,
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
 
 import { Schedule } from "@/icons/Schedule";
+import { useMusicStore } from "@/modules/media/services/Music";
 import { useTheme } from "@/hooks/useTheme";
 
 import { pickKeys } from "@/utils/object";
@@ -14,25 +25,24 @@ import { StyledText, TEm } from "@/components/Typography/StyledText";
 import { ReservedPlaylists } from "@/modules/media/constants";
 import { MediaImage } from "@/modules/media/components/MediaImage";
 import { MediaListControls } from "@/modules/media/components/MediaListControls";
+import { arePlaybackSourceEqual } from "@/modules/media/helpers/data";
 import { Vinyl } from "@/modules/media/components/Vinyl";
-import type { MediaType, PlayListSource } from "@/modules/media/types";
 
+type SupportedMedia = "album" | "artist" | "playlist";
+type MediaListSource = { type: SupportedMedia; id: string };
 type ImageSource = MediaImage.ImageSource | Array<string | null>;
 
-/** List of media that we can change artwork for. */
-const SupportedArtwork = new Set<MediaType>(["artist", "playlist"]);
-
 /** Layout for displaying a list of tracks for the specified media. */
-export function CurrentListLayout(props: {
-  title: string;
-  /** If we want to have a link to the artist underneath the title. */
-  artist?: string;
-  /** Strings describing the media (last string indicates total playtime). */
-  metadata: string[];
-  imageSource: ImageSource;
-  mediaSource: PlayListSource;
-  children: React.ReactNode;
-}) {
+export function CurrentListLayout(
+  props: {
+    title: string;
+    /** If we want to have a link to the artist underneath the title. */
+    artist?: string;
+    /** Strings describing the media (last string indicates total playtime). */
+    metadata: string[];
+    children: React.ReactNode;
+  } & AnimatedVinylProps,
+) {
   const { t } = useTranslation();
   const { canvas, foreground } = useTheme();
 
@@ -40,7 +50,7 @@ export function CurrentListLayout(props: {
 
   return (
     <>
-      <View className="flex-row gap-2 px-4">
+      <View className="flex-row gap-2 pr-4">
         <ContentImage
           {...pickKeys(props, ["title", "mediaSource", "imageSource"])}
         />
@@ -90,20 +100,16 @@ export function CurrentListLayout(props: {
 }
 
 /** Determines the look and features of the image displayed. */
-function ContentImage(props: {
-  title: string;
-  mediaSource: PlayListSource;
-  imageSource: ImageSource;
-}) {
+function ContentImage({
+  title,
+  ...props
+}: { title: string } & AnimatedVinylProps) {
   const { t } = useTranslation();
 
   const type = props.mediaSource.type;
-  const renderMediaImage =
-    getIsFavoritePlaylist(props.title, type) || !SupportedArtwork.has(type);
 
-  if (renderMediaImage) {
-    return <RenderImage type={type} source={props.imageSource} />;
-  }
+  if (getIsFavoritePlaylist(title, type) || type === "album")
+    return <AnimatedVinyl {...props} />;
 
   return (
     <Pressable
@@ -111,35 +117,92 @@ function ContentImage(props: {
       delayLongPress={100}
       onLongPress={() => {
         SheetManager.show(`${capitalize(type)}ArtworkSheet`, {
-          payload: { id: props.title },
+          payload: { id: title },
         });
       }}
-      className="active:opacity-75"
+      className="group"
     >
-      <RenderImage
-        type={type}
-        source={props.imageSource}
-        asImage={type === "artist"}
-      />
+      {type === "artist" ? (
+        <MediaImage
+          type="artist"
+          source={props.imageSource as string | null}
+          size={128}
+          className="ml-4 group-active:opacity-75"
+        />
+      ) : (
+        <AnimatedVinyl {...props} />
+      )}
     </Pressable>
   );
 }
 
-function RenderImage(props: {
-  type: MediaType;
-  source: ImageSource;
-  asImage?: boolean;
-}) {
-  if (props.asImage) {
-    return (
-      /* @ts-expect-error Things should be fine with proper usage. */
-      <MediaImage type={props.type} source={props.source} size={128} />
-    );
-  }
-  return <Vinyl source={props.source} size={128} />;
+type AnimatedVinylProps = {
+  mediaSource: MediaListSource;
+  imageSource: ImageSource;
+};
+
+/** Have the vinyl spin if the playing media list is this source. */
+function AnimatedVinyl(props: AnimatedVinylProps) {
+  const isPlaying = useMusicStore((state) => state.isPlaying);
+  const playingSource = useMusicStore((state) => state.playingSource);
+  const coverPosition = useSharedValue(0);
+  const rotationProgress = useSharedValue(0);
+  const _discOpacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (isPlaying && arePlaybackSourceEqual(playingSource, props.mediaSource)) {
+      // `rotationProgress.value` becomes the new starting point when we
+      // cancel the animation (hence the `+ 360`).
+      rotationProgress.value = withRepeat(
+        withTiming(rotationProgress.value + 360, {
+          duration: 15000,
+          easing: Easing.linear,
+        }),
+        -1,
+        false,
+      );
+    } else {
+      cancelAnimation(rotationProgress);
+    }
+  }, [props.mediaSource, isPlaying, playingSource, rotationProgress]);
+
+  // Since the cover size is fixed, we know how much to translate.
+  const coverStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: coverPosition.value }],
+  }));
+
+  const diskStyle = useAnimatedStyle(() => ({
+    // The SVG flashes in on 1st mount, so the opacity is there to combat it.
+    opacity: _discOpacity.value,
+    transform: [{ rotate: `${rotationProgress.value}deg` }],
+  }));
+
+  return (
+    <Animated.View
+      onLayout={() => {
+        coverPosition.value = withDelay(50, withTiming(-64, { duration: 500 }));
+        _discOpacity.value = withTiming(1, { duration: 50 });
+      }}
+      className="ml-4"
+    >
+      <View className="group-active:opacity-75">
+        <Animated.View style={diskStyle}>
+          <Vinyl source={props.imageSource} size={128} />
+        </Animated.View>
+      </View>
+      <Animated.View style={coverStyle} className="absolute left-0 top-0 z-10">
+        {/* @ts-expect-error Things should be fine with proper usage. */}
+        <MediaImage
+          type={props.mediaSource.type}
+          source={props.imageSource}
+          size={128}
+        />
+      </Animated.View>
+    </Animated.View>
+  );
 }
 
 /** Determine if whether this layout is for the "Favorite Playlists" page. */
-function getIsFavoritePlaylist(title: string, type: MediaType) {
+function getIsFavoritePlaylist(title: string, type: SupportedMedia) {
   return title === ReservedPlaylists.favorites && type === "playlist";
 }

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -185,7 +185,7 @@ function AnimatedVinyl(props: AnimatedVinylProps) {
       }}
       className="ml-4"
     >
-      <View className="group-active:opacity-75">
+      <View needsOffscreenAlphaCompositing className="group-active:opacity-75">
         <Animated.View style={diskStyle}>
           <Vinyl source={props.imageSource} size={128} />
         </Animated.View>

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -155,7 +155,7 @@ function AnimatedVinyl(props: AnimatedVinylProps) {
       // cancel the animation (hence the `+ 360`).
       rotationProgress.value = withRepeat(
         withTiming(rotationProgress.value + 360, {
-          duration: 15000,
+          duration: 24000,
           easing: Easing.linear,
         }),
         -1,

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -25,8 +25,8 @@ import { StyledText, TEm } from "@/components/Typography/StyledText";
 import { ReservedPlaylists } from "@/modules/media/constants";
 import { MediaImage } from "@/modules/media/components/MediaImage";
 import { MediaListControls } from "@/modules/media/components/MediaListControls";
-import { arePlaybackSourceEqual } from "@/modules/media/helpers/data";
 import { Vinyl } from "@/modules/media/components/Vinyl";
+import { arePlaybackSourceEqual } from "@/modules/media/helpers/data";
 
 type SupportedMedia = "album" | "artist" | "playlist";
 type MediaListSource = { type: SupportedMedia; id: string };

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -30,7 +30,7 @@ import { Vinyl } from "@/modules/media/components/Vinyl";
 
 type SupportedMedia = "album" | "artist" | "playlist";
 type MediaListSource = { type: SupportedMedia; id: string };
-type ImageSource = MediaImage.ImageSource | Array<string | null>;
+type ImageSource = MediaImage.ImageSource | MediaImage.ImageSource[];
 
 /** Layout for displaying a list of tracks for the specified media. */
 export function CurrentListLayout(

--- a/mobile/src/modules/media/components/MiniPlayer.tsx
+++ b/mobile/src/modules/media/components/MiniPlayer.tsx
@@ -46,7 +46,12 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
         onPress={() => router.navigate("/now-playing")}
         className="flex-row items-center bg-surface p-2 active:opacity-75"
       >
-        <MediaImage type="track" radius="sm" size={48} source={track.artwork} />
+        <MediaImage
+          type="track"
+          size={48}
+          source={track.artwork}
+          className="rounded-sm"
+        />
 
         <View className="ml-2 shrink grow">
           <Marquee color={surface}>

--- a/mobile/src/modules/media/components/MiniPlayer.tsx
+++ b/mobile/src/modules/media/components/MiniPlayer.tsx
@@ -43,7 +43,7 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
       })}
     >
       <Pressable
-        onPress={() => router.navigate("/current-track")}
+        onPress={() => router.navigate("/now-playing")}
         className="flex-row items-center bg-surface p-2 active:opacity-75"
       >
         <MediaImage type="track" radius="sm" size={48} source={track.artwork} />

--- a/mobile/src/modules/media/components/Vinyl.tsx
+++ b/mobile/src/modules/media/components/Vinyl.tsx
@@ -1,5 +1,5 @@
 import type { CircleProps } from "react-native-svg";
-import Svg, { Circle, Rect } from "react-native-svg";
+import Svg, { Circle, ClipPath, Defs, G, Image, Rect } from "react-native-svg";
 
 import { useTheme } from "@/hooks/useTheme";
 
@@ -22,6 +22,11 @@ export function Vinyl(props: {
   const { canvas } = useTheme();
   return (
     <Svg width={props.size} height={props.size} viewBox="0 0 768 768">
+      <Defs>
+        <ClipPath id="round">
+          <Circle {...CENTER} r={192} />
+        </ClipPath>
+      </Defs>
       {/* Background */}
       <Circle {...CENTER} r={384} fill={Colors.neutral10} />
       {/* Grooves */}
@@ -30,6 +35,7 @@ export function Vinyl(props: {
       <Circle {...GROOVES} r={344} />
       {/* Artwork */}
       <Circle {...CENTER} r={192} fill={Colors.red} />
+      <RenderArtwork source={props.source} />
       {/* Spin Indicator */}
       <Rect x={384} y={193} width={2} height={24} fill="#FFF" />
       {/* Center hole */}
@@ -41,5 +47,44 @@ export function Vinyl(props: {
         strokeWidth={6}
       />
     </Svg>
+  );
+}
+
+/** Helper to render the artwork in the center of the vinyl. */
+function RenderArtwork(props: {
+  source: string | null | Array<string | null>;
+}) {
+  if (props.source === null) return null;
+  if (typeof props.source === "string")
+    return <SVGImg href={props.source} size={384} rounded />;
+  return (
+    <G clipPath="url(#round)">
+      {props.source.slice(0, 4).map((source, idx) => {
+        if (source === null) return null;
+        const extraX = idx % 2 === 1;
+        const extraY = idx % 4 > 1;
+        return (
+          <SVGImg key={idx} href={source} size={192} {...{ extraX, extraY }} />
+        );
+      })}
+    </G>
+  );
+}
+
+/** Special wrapper around SVG's `Image` component. */
+function SVGImg(
+  props: { size: number; href: string } & Partial<
+    Record<"extraX" | "extraY" | "rounded", boolean>
+  >,
+) {
+  return (
+    <Image
+      href={props.href}
+      x={props.extraX ? "50%" : "25%"}
+      y={props.extraY ? "50%" : "25%"}
+      {...{ width: props.size, height: props.size }}
+      preserveAspectRatio="xMidYMid slice" // "background-size: cover"
+      {...(props.rounded ? { clipPath: "url(#round)" } : {})}
+    />
   );
 }

--- a/mobile/src/modules/media/components/Vinyl.tsx
+++ b/mobile/src/modules/media/components/Vinyl.tsx
@@ -1,0 +1,45 @@
+import type { CircleProps } from "react-native-svg";
+import Svg, { Circle, Rect } from "react-native-svg";
+
+import { useTheme } from "@/hooks/useTheme";
+
+import { Colors } from "@/constants/Styles";
+
+const CENTER = { cx: 384, cy: 384 };
+const GROOVES = {
+  ...CENTER,
+  fill: "none",
+  stroke: "#FFF",
+  strokeWidth: 3,
+  opacity: 0.075,
+} satisfies CircleProps;
+
+/** Plain vinyl component. */
+export function Vinyl(props: {
+  size: number;
+  source: string | null | Array<string | null>;
+}) {
+  const { canvas } = useTheme();
+  return (
+    <Svg width={props.size} height={props.size} viewBox="0 0 768 768">
+      {/* Background */}
+      <Circle {...CENTER} r={384} fill={Colors.neutral10} />
+      {/* Grooves */}
+      <Circle {...GROOVES} r={264} />
+      <Circle {...GROOVES} r={304} />
+      <Circle {...GROOVES} r={344} />
+      {/* Artwork */}
+      <Circle {...CENTER} r={192} fill={Colors.red} />
+      {/* Spin Indicator */}
+      <Rect x={384} y={193} width={2} height={24} fill="#FFF" />
+      {/* Center hole */}
+      <Circle
+        {...CENTER}
+        r={12}
+        fill={canvas}
+        stroke={Colors.neutral80}
+        strokeWidth={6}
+      />
+    </Svg>
+  );
+}

--- a/mobile/src/modules/media/components/Vinyl.tsx
+++ b/mobile/src/modules/media/components/Vinyl.tsx
@@ -1,9 +1,11 @@
+import { View } from "react-native";
 import type { CircleProps } from "react-native-svg";
-import Svg, { Circle, ClipPath, Defs, G, Image, Rect } from "react-native-svg";
+import Svg, { Circle, Defs, Mask, Rect } from "react-native-svg";
 
 import { useTheme } from "@/hooks/useTheme";
 
 import { Colors } from "@/constants/Styles";
+import { MediaImage } from "./MediaImage";
 
 const CENTER = { cx: 384, cy: 384 };
 const GROOVES = {
@@ -14,77 +16,48 @@ const GROOVES = {
   opacity: 0.075,
 } satisfies CircleProps;
 
-/** Plain vinyl component. */
+/**
+ * Plain vinyl component. Need this convoluted way as the SVG `<Image />`
+ * component is slow (ie: the image doesn't load immediately on first look).
+ */
 export function Vinyl(props: {
   size: number;
-  source: string | null | Array<string | null>;
+  source: MediaImage.ImageSource | MediaImage.ImageSource[];
 }) {
   const { canvas } = useTheme();
   return (
-    <Svg width={props.size} height={props.size} viewBox="0 0 768 768">
-      <Defs>
-        <ClipPath id="round">
-          <Circle {...CENTER} r={192} />
-        </ClipPath>
-      </Defs>
-      {/* Background */}
-      <Circle {...CENTER} r={384} fill={Colors.neutral10} />
-      {/* Grooves */}
-      <Circle {...GROOVES} r={264} />
-      <Circle {...GROOVES} r={304} />
-      <Circle {...GROOVES} r={344} />
-      {/* Artwork */}
-      <Circle {...CENTER} r={192} fill={Colors.red} />
-      <RenderArtwork source={props.source} />
-      {/* Spin Indicator */}
-      <Rect x={384} y={193} width={2} height={24} fill="#FFF" />
-      {/* Center hole */}
-      <Circle
-        {...CENTER}
-        r={12}
-        fill={canvas}
-        stroke={Colors.neutral80}
-        strokeWidth={6}
+    <View className="relative">
+      <MediaImage
+        type="playlist"
+        source={props.source}
+        size={props.size / 2}
+        className="absolute translate-x-1/2 translate-y-1/2 rounded-full bg-red"
+        noPlaceholder
       />
-    </Svg>
-  );
-}
-
-/** Helper to render the artwork in the center of the vinyl. */
-function RenderArtwork(props: {
-  source: string | null | Array<string | null>;
-}) {
-  if (props.source === null) return null;
-  if (typeof props.source === "string")
-    return <SVGImg href={props.source} size={384} rounded />;
-  return (
-    <G clipPath="url(#round)">
-      {props.source.slice(0, 4).map((source, idx) => {
-        if (source === null) return null;
-        const extraX = idx % 2 === 1;
-        const extraY = idx % 4 > 1;
-        return (
-          <SVGImg key={idx} href={source} size={192} {...{ extraX, extraY }} />
-        );
-      })}
-    </G>
-  );
-}
-
-/** Special wrapper around SVG's `Image` component. */
-function SVGImg(
-  props: { size: number; href: string } & Partial<
-    Record<"extraX" | "extraY" | "rounded", boolean>
-  >,
-) {
-  return (
-    <Image
-      href={props.href}
-      x={props.extraX ? "50%" : "25%"}
-      y={props.extraY ? "50%" : "25%"}
-      {...{ width: props.size, height: props.size }}
-      preserveAspectRatio="xMidYMid slice" // "background-size: cover"
-      {...(props.rounded ? { clipPath: "url(#round)" } : {})}
-    />
+      <Svg width={props.size} height={props.size} viewBox="0 0 768 768">
+        <Defs>
+          <Mask id="hole">
+            <Circle {...CENTER} r={384} fill="white" />
+            <Circle {...CENTER} r={192} fill="black" />
+          </Mask>
+        </Defs>
+        {/* Background */}
+        <Circle {...CENTER} r={384} fill={Colors.neutral10} mask="url(#hole)" />
+        {/* Grooves */}
+        <Circle {...GROOVES} r={264} />
+        <Circle {...GROOVES} r={304} />
+        <Circle {...GROOVES} r={344} />
+        {/* Spin Indicator */}
+        <Rect x={384} y={193} width={2} height={24} fill="#FFF" />
+        {/* Center hole */}
+        <Circle
+          {...CENTER}
+          r={12}
+          fill={canvas}
+          stroke={Colors.neutral80}
+          strokeWidth={6}
+        />
+      </Svg>
+    </View>
   );
 }

--- a/mobile/src/modules/search/components/SearchResult.tsx
+++ b/mobile/src/modules/search/components/SearchResult.tsx
@@ -15,7 +15,7 @@ export namespace SearchResult {
     title: string;
     description?: string;
     type: MediaType;
-    imageSource?: MediaImage.ImageSource | Array<string | null>;
+    imageSource?: MediaImage.ImageSource | MediaImage.ImageSource[];
     /** Renders this instead of the image if provided. */
     LeftElement?: React.JSX.Element;
     className?: string;
@@ -74,7 +74,7 @@ function SearchResultContent(
           type={props.type}
           size={48}
           source={props.imageSource ?? null}
-          radius="sm"
+          className="rounded-sm"
         />
       )}
       <View className="shrink grow">

--- a/mobile/src/providers/RouteHandlers.tsx
+++ b/mobile/src/providers/RouteHandlers.tsx
@@ -18,7 +18,7 @@ export function DeepLinkHandler() {
   useEffect(() => {
     function deepLinkHandler(data: { url: string }) {
       if (data.url === "trackplayer://notification.click") {
-        router.navigate("/current-track");
+        router.navigate("/now-playing");
       }
     }
     // This event will be fired when the app is already open and the notification is clicked

--- a/mobile/src/screens/NowPlaying/SeekService.ts
+++ b/mobile/src/screens/NowPlaying/SeekService.ts
@@ -1,0 +1,16 @@
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+
+interface SeekStore {
+  sliderPos: number | null;
+  setSliderPos: (newPos: number | null) => void;
+}
+
+/** Tracks when we manipulate the seekbar. */
+export const seekStore = createStore<SeekStore>()((set) => ({
+  sliderPos: null,
+  setSliderPos: (newPos) => set({ sliderPos: newPos }),
+}));
+
+export const useSeekStore = <T>(selector: (state: SeekStore) => T): T =>
+  useStore(seekStore, selector);

--- a/mobile/src/screens/NowPlaying/useVinylSeekbar.ts
+++ b/mobile/src/screens/NowPlaying/useVinylSeekbar.ts
@@ -1,0 +1,44 @@
+import { useMemo, useRef } from "react";
+import {
+  cancelAnimation,
+  Easing,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { useProgress } from "react-native-track-player";
+
+import { useMusicStore } from "@/modules/media/services/Music";
+import { useSeekStore } from "@/screens/NowPlaying/SeekService";
+
+/** Controls the rotation of the vinyl on the "Now Playing" screen. */
+export function useVinylSeekbar() {
+  const { position } = useProgress(200);
+  const rotationProgress = useSharedValue(0);
+  const hasMounted = useRef(false);
+  const activeTrack = useMusicStore((state) => state.activeTrack);
+  const isPlaying = useMusicStore((state) => state.isPlaying);
+  const sliderPos = useSeekStore((state) => state.sliderPos);
+
+  if (position === 0) {
+    // Reset animation when position goes back to 0s.
+    cancelAnimation(rotationProgress);
+    rotationProgress.value = 0;
+  } else if (!isPlaying) {
+    // Instantaneously go to new rotated position when paused.
+    cancelAnimation(rotationProgress);
+    rotationProgress.value = ((sliderPos ?? position) * 360) / 24;
+  } else if (position < (activeTrack?.duration ?? 0) - 1) {
+    rotationProgress.value = withTiming(
+      ((sliderPos ?? position) * 360) / 24,
+      // Prevent vinyl rotation on mount.
+      { duration: hasMounted.current ? 500 : 0, easing: Easing.linear },
+    );
+    if (!hasMounted.current) hasMounted.current = true;
+  } else {
+    // Cancel animation ~1s before the end due to weird behaviors if
+    // the following image is large in size (ie: "animation spike").
+    cancelAnimation(rotationProgress);
+  }
+
+  return useMemo(() => rotationProgress, [rotationProgress]);
+}

--- a/mobile/src/screens/Sheets/Artwork.tsx
+++ b/mobile/src/screens/Sheets/Artwork.tsx
@@ -54,7 +54,7 @@ export function PlaylistArtworkSheet(props: { payload: { id: string } }) {
 /** Reusable sheet for changing the artwork of some media. */
 function BaseArtworkSheetContent(props: {
   type: MediaType;
-  imageSource: MediaImage.ImageSource | Array<string | null>;
+  imageSource: MediaImage.ImageSource | MediaImage.ImageSource[];
   mutationResult: UseMutationResult<void, Error, { artwork?: string | null }>;
 }) {
   const { height, width } = useWindowDimensions();

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -182,7 +182,7 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
   const playingList = useMusicStore((state) => state.playingList);
 
   const canShowPlaylistBtn =
-    pathname === "/current-track" && playingSource?.type === "playlist";
+    pathname === "/now-playing" && playingSource?.type === "playlist";
   const isInList = playingList.some((id) => id === data.id);
 
   // Don't render the last `<Divider />` if there's no content in this row.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Created a new vinyl design to replace the old design that was temporarily removed in the v2 redesign. This design is more symmetrical (just a disk instead of sleeve + disk) and will look more consistent across devices.
- A full revolution of the vinyl is `24s` long.
- Re-created the sleeve + disk animation for the albums & playlists screen. Instead of the vinyl moving to the right, the sleeve moves to the left (as we want as much space as possible for the metadata that's on its right).
- The vinyl on the "Now Playing" screen now spins proportionally to the seek bar position. In addition, it syncs with when we drag the thumb in the seek bar (ie: spins back and forwards).
- Slight adjustment to `<MediaImage />`.
- Renamed `/current-track` route to `/now-playing`.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
