### PR TITLE
chore: Drag list improvements

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -58,7 +58,7 @@
     "react-native": "0.75.4",
     "react-native-actions-sheet": "^0.9.7",
     "react-native-bootsplash": "^6.3.2",
-    "react-native-draglist": "github:MissingCore/react-native-draglist#b5d855404c809513e1f8137fb58ef0f823d72321",
+    "react-native-draglist": "github:MissingCore/react-native-draglist#6e926d101e6293785d5cab4c014ccdc4812c19d2",
     "react-native-edge-to-edge": "^1.3.1",
     "react-native-gesture-handler": "~2.21.2",
     "react-native-markdown-display": "^7.0.2",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -58,7 +58,7 @@
     "react-native": "0.75.4",
     "react-native-actions-sheet": "^0.9.7",
     "react-native-bootsplash": "^6.3.2",
-    "react-native-draglist": "github:MissingCore/react-native-draglist#30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71",
+    "react-native-draglist": "github:MissingCore/react-native-draglist#b3b82b42e4ba37d2f2d62f33f282e88e385a2178",
     "react-native-edge-to-edge": "^1.3.1",
     "react-native-gesture-handler": "~2.21.2",
     "react-native-markdown-display": "^7.0.2",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -58,7 +58,7 @@
     "react-native": "0.75.4",
     "react-native-actions-sheet": "^0.9.7",
     "react-native-bootsplash": "^6.3.2",
-    "react-native-draglist": "github:MissingCore/react-native-draglist#b3b82b42e4ba37d2f2d62f33f282e88e385a2178",
+    "react-native-draglist": "github:MissingCore/react-native-draglist#b5d855404c809513e1f8137fb58ef0f823d72321",
     "react-native-edge-to-edge": "^1.3.1",
     "react-native-gesture-handler": "~2.21.2",
     "react-native-markdown-display": "^7.0.2",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^6.3.2
         version: 6.3.2(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-draglist:
-        specifier: github:MissingCore/react-native-draglist#b3b82b42e4ba37d2f2d62f33f282e88e385a2178
-        version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
+        specifier: github:MissingCore/react-native-draglist#b5d855404c809513e1f8137fb58ef0f823d72321
+        version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: ^1.3.1
         version: 1.3.1(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
@@ -5182,8 +5182,8 @@ packages:
       react-native-svg:
         optional: true
 
-  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178:
-    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178}
+  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321:
+    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321}
     version: 3.8.2
     peerDependencies:
       '@shopify/flash-list': '*'
@@ -12264,7 +12264,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
+  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
     dependencies:
       '@shopify/flash-list': 1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react: 18.3.1

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^6.3.2
         version: 6.3.2(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-draglist:
-        specifier: github:MissingCore/react-native-draglist#30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71
-        version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
+        specifier: github:MissingCore/react-native-draglist#b3b82b42e4ba37d2f2d62f33f282e88e385a2178
+        version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: ^1.3.1
         version: 1.3.1(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
@@ -5182,9 +5182,9 @@ packages:
       react-native-svg:
         optional: true
 
-  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71:
-    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71}
-    version: 3.8.0
+  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178:
+    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178}
+    version: 3.8.2
     peerDependencies:
       '@shopify/flash-list': '*'
       react: '>=17.0.1'
