### PR TITLE
feat: Tab visibility (Part 1)

### DIFF
--- a/mobile/src/app/(main)/(home)/_layout.tsx
+++ b/mobile/src/app/(main)/(home)/_layout.tsx
@@ -15,7 +15,7 @@ type TabState = EventArg<
 >;
 
 export default function HomeLayout() {
-  const homeTabsOrder = useUserPreferencesStore((state) => state.homeTabsOrder);
+  const tabsOrder = useUserPreferencesStore((state) => state.tabsOrder);
   // Should be fine to store navigation state in ref as it doesn't affect rendering.
   //  - https://react.dev/learn/referencing-values-with-refs#when-to-use-refs
   const prevTabState = useRef<TabState>();
@@ -54,7 +54,7 @@ export default function HomeLayout() {
       screenListeners={listeners}
     >
       <MaterialTopTabs.Screen name="index" />
-      {homeTabsOrder.map((tabKey) => (
+      {tabsOrder.map((tabKey) => (
         <MaterialTopTabs.Screen key={tabKey} name={tabKey} />
       ))}
     </MaterialTopTabs>

--- a/mobile/src/app/(main)/(home)/_layout.tsx
+++ b/mobile/src/app/(main)/(home)/_layout.tsx
@@ -26,6 +26,7 @@ export default function HomeLayout() {
       if (prevTabState.current) {
         // Get top of history.
         const currRoute = e.data.state.history.at(-1)!;
+        const currIndex = e.data.state.index;
         // See if route was seen previously.
         const oldHistory = prevTabState.current.data.state.history;
         const atIndex = oldHistory.findIndex((r) => currRoute.key === r.key);
@@ -37,7 +38,7 @@ export default function HomeLayout() {
           //  of the `reset` function.
           //  - https://reactnavigation.org/docs/navigation-actions/#reset
           e.data.state.history = oldHistory
-            .toSpliced(atIndex + 1)
+            .toSpliced(currIndex === atIndex ? atIndex + 1 : 1)
             .filter((r) => !hiddenTabs.some((t) => r.key.startsWith(`${t}-`)));
         }
       }

--- a/mobile/src/app/(main)/(home)/_layout.tsx
+++ b/mobile/src/app/(main)/(home)/_layout.tsx
@@ -21,25 +21,30 @@ export default function HomeLayout() {
   const prevTabState = useRef<TabState>();
 
   /** Have Tab history operate like Stack history. */
-  const manageAsStackHistory = useCallback((e: TabState) => {
-    if (prevTabState.current) {
-      // Get top of history.
-      const currRoute = e.data.state.history.at(-1)!;
-      // See if route was seen previously.
-      const oldHistory = prevTabState.current.data.state.history;
-      const atIndex = oldHistory.findIndex(({ key }) => currRoute.key === key);
-      // Handle if we visited this tab earlier.
-      if (atIndex !== -1) {
-        // FIXME: Modifying the value in `e` for some reason modifies the
-        // original reference (even if we cloned `e` via object spreading).
-        //  - This might be fragile code, so we might swap over to the use
-        //  of the `reset` function.
-        //  - https://reactnavigation.org/docs/navigation-actions/#reset
-        e.data.state.history = oldHistory.toSpliced(atIndex + 1);
+  const manageAsStackHistory = useCallback(
+    (e: TabState) => {
+      if (prevTabState.current) {
+        // Get top of history.
+        const currRoute = e.data.state.history.at(-1)!;
+        // See if route was seen previously.
+        const oldHistory = prevTabState.current.data.state.history;
+        const atIndex = oldHistory.findIndex((r) => currRoute.key === r.key);
+        // Handle if we visited this tab earlier.
+        if (atIndex !== -1) {
+          // FIXME: Modifying the value in `e` for some reason modifies the
+          // original reference (even if we cloned `e` via object spreading).
+          //  - This might be fragile code, so we might swap over to the use
+          //  of the `reset` function.
+          //  - https://reactnavigation.org/docs/navigation-actions/#reset
+          e.data.state.history = oldHistory
+            .toSpliced(atIndex + 1)
+            .filter((r) => !hiddenTabs.some((t) => r.key.startsWith(`${t}-`)));
+        }
       }
-    }
-    prevTabState.current = e;
-  }, []);
+      prevTabState.current = e;
+    },
+    [hiddenTabs],
+  );
 
   const listeners = useMemo(
     () => ({ state: manageAsStackHistory }),

--- a/mobile/src/app/(main)/(home)/_layout.tsx
+++ b/mobile/src/app/(main)/(home)/_layout.tsx
@@ -5,7 +5,7 @@ import type {
 } from "@react-navigation/native";
 import { useCallback, useMemo, useRef } from "react";
 
-import { useUserPreferencesStore } from "@/services/UserPreferences";
+import { useTabsByVisibility } from "@/services/UserPreferences";
 import { MaterialTopTabs } from "@/layouts/MaterialTopTabs";
 
 type TabState = EventArg<
@@ -15,7 +15,7 @@ type TabState = EventArg<
 >;
 
 export default function HomeLayout() {
-  const tabsOrder = useUserPreferencesStore((state) => state.tabsOrder);
+  const { displayedTabs, hiddenTabs } = useTabsByVisibility();
   // Should be fine to store navigation state in ref as it doesn't affect rendering.
   //  - https://react.dev/learn/referencing-values-with-refs#when-to-use-refs
   const prevTabState = useRef<TabState>();
@@ -54,8 +54,11 @@ export default function HomeLayout() {
       screenListeners={listeners}
     >
       <MaterialTopTabs.Screen name="index" />
-      {tabsOrder.map((tabKey) => (
+      {displayedTabs.map((tabKey) => (
         <MaterialTopTabs.Screen key={tabKey} name={tabKey} />
+      ))}
+      {hiddenTabs.map((tabKey) => (
+        <MaterialTopTabs.Screen key={tabKey} name={tabKey} redirect />
       ))}
     </MaterialTopTabs>
   );

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -96,19 +96,19 @@ function NavigationList() {
   const { surface } = useTheme();
   const navState = useRootNavigationState();
   const listRef = useRef<FlatList>(null);
-  const homeTabsOrder = useUserPreferencesStore((state) => state.homeTabsOrder);
+  const tabsOrder = useUserPreferencesStore((state) => state.tabsOrder);
 
   // Buttons for the routes we can navigate to on the "home" screen, whose
   // order can be customized.
   const NavRoutes = useMemo(
     () => [
       { href: "/", key: "header.home" },
-      ...homeTabsOrder.map((tabKey) => ({
+      ...tabsOrder.map((tabKey) => ({
         href: `/${tabKey}`,
         key: `common.${tabKey}s`,
       })),
     ],
-    [homeTabsOrder],
+    [tabsOrder],
   );
 
   const tabIndex = useMemo(() => {

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -199,7 +199,7 @@ function VolumeSlider() {
         <Slider
           value={savedVolume}
           max={1}
-          onChange={(newPos) => setVolume(newPos)}
+          onChange={setVolume}
           thumbSize={12}
         />
       </View>

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -21,7 +21,7 @@ type RenderItemProps = DragListRenderItemInfo<TabValues>;
 
 /** Screen for `/setting/appearance/home-tabs-order` route. */
 export default function HomeTabsOrderScreen() {
-  const data = useUserPreferencesStore((state) => state.homeTabsOrder);
+  const data = useUserPreferencesStore((state) => state.tabsOrder);
   const onMove = useUserPreferencesStore((state) => state.moveTab);
   const { items, onReordered } = useDragListState({ data, onMove });
 

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -1,9 +1,12 @@
 import { memo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { Pressable } from "react-native";
 import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
 
 import { DragIndicator } from "@/icons/DragIndicator";
-import type { OrderableTabs } from "@/services/UserPreferences";
+import { Eye } from "@/icons/Eye";
+import { EyeOff } from "@/icons/EyeOff";
+import type { OrderableTab } from "@/services/UserPreferences";
 import { useUserPreferencesStore } from "@/services/UserPreferences";
 import { StandardScrollLayout } from "@/layouts/StandardScroll";
 import {
@@ -14,10 +17,10 @@ import {
 import { cn } from "@/lib/style";
 import { FlashDragList } from "@/components/Defaults";
 import { Divider } from "@/components/Divider";
+import { IconButton } from "@/components/Form/Button";
 import { TStyledText } from "@/components/Typography/StyledText";
 
-type TabValues = (typeof OrderableTabs)[number];
-type RenderItemProps = DragListRenderItemInfo<TabValues>;
+type RenderItemProps = DragListRenderItemInfo<OrderableTab>;
 
 /** Screen for `/setting/appearance/home-tabs-order` route. */
 export default function HomeTabsOrderScreen() {
@@ -52,12 +55,24 @@ export default function HomeTabsOrderScreen() {
 /** Item rendered in the `<DragList />`. */
 const RenderItem = memo(
   function RenderItem({ item, ...info }: RenderItemProps) {
+    const { t } = useTranslation();
+    const tabsVisibility = useUserPreferencesStore(
+      (state) => state.tabsVisibility,
+    );
+    const toggleVisibility = useUserPreferencesStore(
+      (state) => state.toggleTabVisibility,
+    );
+
+    const isVisible = tabsVisibility[item];
+    const Icon = isVisible ? Eye : EyeOff;
+    const tabNameKey = `common.${item}s` as const;
+
     return (
       <Pressable
         onPressIn={info.onDragStart}
         onPressOut={info.onDragEnd}
         className={cn(
-          "min-h-12 flex-row items-center gap-2 rounded-md p-4 pl-2 active:bg-surface/50",
+          "min-h-12 flex-row items-center rounded-md pl-2 active:bg-surface/50",
           {
             "opacity-25": !info.isActive && info.isDragging,
             "!bg-surface": info.isActive,
@@ -66,7 +81,18 @@ const RenderItem = memo(
         )}
       >
         <DragIndicator />
-        <TStyledText textKey={`common.${item}s`} className="pl-2" />
+        <TStyledText textKey={tabNameKey} className="shrink grow p-4 pr-2" />
+        <IconButton
+          kind="ripple"
+          accessibilityLabel={t(
+            isVisible ? "template.hideEntry" : "template.showEntry",
+            { name: t(tabNameKey) },
+          )}
+          onPress={() => toggleVisibility(item)}
+          disabled={info.isDragging}
+        >
+          <Icon />
+        </IconButton>
       </Pressable>
     );
   },

--- a/mobile/src/icons/Eye.tsx
+++ b/mobile/src/icons/Eye.tsx
@@ -1,0 +1,16 @@
+import Svg, { Circle, Path } from "react-native-svg";
+
+import { useTheme } from "@/hooks/useTheme";
+import type { Icon } from "./type";
+
+// From ionicons.
+export function Eye({ size = 24, color }: Icon) {
+  const { foreground } = useTheme();
+  const usedColor = color ?? foreground;
+  return (
+    <Svg width={size} height={size} viewBox="0 0 512 512" fill={usedColor}>
+      <Circle cx="256" cy="256" r="64" />
+      <Path d="M394.82 141.18C351.1 111.2 304.31 96 255.76 96c-43.69 0-86.28 13-126.59 38.48C88.52 160.23 48.67 207 16 256c26.42 44 62.56 89.24 100.2 115.18C159.38 400.92 206.33 416 255.76 416c49 0 95.85-15.07 139.3-44.79C433.31 345 469.71 299.82 496 256c-26.38-43.43-62.9-88.56-101.18-114.82zM256 352a96 96 0 1196-96 96.11 96.11 0 01-96 96z" />
+    </Svg>
+  );
+}

--- a/mobile/src/icons/EyeOff.tsx
+++ b/mobile/src/icons/EyeOff.tsx
@@ -1,0 +1,16 @@
+import Svg, { Path } from "react-native-svg";
+
+import { useTheme } from "@/hooks/useTheme";
+import type { Icon } from "./type";
+
+// From ionicons.
+export function EyeOff({ size = 24, color }: Icon) {
+  const { foreground } = useTheme();
+  const usedColor = color ?? foreground;
+  return (
+    <Svg width={size} height={size} viewBox="0 0 512 512" fill={usedColor}>
+      <Path d="M63.998 86.004l21.998-21.998L448 426.01l-21.998 21.998zM259.34 192.09l60.57 60.57a64.07 64.07 0 00-60.57-60.57zM252.66 319.91l-60.57-60.57a64.07 64.07 0 0060.57 60.57z" />
+      <Path d="M256 352a96 96 0 01-92.6-121.34l-69.07-69.08C66.12 187.42 39.24 221.14 16 256c26.42 44 62.56 89.24 100.2 115.18C159.38 400.92 206.33 416 255.76 416A233.47 233.47 0 00335 402.2l-53.61-53.6A95.84 95.84 0 01256 352zM256 160a96 96 0 0192.6 121.34L419.26 352c29.15-26.25 56.07-61.56 76.74-96-26.38-43.43-62.9-88.56-101.18-114.82C351.1 111.2 304.31 96 255.76 96a222.92 222.92 0 00-78.21 14.29l53.11 53.11A95.84 95.84 0 01256 160z" />
+    </Svg>
+  );
+}

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -52,8 +52,9 @@ interface UserPreferencesStore {
   setNowPlayingDesign: (
     newDesign: UserPreferencesStore["nowPlayingDesign"],
   ) => void;
+
   /** Order of tabs on the home screen. */
-  homeTabsOrder: Array<(typeof OrderableTabs)[number]>;
+  tabsOrder: Array<(typeof OrderableTabs)[number]>;
   moveTab: (fromIndex: number, toIndex: number) => void;
 
   /** Minimum number of seconds a track needs to have to be saved. */
@@ -111,10 +112,11 @@ export const userPreferencesStore =
 
       nowPlayingDesign: "vinyl",
       setNowPlayingDesign: (newDesign) => set({ nowPlayingDesign: newDesign }),
-      homeTabsOrder: ["folder", "playlist", "track", "album", "artist"],
+
+      tabsOrder: ["folder", "playlist", "track", "album", "artist"],
       moveTab: (fromIndex: number, toIndex: number) => {
-        set(({ homeTabsOrder }) => ({
-          homeTabsOrder: moveArray(homeTabsOrder, { fromIndex, toIndex }),
+        set(({ tabsOrder }) => ({
+          tabsOrder: moveArray(tabsOrder, { fromIndex, toIndex }),
         }));
       },
 

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -20,13 +20,7 @@ export const FontOptions = ["NDot", "NType", "Roboto"] as const;
 /** Options for "Now Playing" screen designs. */
 export const NowPlayingDesignOptions = ["vinyl", "plain"] as const;
 /** Options for the tabs we can reorder. */
-export const OrderableTabs = [
-  "album",
-  "artist",
-  "folder",
-  "playlist",
-  "track",
-] as const;
+export type OrderableTab = "album" | "artist" | "folder" | "playlist" | "track";
 
 //#region Zustand Store
 //#region UserPreferencesStore Interface
@@ -54,8 +48,11 @@ interface UserPreferencesStore {
   ) => void;
 
   /** Order of tabs on the home screen. */
-  tabsOrder: Array<(typeof OrderableTabs)[number]>;
+  tabsOrder: OrderableTab[];
   moveTab: (fromIndex: number, toIndex: number) => void;
+  /** Visibility of the tabs on the home screen. */
+  tabsVisibility: Record<OrderableTab, boolean>;
+  toggleTabVisibility: (tab: OrderableTab) => void;
 
   /** Minimum number of seconds a track needs to have to be saved. */
   minSeconds: number;
@@ -79,6 +76,8 @@ const OMITTED_FIELDS: string[] = [
   "setTheme",
   "setAccentFont",
   "setNowPlayingDesign",
+  "moveTab",
+  "toggleTabVisibility",
   "setVolume",
 ] satisfies Array<keyof UserPreferencesStore>;
 //#endregion
@@ -97,7 +96,7 @@ export const userPreferencesStore =
           const usedLanguage = i18next.resolvedLanguage;
           // Ensured the resolved value exists.
           const exists = LANGUAGES.some((l) => l.code === usedLanguage);
-          state.setLanguage(exists && usedLanguage ? usedLanguage : "en");
+          set({ language: exists && usedLanguage ? usedLanguage : "en" });
         }
         set({ _hasHydrated: true });
       },
@@ -117,6 +116,18 @@ export const userPreferencesStore =
       moveTab: (fromIndex: number, toIndex: number) => {
         set(({ tabsOrder }) => ({
           tabsOrder: moveArray(tabsOrder, { fromIndex, toIndex }),
+        }));
+      },
+      tabsVisibility: {
+        album: true,
+        artist: true,
+        folder: true,
+        playlist: true,
+        track: true,
+      },
+      toggleTabVisibility: (tab) => {
+        set(({ tabsVisibility }) => ({
+          tabsVisibility: { ...tabsVisibility, [tab]: !tabsVisibility[tab] },
         }));
       },
 

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -164,6 +164,19 @@ export const userPreferencesStore =
 export const useUserPreferencesStore = <T>(
   selector: (state: UserPreferencesStore) => T,
 ): T => useStore(userPreferencesStore, selector);
+
+/** Return tabs that are displayed or hidden. */
+export function useTabsByVisibility() {
+  const tabsOrder = useUserPreferencesStore((state) => state.tabsOrder);
+  const tabsVisibility = useUserPreferencesStore(
+    (state) => state.tabsVisibility,
+  );
+
+  return {
+    displayedTabs: tabsOrder.filter((tabName) => tabsVisibility[tabName]),
+    hiddenTabs: tabsOrder.filter((tabName) => !tabsVisibility[tabName]),
+  };
+}
 //#endregion
 //#endregion
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds the ability to hide tabs. Though a problem with the current set up is that **it's impossible to make the hidden route accessible under a different navigator**. This is important as it prevents any unexpected behavior caused by the route being disabled. From exploring information about `expo-router`, the idea that I have (ie: conditionally rendering routes to ignore file-based routing) doesn't work, so we need to explore potentially switching everything over to `react-navigation`.

The idea I had was:
```
- (home)
  - index
  - folder
  - playlist
  - track
  - album
  - artist
- (hidden)
  - folder
  - playlist
  - track
  - album
  - artist
```

If we hide the "album" & "artist" route, we want to conditionally render those routes under the "(hidden)" group, which uses a different navigator (to prevent the swipe navigation from picking up those routes in the "(home)" group).

Conditionally rendering the routes in the expo router navigators doesn't work - for the Material Top Tabs (swipe navigation on the home screen), if we don't register the screen, it'll be put at the end of the tabs. We can put a `redirect` prop on the screen to prevent it from being seen, but this doesn't exactly "hide" the route which would allow us to go to the same-named route, but in a different navigator.

## Some Edge Case Checks

> Deleting a playlist when we've hidden the `/playlist` route (we can access a playlist through the main "Home" and the "Now Playing" screens).

I think in version 1, we explicitly went to `/playlist`, but we changed it call `back()` twice, so everything is fine.

> Hiding the screen we were last on before going to "Settings > Appearance > Home Tabs Order".

The navigator automatically boots us to the screen determined by `initialRouteName`, so things are sort of fine, but the history is a bit messed up since the "back" gesture would go 2 routes back from the screen we hidden. To eliminate this behavior, we just reset the history to just only have the initial route (which is the "Home" screen).

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
