### PR TITLE
feat: Updated vinyl design (Part 2)

### DIFF
--- a/docs/supported-gestures.md
+++ b/docs/supported-gestures.md
@@ -15,7 +15,7 @@ This involves swiping left on some content to reveal actions related to that con
   <thead>
     <tr>
       <th align="center"><code>Home Navigation</code></th>
-      <th align="center"><code>Filter List</code></th>
+      <th align="center"><code>Filter List Entries</code></th>
       <th align="center"><code>Queue List</code></th>
     </tr>
   </thead>
@@ -40,3 +40,9 @@ This involves long-pressing an item to reveal some action. It's currently presen
 
 - **`Artist & Playlist Artwork`:** You can long-press on the artist or playlist artwork on their respective screens to reveal a modal to change or remove the specified artwork.
 - **`Playlist Tracks`:** You can long-press on tracks in the playlist screen or playlist modification screen (create or edit) to change its order/position in the playlist.
+
+## Drag for Action
+
+This involves dragging an item to do some action. It's currently present in the following features.
+
+- **`Now Playing Vinyl`:** You can drag your finger in a circular motion on the vinyl (when enabled) to have it act as a seekbar. 1 full rotation of the vinyl is equivalent to 24s.

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -109,18 +109,10 @@ function Artwork({ artwork: source }: { artwork: string | null }) {
 
 /** Seekbar variant that uses the vinyl artwork. */
 function VinylSeekBar(props: { source: string | null; size: number }) {
-  const [center, setCenter] = useState({ x: 0, y: 0 });
-  const { vinylStyle, seekGesture } = useVinylSeekbar({ center });
-
+  const { initCenter, vinylStyle, seekGesture } = useVinylSeekbar();
   return (
     <GestureDetector gesture={seekGesture}>
-      <Animated.View
-        onLayout={(e) => {
-          const { x, y, width, height } = e.nativeEvent.layout;
-          setCenter({ x: x + width / 2, y: y + height / 2 });
-        }}
-        style={vinylStyle}
-      >
+      <Animated.View onLayout={initCenter} style={vinylStyle}>
         <Vinyl {...props} />
       </Animated.View>
     </GestureDetector>

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -3,7 +3,8 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View, useWindowDimensions } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
-import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { GestureDetector } from "react-native-gesture-handler";
+import Animated from "react-native-reanimated";
 import { useProgress } from "react-native-track-player";
 
 import { Favorite } from "@/icons/Favorite";
@@ -108,16 +109,21 @@ function Artwork({ artwork: source }: { artwork: string | null }) {
 
 /** Seekbar variant that uses the vinyl artwork. */
 function VinylSeekBar(props: { source: string | null; size: number }) {
-  const rotationProgress = useVinylSeekbar();
-
-  const diskStyle = useAnimatedStyle(() => ({
-    transform: [{ rotate: `${rotationProgress.value}deg` }],
-  }));
+  const [center, setCenter] = useState({ x: 0, y: 0 });
+  const { vinylStyle, seekGesture } = useVinylSeekbar({ center });
 
   return (
-    <Animated.View style={diskStyle}>
-      <Vinyl {...props} />
-    </Animated.View>
+    <GestureDetector gesture={seekGesture}>
+      <Animated.View
+        onLayout={(e) => {
+          const { x, y, width, height } = e.nativeEvent.layout;
+          setCenter({ x: x + width / 2, y: y + height / 2 });
+        }}
+        style={vinylStyle}
+      >
+        <Vinyl {...props} />
+      </Animated.View>
+    </GestureDetector>
   );
 }
 //#endregion

--- a/mobile/src/screens/NowPlaying/useVinylSeekbar.ts
+++ b/mobile/src/screens/NowPlaying/useVinylSeekbar.ts
@@ -1,23 +1,43 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useRef } from "react";
+import { Gesture } from "react-native-gesture-handler";
 import {
   cancelAnimation,
   Easing,
+  runOnJS,
+  useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
-import { useProgress } from "react-native-track-player";
+import TrackPlayer, { useProgress } from "react-native-track-player";
 
 import { useMusicStore } from "@/modules/media/services/Music";
 import { useSeekStore } from "@/screens/NowPlaying/SeekService";
 
 /** Controls the rotation of the vinyl on the "Now Playing" screen. */
-export function useVinylSeekbar() {
+export function useVinylSeekbar({
+  center,
+}: {
+  /** Coordinates pointing to the center of the vinyl. */
+  center: { x: number; y: number };
+}) {
   const { position } = useProgress(200);
-  const rotationProgress = useSharedValue(0);
-  const hasMounted = useRef(false);
   const activeTrack = useMusicStore((state) => state.activeTrack);
   const sliderPos = useSeekStore((state) => state.sliderPos);
 
+  const hasMounted = useRef(false);
+  /** Rotation progress based on `position`. */
+  const rotationProgress = useSharedValue(0);
+  /** Rotation progress based on "seeking" on vinyl. */
+  const seekProgress = useSharedValue<number | null>(null);
+  /** Number of seconds we need to move by. */
+  const cueAmount = useSharedValue(0);
+  const prevAngle = useSharedValue(0);
+
+  const onEnd = useCallback(async (movedAmount: number) => {
+    await TrackPlayer.seekBy(movedAmount);
+  }, []);
+
+  //#region True Position
   if (position === 0) {
     // Reset animation when position goes back to 0s.
     cancelAnimation(rotationProgress);
@@ -34,6 +54,37 @@ export function useVinylSeekbar() {
     // the following image is large in size (ie: "animation spike").
     cancelAnimation(rotationProgress);
   }
+  //#endregion
 
-  return useMemo(() => rotationProgress, [rotationProgress]);
+  const seekGesture = Gesture.Pan()
+    .onStart(({ absoluteX, absoluteY }) => {
+      cancelAnimation(rotationProgress);
+      seekProgress.value = rotationProgress.value;
+      prevAngle.value = Math.atan2(absoluteY - center.y, absoluteX - center.x);
+    })
+    .onUpdate(({ absoluteX, absoluteY }) => {
+      let currAngle = Math.atan2(absoluteY - center.y, absoluteX - center.x);
+      while (currAngle < prevAngle.value - Math.PI) currAngle += 2 * Math.PI;
+      while (currAngle > prevAngle.value + Math.PI) currAngle -= 2 * Math.PI;
+      const difference = currAngle - prevAngle.value;
+      prevAngle.value = currAngle;
+
+      seekProgress.value =
+        (seekProgress.value ?? 0) + (difference * 180) / Math.PI;
+      // Convert `difference` to duration represented by duration.
+      cueAmount.value = cueAmount.value + (difference * 24) / (2 * Math.PI);
+    })
+    .onEnd(() => {
+      runOnJS(onEnd)(cueAmount.value);
+      rotationProgress.value = seekProgress.value ?? 0;
+      cueAmount.value = 0;
+      seekProgress.value = null;
+    });
+
+  const vinylStyle = useAnimatedStyle(() => {
+    const rotateAmount = seekProgress.value ?? rotationProgress.value;
+    return { transform: [{ rotate: `${rotateAmount}deg` }] };
+  });
+
+  return { vinylStyle, seekGesture };
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

The PR adds the ability to use the vinyl on the "Now Playing" screen as a seekbar. As mentioned in the previous PR, a full revolution is equivalent to `24s`.
- We included logic to prevent over rotating the vinyl beyond its duration.

I initially wanted to use the [Rotation Gesture](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/rotation-gesture/) from `react-native-gesture-handler`, but it required using 2 fingers to activate the tracking and it wasn't that accurate.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
