### PR TITLE
fix: Duplicate albums caused by album not having an associated year

### DIFF
--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -8,6 +8,7 @@ import { useGetColumn } from "~/hooks/useGetColumn";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
 import { cn } from "~/lib/style";
+import { isYearDefined } from "~/utils/number";
 import { FlashList } from "~/components/Defaults";
 import { PagePlaceholder } from "~/components/Transition/Placeholder";
 import { TEm } from "~/components/Typography/StyledText";
@@ -76,7 +77,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
             source={item.artwork}
             href={`/album/${item.id}`}
             title={item.name}
-            description={`${item.releaseYear ?? "————"}`}
+            description={`${isYearDefined(item.releaseYear) ? item.releaseYear : "————"}`}
             className={index > 0 ? "ml-3" : undefined}
           />
         )}

--- a/mobile/src/db/drizzle/0006_wild_gabe_jones.sql
+++ b/mobile/src/db/drizzle/0006_wild_gabe_jones.sql
@@ -1,0 +1,16 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_albums` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`artist_name` text NOT NULL,
+	`release_year` integer DEFAULT -1,
+	`artwork` text,
+	`is_favorite` integer DEFAULT false NOT NULL,
+	FOREIGN KEY (`artist_name`) REFERENCES `artists`(`name`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_albums`("id", "name", "artist_name", "release_year", "artwork", "is_favorite") SELECT "id", "name", "artist_name", "release_year", "artwork", "is_favorite" FROM `albums`;--> statement-breakpoint
+DROP TABLE `albums`;--> statement-breakpoint
+ALTER TABLE `__new_albums` RENAME TO `albums`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `albums_name_artist_name_release_year_unique` ON `albums` (`name`,`artist_name`,`release_year`);