@@ -12264,7 +12264,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/30df0ad6d4ca7686a84a9ce7328d7faf7d1e5b71(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
+  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b3b82b42e4ba37d2f2d62f33f282e88e385a2178(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
     dependencies:
       '@shopify/flash-list': 1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react: 18.3.1

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^6.3.2
         version: 6.3.2(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-draglist:
-        specifier: github:MissingCore/react-native-draglist#b5d855404c809513e1f8137fb58ef0f823d72321
-        version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
+        specifier: github:MissingCore/react-native-draglist#6e926d101e6293785d5cab4c014ccdc4812c19d2
+        version: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/6e926d101e6293785d5cab4c014ccdc4812c19d2(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: ^1.3.1
         version: 1.3.1(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
@@ -5182,8 +5182,8 @@ packages:
       react-native-svg:
         optional: true
 
-  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321:
-    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321}
+  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/6e926d101e6293785d5cab4c014ccdc4812c19d2:
+    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/6e926d101e6293785d5cab4c014ccdc4812c19d2}
     version: 3.8.2
     peerDependencies:
       '@shopify/flash-list': '*'
@@ -12264,7 +12264,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/b5d855404c809513e1f8137fb58ef0f823d72321(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
+  react-native-draglist@https://codeload.github.com/MissingCore/react-native-draglist/tar.gz/6e926d101e6293785d5cab4c014ccdc4812c19d2(@shopify/flash-list@1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1):
     dependencies:
       '@shopify/flash-list': 1.7.2(@babel/runtime@7.26.0)(react-native@0.75.4(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.17)(react@18.3.1)(typescript@5.6.3))(react@18.3.1)
       react: 18.3.1

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -2,8 +2,8 @@ import { Stack, router, useLocalSearchParams } from "expo-router";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
-import type { DragListRenderItemInfo } from "react-native-draglist";
-import DragList from "react-native-draglist";
+import type { DragListRenderItemInfo } from "react-native-draglist/FlashList";
+import FlashDragList from "react-native-draglist/FlashList";
 
 import { Edit } from "@/icons/Edit";
 import { Favorite } from "@/icons/Favorite";
@@ -108,7 +108,7 @@ export default function CurrentPlaylistScreen() {
         imageSource={data.imageSource}
         mediaSource={trackSource}
       >
-        <DragList
+        <FlashDragList
           estimatedItemSize={56} // 48px Height + 8px Margin Top
           data={playlistTracks}
           keyExtractor={({ id }) => id}

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -2,8 +2,8 @@ import { Stack, router, useLocalSearchParams } from "expo-router";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
-import type { DragListRenderItemInfo } from "react-native-draglist/FlashList";
-import FlashDragList from "react-native-draglist/FlashList";
+import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
+import FlashDragList from "react-native-draglist/dist/FlashList";
 
 import { Edit } from "@/icons/Edit";
 import { Favorite } from "@/icons/Favorite";

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -3,7 +3,6 @@ import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
-import FlashDragList from "react-native-draglist/dist/FlashList";
 
 import { Edit } from "@/icons/Edit";
 import { Favorite } from "@/icons/Favorite";
@@ -24,7 +23,7 @@ import {
 import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
 import { cn } from "@/lib/style";
-import { useListPresets } from "@/components/Defaults";
+import { FlashDragList } from "@/components/Defaults";
 import { IconButton } from "@/components/Form/Button";
 import type { SwipeableRef } from "@/components/Swipeable";
 import { Swipeable } from "@/components/Swipeable";
@@ -33,14 +32,12 @@ import { Track } from "@/modules/media/components/Track";
 import type { PlayListSource } from "@/modules/media/types";
 
 type ScreenData = Track.Content & { disc: number | null; track: number | null };
-
 type RenderItemProps = DragListRenderItemInfo<ScreenData>;
 
 /** Screen for `/playlist/[id]` route. */
 export default function CurrentPlaylistScreen() {
   const { t } = useTranslation();
   const { bottomInset } = useBottomActionsContext();
-  const listPresets = useListPresets({ emptyMsgKey: "response.noTracks" });
   const { id } = useLocalSearchParams<{ id: string }>();
   const { isPending, error, data } = usePlaylistForScreen(id);
   const moveInPlaylist = useMoveInPlaylist(id);
@@ -114,9 +111,9 @@ export default function CurrentPlaylistScreen() {
           keyExtractor={({ id }) => id}
           renderItem={renderItem}
           onReordered={onReordered}
-          {...listPresets}
           contentContainerClassName="pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
+          emptyMsgKey="response.noTracks"
         />
       </CurrentListLayout>
     </>

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useState } from "react";
 import { Pressable } from "react-native";
-import type { DragListRenderItemInfo } from "react-native-draglist/FlashList";
-import FlashDragList from "react-native-draglist/FlashList";
+import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
+import FlashDragList from "react-native-draglist/dist/FlashList";
 
 import { DragIndicator } from "@/icons/DragIndicator";
 import type { OrderableTabs } from "@/services/UserPreferences";

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback } from "react";
 import { Pressable } from "react-native";
 import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
-import FlashDragList from "react-native-draglist/dist/FlashList";
 
 import { DragIndicator } from "@/icons/DragIndicator";
 import type { OrderableTabs } from "@/services/UserPreferences";
@@ -13,15 +12,15 @@ import {
 } from "@/lib/react-native-draglist";
 
 import { cn } from "@/lib/style";
-import { useListPresets } from "@/components/Defaults";
+import { FlashDragList } from "@/components/Defaults";
 import { Divider } from "@/components/Divider";
 import { TStyledText } from "@/components/Typography/StyledText";
 
 type TabValues = (typeof OrderableTabs)[number];
+type RenderItemProps = DragListRenderItemInfo<TabValues>;
 
 /** Screen for `/setting/appearance/home-tabs-order` route. */
 export default function HomeTabsOrderScreen() {
-  const listPresets = useListPresets();
   const data = useUserPreferencesStore((state) => state.homeTabsOrder);
   const onMove = useUserPreferencesStore((state) => state.moveTab);
   const { items, onReordered } = useDragListState({ data, onMove });
@@ -45,14 +44,10 @@ export default function HomeTabsOrderScreen() {
         keyExtractor={(tabKey) => tabKey}
         renderItem={renderItem}
         onReordered={onReordered}
-        {...listPresets}
       />
     </StandardScrollLayout>
   );
 }
-
-/** Items rendered in the `<DragList />`. */
-type RenderItemProps = DragListRenderItemInfo<TabValues>;
 
 /** Item rendered in the `<DragList />`. */
 const RenderItem = memo(

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -54,8 +54,7 @@ const RenderItem = memo(
   function RenderItem({ item, ...info }: RenderItemProps) {
     return (
       <Pressable
-        delayLongPress={100}
-        onLongPress={info.onDragStart}
+        onPressIn={info.onDragStart}
         onPressOut={info.onDragEnd}
         className={cn(
           "min-h-12 flex-row items-center gap-2 rounded-md p-4 pl-2 active:bg-surface/50",

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -7,10 +7,12 @@ import { DragIndicator } from "@/icons/DragIndicator";
 import type { OrderableTabs } from "@/services/UserPreferences";
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 import { StandardScrollLayout } from "@/layouts/StandardScroll";
-import { useDragListState } from "@/lib/react-native-draglist";
+import {
+  areRenderItemPropsEqual,
+  useDragListState,
+} from "@/lib/react-native-draglist";
 
 import { cn } from "@/lib/style";
-import { pickKeys } from "@/utils/object";
 import { useListPresets } from "@/components/Defaults";
 import { Divider } from "@/components/Divider";
 import { TStyledText } from "@/components/Typography/StyledText";
@@ -53,42 +55,26 @@ export default function HomeTabsOrderScreen() {
 type RenderItemProps = DragListRenderItemInfo<TabValues>;
 
 /** Item rendered in the `<DragList />`. */
-const RenderItem = memo(function RenderItem({
-  item,
-  ...info
-}: RenderItemProps) {
-  return (
-    <Pressable
-      delayLongPress={100}
-      onLongPress={info.onDragStart}
-      onPressOut={info.onDragEnd}
-      className={cn(
-        "min-h-12 flex-row items-center gap-2 rounded-md p-4 pl-2 active:bg-surface/50",
-        {
-          "opacity-25": !info.isActive && info.isDragging,
-          "!bg-surface": info.isActive,
-          "mt-1": info.index > 0,
-        },
-      )}
-    >
-      <DragIndicator />
-      <TStyledText textKey={`common.${item}s`} className="pl-2" />
-    </Pressable>
-  );
-}, areRenderItemPropsEqual);
-
-const RenderItemPrimitiveProps = ["index", "isActive", "isDragging"] as const;
-
-function areRenderItemPropsEqual(
-  oldProps: RenderItemProps,
-  newProps: RenderItemProps,
-) {
-  const primitiveProps = pickKeys(oldProps, RenderItemPrimitiveProps);
-  return (
-    oldProps.item === newProps.item &&
-    Object.entries(primitiveProps).every(
-      // @ts-expect-error - Non-existent type conflicts.
-      ([key, value]) => value === newProps[key],
-    )
-  );
-}
+const RenderItem = memo(
+  function RenderItem({ item, ...info }: RenderItemProps) {
+    return (
+      <Pressable
+        delayLongPress={100}
+        onLongPress={info.onDragStart}
+        onPressOut={info.onDragEnd}
+        className={cn(
+          "min-h-12 flex-row items-center gap-2 rounded-md p-4 pl-2 active:bg-surface/50",
+          {
+            "opacity-25": !info.isActive && info.isDragging,
+            "!bg-surface": info.isActive,
+            "mt-1": info.index > 0,
+          },
+        )}
+      >
+        <DragIndicator />
+        <TStyledText textKey={`common.${item}s`} className="pl-2" />
+      </Pressable>
+    );
+  },
+  areRenderItemPropsEqual((o, n) => o.item === n.item),
+);

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useState } from "react";
 import { Pressable } from "react-native";
-import type { DragListRenderItemInfo } from "react-native-draglist";
-import DragList from "react-native-draglist";
+import type { DragListRenderItemInfo } from "react-native-draglist/FlashList";
+import FlashDragList from "react-native-draglist/FlashList";
 
 import { DragIndicator } from "@/icons/DragIndicator";
 import type { OrderableTabs } from "@/services/UserPreferences";
@@ -49,7 +49,7 @@ export default function HomeTabsOrderScreen() {
         className="text-center text-sm"
       />
       <Divider />
-      <DragList
+      <FlashDragList
         estimatedItemSize={52} // 48px Height + 4px Margin top
         data={tabOrder}
         keyExtractor={(tabKey) => tabKey}

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -9,6 +9,10 @@ import {
 } from "react-native";
 import { FlatList as RNASFlatList } from "react-native-actions-sheet";
 import { FlashList as RNASFlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
+import type { DragListProps } from "react-native-draglist";
+import RNDragList from "react-native-draglist";
+import type { FlashDragListProps } from "react-native-draglist/dist/FlashList";
+import RNFlashDragList from "react-native-draglist/dist/FlashList";
 
 import { ContentPlaceholder } from "./Transition/Placeholder";
 
@@ -40,7 +44,7 @@ export function useListPresets(args?: ListEmptyProps) {
 }
 //#endregion
 
-//#region Preset Native Components
+//#region Native Components
 /** `<FlatList />` with some defaults applied. */
 export function FlatList<TData>(
   props: WithListEmptyProps<FlatListProps<TData>>,
@@ -56,7 +60,7 @@ export function ScrollView(props: ScrollViewProps) {
 }
 //#endregion
 
-//#region Preset Alternate Components
+//#region FlashLists
 /** `<FlashList />` with some defaults applied. */
 export function FlashList<TData>(
   props: WithListEmptyProps<FlashListProps<TData>>,
@@ -82,5 +86,25 @@ export function SheetsFlashList<TData>(
   const { isPending, emptyMsgKey, ...rest } = props;
   const listPresets = useListPresets({ isPending, emptyMsgKey });
   return <RNASFlashList {...listPresets} {...rest} />;
+}
+//#endregion
+
+//#region DragLists
+/** `<DragList />` with some defaults applied. */
+export function DragList<TData>(
+  props: WithListEmptyProps<DragListProps<TData>>,
+) {
+  const { isPending, emptyMsgKey, ...rest } = props;
+  const listPresets = useListPresets({ isPending, emptyMsgKey });
+  return <RNDragList {...listPresets} {...rest} />;
+}
+
+/** `<FlashDragList />` with some defaults applied. */
+export function FlashDragList<TData>(
+  props: WithListEmptyProps<FlashDragListProps<TData>>,
+) {
+  const { isPending, emptyMsgKey, ...rest } = props;
+  const listPresets = useListPresets({ isPending, emptyMsgKey });
+  return <RNFlashDragList {...listPresets} {...rest} />;
 }
 //#endregion

--- a/mobile/src/lib/react-native-draglist.ts
+++ b/mobile/src/lib/react-native-draglist.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
 
 import { moveArray } from "@/utils/object";
 
@@ -29,4 +30,21 @@ export function useDragListState<T>(args: {
   }, [args.data]);
 
   return { items, onReordered };
+}
+
+type EqualityFn<T> = (
+  oldProps: DragListRenderItemInfo<T>,
+  newProps: DragListRenderItemInfo<T>,
+) => boolean;
+
+// Props that should account to re-rendering (ie: ignore functions).
+const primitiveProps = ["index", "isActive", "isDragging"] as const;
+
+/** Custom memoization function to determine when the item should be re-rendered. */
+export function areRenderItemPropsEqual<T>(
+  itemEqualityFn: EqualityFn<T>,
+): EqualityFn<T> {
+  return (oldProps, newProps) =>
+    itemEqualityFn(oldProps, newProps) &&
+    primitiveProps.every((key) => oldProps[key] === newProps[key]);
 }

--- a/mobile/src/lib/react-native-draglist.ts
+++ b/mobile/src/lib/react-native-draglist.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { moveArray } from "@/utils/object";
+
+/**
+ * Hook that returns a localized state synchronized with its source to
+ * prevent the jankiness from rendering data from an async source.
+ */
+export function useDragListState<T>(args: {
+  /** Asynchronous data rendered in the drag list. */
+  data: T[] | undefined;
+  /** Function called when we moved an item in the drag list to its new location. */
+  onMove: (fromIndex: number, toIndex: number) => Promise<void> | void;
+}) {
+  const [items, setItems] = useState<T[]>([]);
+
+  const onReordered = useCallback(
+    async (fromIndex: number, toIndex: number) => {
+      setItems((prev) => moveArray(prev, { fromIndex, toIndex }));
+      await args.onMove(fromIndex, toIndex);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [args.onMove],
+  );
+
+  // Synchronize local state with async data.
+  useEffect(() => {
+    if (args.data && Array.isArray(args.data)) setItems(args.data);
+  }, [args.data]);
+
+  return { items, onReordered };
+}

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -305,7 +305,7 @@
   },
   "react-native-draglist": {
     "name": "react-native-draglist",
-    "version": "3.8.0",
+    "version": "3.8.2",
     "copyright": "Copyright (c) 2022 fivecar",
     "source": "https://github.com/fivecar/react-native-draglist",
     "license": "MIT",

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -4,8 +4,8 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BackHandler, Modal, Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
-import type { DragListRenderItemInfo } from "react-native-draglist/FlashList";
-import FlashDragList from "react-native-draglist/FlashList";
+import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
+import FlashDragList from "react-native-draglist/dist/FlashList";
 
 import type { TrackWithAlbum } from "@/db/schema";
 

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import { BackHandler, Modal, Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
 import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
-import FlashDragList from "react-native-draglist/dist/FlashList";
 
 import type { TrackWithAlbum } from "@/db/schema";
 
@@ -24,7 +23,7 @@ import { Colors } from "@/constants/Styles";
 import { mutateGuard } from "@/lib/react-query";
 import { cn } from "@/lib/style";
 import { wait } from "@/utils/promise";
-import { useListPresets } from "@/components/Defaults";
+import { FlashDragList } from "@/components/Defaults";
 import { IconButton } from "@/components/Form/Button";
 import { TextInput } from "@/components/Form/Input";
 import type { SwipeableRef } from "@/components/Swipeable";
@@ -83,8 +82,6 @@ type RenderItemProps = DragListRenderItemInfo<TrackWithAlbum>;
 
 /** Contains the logic for editing the playlist name and tracks. */
 function PageContent() {
-  const listPresets = useListPresets({ emptyMsgKey: "response.noTracks" });
-
   const tracks = usePlaylistStore((state) => state.tracks);
   const isUnchanged = usePlaylistStore((state) => state.isUnchanged);
   const isSubmitting = usePlaylistStore((state) => state.isSubmitting);
@@ -125,8 +122,8 @@ function PageContent() {
         renderItem={renderItem}
         onReordered={moveTrack}
         ListHeaderComponent={ListHeaderComponent}
-        {...listPresets}
         contentContainerClassName="py-4" // Applies to the internal `<FlashList />`.
+        emptyMsgKey="response.noTracks"
       />
     </View>
   );

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -4,8 +4,8 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BackHandler, Modal, Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
-import type { DragListRenderItemInfo } from "react-native-draglist";
-import DragList from "react-native-draglist";
+import type { DragListRenderItemInfo } from "react-native-draglist/FlashList";
+import FlashDragList from "react-native-draglist/FlashList";
 
 import type { TrackWithAlbum } from "@/db/schema";
 
@@ -118,7 +118,7 @@ function PageContent() {
       needsOffscreenAlphaCompositing
       className={cn("flex-1", { "opacity-25": isSubmitting })}
     >
-      <DragList
+      <FlashDragList
         estimatedItemSize={56} // 48px Height + 8px Margin Top
         data={tracks}
         keyExtractor={({ id }) => id}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -4,11 +4,11 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"]
     },
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "moduleResolution": "bundler",
+    "module": "ESNext"
   },
   "include": [
     ".eslintrc.js",
@@ -20,7 +20,5 @@
     "expo-env.d.ts",
     "nativewind-env.d.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -6,9 +6,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "noUncheckedIndexedAccess": true,
-    "moduleResolution": "bundler",
-    "module": "ESNext"
+    "noUncheckedIndexedAccess": true
   },
   "include": [
     ".eslintrc.js",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

- Updated `react-native-draglist` package to export FlashList variant in its own file, allowing us to use the initial FlatList variant.
- Dedupe code for localized async state (which prevents content flashing from its old position to new) and memoization comparison function for rendering the draglist items.
- Some what fixed issue where the long-press behavior doesn't trigger due to `onPressOut` firing before the `onLongPress` event for whatever reason.
  - We replaced `onLongPress` with `onPressIn`, which fixed the issue, but only for the home tabs reordering screen as using `onPressIn` instead of `onLongPress` for the other uses would break the swipeable behavior.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