--- a/mobile/src/db/drizzle/meta/0006_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,460 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "35a319be-980b-43c4-af1f-a8217a06258c",
+  "prevId": "8c1393ab-971b-4a46-9d55-30c827f93cd4",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": -1
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "albums_name_artist_name_release_year_unique": {
+          "name": "albums_name_artist_name_release_year_unique",
+          "columns": [
+            "name",
+            "artist_name",
+            "release_year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1734926347792,
       "tag": "0005_equal_cerise",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1738535238286,
+      "tag": "0006_wild_gabe_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -7,6 +7,7 @@ import m0002 from "./0002_third_giant_man.sql";
 import m0003 from "./0003_breezy_wolverine.sql";
 import m0004 from "./0004_past_starfox.sql";
 import m0005 from "./0005_equal_cerise.sql";
+import m0006 from "./0006_wild_gabe_jones.sql";
 
 export default {
   journal,
@@ -17,5 +18,6 @@ export default {
     m0003,
     m0004,
     m0005,
+    m0006,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -33,7 +33,11 @@ export const albums = sqliteTable(
     artistName: text("artist_name")
       .notNull()
       .references(() => artists.name),
-    releaseYear: integer("release_year"),
+    /*
+      FIXME: This is technically `.notNull()`, but the migration will fail
+      for users who have "duplicate" album where `releaseYear = null`.
+    */
+    releaseYear: integer("release_year").default(-1),
     artwork: text(),
     isFavorite: integer({ mode: "boolean" }).notNull().default(false),
   },

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -10,7 +10,7 @@ import type {
 
 import i18next from "~/modules/i18n";
 
-import { formatSeconds } from "~/utils/number";
+import { formatSeconds, isYearDefined } from "~/utils/number";
 import { omitKeys } from "~/utils/object";
 import type { AtLeast, Prettify } from "~/utils/types";
 import { ReservedNames, ReservedPlaylists } from "~/modules/media/constants";
@@ -125,7 +125,7 @@ export function formatForCurrentScreen({ type, data, t }: ScreenFormatter) {
       data.tracks.reduce((total, curr) => total + curr.duration, 0),
     ),
   ];
-  if (type === "album" && data.releaseYear) {
+  if (type === "album" && isYearDefined(data.releaseYear)) {
     metadata.unshift(String(data.releaseYear));
   }
 

--- a/mobile/src/modules/scanning/constants.ts
+++ b/mobile/src/modules/scanning/constants.ts
@@ -3,6 +3,7 @@ const MigrationOptions = [
   "v1-to-v2-schema",
   "no-track-playlist-ref",
   "recheck-invalid-tracks",
+  "fix-null-releaseYear",
 ] as const;
 
 export type MigrationOption = (typeof MigrationOptions)[number];
@@ -30,5 +31,8 @@ export const MigrationHistory: Record<
     changes: ["v1-to-v2-store", "v1-to-v2-schema"],
   },
   4: { version: "v2.0.1", changes: ["no-track-playlist-ref"] },
-  5: { version: "v2.1.1-rc.1", changes: ["recheck-invalid-tracks"] },
+  5: {
+    version: "v2.1.1-rc.1",
+    changes: ["recheck-invalid-tracks", "fix-null-releaseYear"],
+  },
 };

--- a/mobile/src/modules/scanning/helpers/_album-fracturization.ts
+++ b/mobile/src/modules/scanning/helpers/_album-fracturization.ts
@@ -1,0 +1,77 @@
+import { inArray, isNull } from "drizzle-orm";
+
+import { db } from "~/db";
+import { albums, tracks } from "~/db/schema";
+
+import { getAlbums } from "~/api/album";
+
+import { musicStore } from "~/modules/media/services/Music";
+
+type UniqueFields = { name: string; artistName: string };
+
+/**
+ * Fix album fracturization caused by having `null` in the `releaseYear`
+ * field as in SQL, `null !== null`.
+ */
+export async function fixAlbumFracturization() {
+  const nullYearAlbums = await getAlbums({
+    where: [isNull(albums.releaseYear)],
+    columns: ["id", "name", "artistName"],
+    withTracks: false,
+  });
+
+  // Find which `name` + `artistName` combinations have been duplicated
+  // with `releaseYear = null`.
+  let duplicateCombos: Array<{ key: UniqueFields; ids: string[] }> = [];
+  nullYearAlbums.forEach((al, idx) => {
+    // See if we found this album earlier.
+    const existsIdx = duplicateCombos.findIndex((dupAl) =>
+      doesAlbumCopyExists(al, dupAl.key),
+    );
+    if (existsIdx !== -1) {
+      duplicateCombos[existsIdx]!.ids.push(al.id);
+      return;
+    }
+    // Don't need to check last index for duplicate.
+    if (idx === nullYearAlbums.length - 1) return;
+    // See if this album appears again later on.
+    const exists = [...nullYearAlbums]
+      .slice(idx + 1)
+      .some((al2) => doesAlbumCopyExists(al, al2));
+    if (exists) {
+      duplicateCombos.push({
+        key: { name: al.name, artistName: al.artistName },
+        ids: [al.id],
+      });
+    }
+  });
+
+  // Replace ids of tracks.
+  await Promise.allSettled(
+    duplicateCombos.map(async ({ ids }) => {
+      const [to, ...from] = ids;
+      if (!to) return;
+      await db.transaction(async (tx) => {
+        await tx
+          .update(tracks)
+          .set({ albumId: to })
+          .where(inArray(tracks.albumId, from));
+        // Delete replaced albums.
+        await tx.delete(albums).where(inArray(albums.id, from));
+      });
+    }),
+  );
+
+  // Ensure `releaseYear` is `-1` if `null`.
+  await db
+    .update(albums)
+    .set({ releaseYear: -1 })
+    .where(isNull(albums.releaseYear));
+
+  // Clear playback store in case the album that got fixed was being played.
+  await musicStore.getState().reset();
+}
+
+function doesAlbumCopyExists(album1: UniqueFields, album2: UniqueFields) {
+  return album1.name === album2.name && album1.artistName === album2.artistName;
+}

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -223,7 +223,7 @@ async function getTrackEntry({
     const newAlbum = await upsertAlbum({
       name: meta.albumTitle,
       artistName: meta.albumArtist,
-      releaseYear: meta.year,
+      releaseYear: meta.year ?? undefined,
     });
     if (newAlbum) albumId = newAlbum.id;
   }

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -213,7 +213,7 @@ async function getTrackEntry({
   await Promise.allSettled(
     [meta.artist, meta.albumArtist]
       .filter((name) => name !== null)
-      .map((name) => createArtist({ name })),
+      .map((name) => createArtist({ name: name.trim() })),
   );
 
   // Add new album to the database. The unique key on `Album` covers the rare
@@ -221,16 +221,16 @@ async function getTrackEntry({
   let albumId: string | null = null;
   if (!!meta.albumTitle && !!meta.albumArtist) {
     const newAlbum = await upsertAlbum({
-      name: meta.albumTitle,
-      artistName: meta.albumArtist,
-      releaseYear: meta.year ?? undefined,
+      name: meta.albumTitle.trim(),
+      artistName: meta.albumArtist.trim(),
+      releaseYear: meta.year ?? -1,
     });
     if (newAlbum) albumId = newAlbum.id;
   }
 
   return {
-    ...{ id, name: meta.title ?? removeFileExtension(filename) },
-    ...{ artistName: meta.artist, albumId, track: meta.trackNumber },
+    ...{ id, name: meta.title?.trim() ?? removeFileExtension(filename) },
+    ...{ artistName: meta.artist?.trim(), albumId, track: meta.trackNumber },
     ...{ disc: meta.discNumber, format: meta.sampleMimeType, bitrate },
     ...{ sampleRate, duration, uri, modificationTime, fetchedArt: false },
     ...{ size: assetInfo.exists ? (assetInfo.size ?? 0) : 0 },

--- a/mobile/src/modules/scanning/helpers/migrations.ts
+++ b/mobile/src/modules/scanning/helpers/migrations.ts
@@ -9,6 +9,7 @@ import { removeInvalidTrackRelations } from "~/api/track";
 import { recentListStore } from "~/modules/media/services/RecentList";
 import { userPreferencesStore } from "~/services/UserPreferences";
 
+import { fixAlbumFracturization } from "./_album-fracturization";
 import type { MigrationOption } from "../constants";
 import { MigrationHistory } from "../constants";
 import type { PlayListSource } from "../../media/types";
@@ -86,6 +87,8 @@ export const MigrationFunctionMap: Record<
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(invalidTracks);
   },
+  /** Fix album fracturization caused by `releaseYear = null`. */
+  "fix-null-releaseYear": fixAlbumFracturization,
 };
 
 /** Helper to parse value from AsyncStorage. */

--- a/mobile/src/utils/number.ts
+++ b/mobile/src/utils/number.ts
@@ -68,3 +68,8 @@ function pushTimeSegment(
     arr.length === 0 ? `${length}` : `${length}`.padStart(2, `0`);
   arr.push(lengthStr + (suffix ?? ""));
 }
+
+/** Determines if a year is defined. */
+export function isYearDefined(year: number | null) {
+  return year !== null && year !== -1;
+}

--- a/mobile/src/utils/string.ts
+++ b/mobile/src/utils/string.ts
@@ -5,7 +5,7 @@ export function addTrailingSlash(path: string) {
 
 /** Removes the file extension from a filename. */
 export function removeFileExtension(filename: string) {
-  return filename.split(".").slice(0, -1).join(".");
+  return filename.split(".").slice(0, -1).join(".").trim();
 }
 
 /** @description Capitalize first letter of string. */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

In SQL, it's considered a pretty bad idea to have a column with `null` as a potential value be part of a unique key as `null != null`. Some references:
- https://stackoverflow.com/a/43828095
- https://stackoverflow.com/a/22699498

In our case, an issue arises because we do use a column with potentially `null` values for the Album unique key (in the form of the `releaseYear` column). This would then cause the duplicate album behavior to occur. This never got caught by me as all my tracks are properly tagged, so I never encountered the issue where I had an album with no associated release year.

This fixes the original issue in #160.

In addition, we trim important information such as track name, album name, artist name, and album artist name in the situation where there's extra spaces on either end that might break uniqueness.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
