### PR TITLE
perf: Improve search modal open speed for users with lots of tracks

### DIFF
--- a/mobile/src/api/playlist.ts
+++ b/mobile/src/api/playlist.ts
@@ -5,7 +5,6 @@ import type {
   Playlist,
   PlaylistWithJunction,
   PlaylistWithTracks,
-  TrackWithAlbum,
 } from "~/db/schema";
 import { playlists, tracksToPlaylists } from "~/db/schema";
 import { sanitizePlaylistName } from "~/db/utils";
@@ -128,7 +127,7 @@ export const getSpecialPlaylist = _getSpecialPlaylist();
 //#region POST Methods
 /** Create a new playlist entry. */
 export async function createPlaylist(
-  entry: typeof playlists.$inferInsert & { tracks?: TrackWithAlbum[] },
+  entry: typeof playlists.$inferInsert & { tracks?: Array<{ id: string }> },
 ) {
   const { tracks, name, ...newPlaylist } = entry;
   const playlistName = sanitizePlaylistName(name);
@@ -180,7 +179,7 @@ export async function moveInPlaylist(info: {
 export async function updatePlaylist(
   id: string,
   values: Partial<typeof playlists.$inferInsert> & {
-    tracks?: TrackWithAlbum[];
+    tracks?: Array<{ id: string }>;
   },
 ) {
   const { tracks, name, ...rest } = values;

--- a/mobile/src/api/track.ts
+++ b/mobile/src/api/track.ts
@@ -7,6 +7,7 @@ import { getTrackCover } from "~/db/utils";
 
 import i18next from "~/modules/i18n";
 
+import { iAsc } from "~/lib/drizzle";
 import type { BooleanPriority } from "~/utils/types";
 import type { DrizzleFilter, QueriedTrack } from "./types";
 import { getColumns, withAlbum } from "./utils";
@@ -64,6 +65,7 @@ export async function getTracks<
     where: and(...(options?.where ?? [])),
     columns: getColumns(options?.columns),
     ...withAlbum({ defaultWithAlbum: true, ...options }),
+    orderBy: (fields) => iAsc(fields.name),
   });
   const hasArtwork =
     // @ts-expect-error - `options.columns` is defined.

--- a/mobile/src/db/slimTypes.ts
+++ b/mobile/src/db/slimTypes.ts
@@ -1,0 +1,27 @@
+import type { Album, Artist, Playlist, Track } from "~/db/schema";
+
+/** What the `artwork` field typically holds. */
+export type Artwork = string | null;
+
+/** Minimum fields required to get `artwork` from tracks. */
+export type TrackArtwork = {
+  artwork: Artwork;
+  album?: { artwork: Artwork } | null;
+};
+
+/** Minimum data typically used from `Album`. */
+export type SlimAlbum = Pick<Album, "id" | "name" | "artistName" | "artwork">;
+export type SlimAlbumWithTracks = SlimAlbum & { tracks: SlimTrack[] };
+
+/** Minimum data typically used from `Artist`. */
+export type SlimArtist = Pick<Artist, "name" | "artwork">;
+
+/** Minimum data typically used from `Playlist`. */
+export type SlimPlaylist = Pick<Playlist, "name" | "artwork">;
+export type SlimPlaylistWithTracks = SlimPlaylist & { tracks: TrackArtwork[] };
+
+/** Minimum data typically used from `Track`. */
+export type SlimTrack = Pick<Track, "id" | "name" | "artistName" | "artwork">;
+export type SlimTrackWithAlbum = SlimTrack & {
+  album: { name: string; artwork: Artwork } | null;
+};

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -7,6 +7,13 @@ import type {
   Track,
   TrackWithAlbum,
 } from "./schema";
+import type {
+  Artwork,
+  SlimAlbum,
+  SlimArtist,
+  SlimPlaylistWithTracks,
+  TrackArtwork,
+} from "./slimTypes";
 
 import i18next from "~/modules/i18n";
 
@@ -17,11 +24,6 @@ import { ReservedNames, ReservedPlaylists } from "~/modules/media/constants";
 import type { MediaCard } from "~/modules/media/components/MediaCard";
 import type { Track as TrackC } from "~/modules/media/components/Track";
 import type { MediaType } from "~/modules/media/types";
-
-//#region Slim Types
-type Artwork = string | null;
-type TrackArtwork = { artwork: Artwork; album?: { artwork: Artwork } | null };
-//#endregion
 
 //#region Artwork Formatters
 /** Get the cover of a playlist. */
@@ -53,16 +55,11 @@ export function mergeTracks<TData extends { id: string }>(
 //#endregion
 
 //#region Format for Component
-type MediaCardData<T = {}> = {
-  name: string;
-  artwork: Artwork;
-  tracks: any[];
-} & T;
 type MediaCardFormatter = Prettify<
   { t: TFunction } & (
-    | { type: "artist"; data: MediaCardData }
-    | { type: "album"; data: MediaCardData<{ id: string; artistName: string }> }
-    | { type: "playlist"; data: MediaCardData<{ tracks: TrackArtwork[] }> }
+    | { type: "artist"; data: SlimArtist & { tracks: any[] } }
+    | { type: "album"; data: SlimAlbum & { tracks: any[] } }
+    | { type: "playlist"; data: SlimPlaylistWithTracks }
   )
 >;
 

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -4,11 +4,11 @@ import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import type {
-  AlbumWithTracks,
-  ArtistWithTracks,
-  PlaylistWithTracks,
-  TrackWithAlbum,
-} from "~/db/schema";
+  SlimAlbumWithTracks,
+  SlimArtist,
+  SlimPlaylistWithTracks,
+  SlimTrackWithAlbum,
+} from "~/db/slimTypes";
 import { getPlaylistCover, getTrackCover } from "~/db/utils";
 
 import { Close } from "~/icons/Close";
@@ -159,10 +159,10 @@ function formatResults(results: Partial<SearchResults>) {
 }
 
 type MediaRelations =
-  | { type: "album"; data: AlbumWithTracks }
-  | { type: "artist"; data: ArtistWithTracks }
-  | { type: "playlist"; data: PlaylistWithTracks }
-  | { type: "track"; data: TrackWithAlbum };
+  | { type: "album"; data: SlimAlbumWithTracks }
+  | { type: "artist"; data: SlimArtist }
+  | { type: "playlist"; data: SlimPlaylistWithTracks }
+  | { type: "track"; data: SlimTrackWithAlbum };
 
 /** Get the artwork of the media that'll be displayed. */
 function getArtwork(props: MediaRelations) {

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -39,7 +39,7 @@ async function getAllMedia() {
   return {
     album: await getAlbums({
       columns: ["id", "name", "artistName", "artwork"],
-      withTracks: false,
+      trackColumns: ["id", "name", "artistName", "artwork"],
     }),
     artist: await getArtists({
       columns: ["name", "artwork"],
@@ -54,7 +54,7 @@ async function getAllMedia() {
       columns: ["id", "name", "artistName", "artwork"],
       albumColumns: ["artwork"],
     }),
-  };
+  } satisfies SearchResults;
 }
 
 const queryKey = ["search"];

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -52,7 +52,7 @@ async function getAllMedia() {
     }),
     track: await getTracks({
       columns: ["id", "name", "artistName", "artwork"],
-      albumColumns: ["artwork"],
+      albumColumns: ["name", "artwork"],
     }),
   } satisfies SearchResults;
 }

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -37,10 +37,23 @@ export function useSearch<TScope extends SearchCategories>(
 //#region Helpers
 async function getAllMedia() {
   return {
-    album: await getAlbums(),
-    artist: await getArtists(),
-    playlist: await getPlaylists(),
-    track: await getTracks(),
+    album: await getAlbums({
+      columns: ["id", "name", "artistName", "artwork"],
+      withTracks: false,
+    }),
+    artist: await getArtists({
+      columns: ["name", "artwork"],
+      withTracks: false,
+    }),
+    playlist: await getPlaylists({
+      columns: ["name", "artwork"],
+      trackColumns: ["artwork"],
+      albumColumns: ["artwork"],
+    }),
+    track: await getTracks({
+      columns: ["id", "name", "artistName", "artwork"],
+      albumColumns: ["artwork"],
+    }),
   };
 }
 

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -40,7 +40,7 @@ async function getAllMedia() {
     album: await getAlbums(),
     artist: await getArtists(),
     playlist: await getPlaylists(),
-    track: (await getTracks()).sort((a, b) => a.name.localeCompare(b.name)),
+    track: await getTracks(),
   };
 }
 

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -11,7 +11,10 @@ type TrackArtwork = { artwork: Artwork; album?: { artwork: Artwork } | null };
 export type SearchCategories = ReadonlyArray<Exclude<MediaType, "folder">>;
 
 /** Minimum data returned for album for search. */
-export type SearchAlbum = Pick<Album, "id" | "name" | "artistName" | "artwork">;
+export type SearchAlbum = Pick<
+  Album,
+  "id" | "name" | "artistName" | "artwork"
+> & { tracks: SearchTrack[] };
 /** Minimum data returned for artist for search. */
 export type SearchArtist = Pick<Artist, "name" | "artwork">;
 /** Minimum data returned for playlist for search. */
@@ -19,10 +22,10 @@ export type SearchPlaylist = Pick<Playlist, "name" | "artwork"> & {
   tracks: TrackArtwork[];
 };
 /** Minimum data returned for track for search. */
-export type SearchTrack = Pick<
-  Track,
-  "id" | "name" | "artistName" | "artwork"
-> & { album?: Artwork };
+export type SearchTrack = Pick<Track, "id" | "name" | "artistName" | "artwork">;
+export type SearchTrackWithAlbum = SearchTrack & {
+  album: { artwork: Artwork } | null;
+};
 
 /** Functions that can be triggered on the categories of media. */
 export type SearchCallbacks = {
@@ -30,7 +33,7 @@ export type SearchCallbacks = {
   artist: (artist: SearchArtist) => void | Promise<void>;
   // folder: (folder: unknown) => void | Promise<void>;
   playlist: (playlist: SearchPlaylist) => void | Promise<void>;
-  track: (track: SearchTrack) => void | Promise<void>;
+  track: (track: SearchTrackWithAlbum) => void | Promise<void>;
 };
 
 /** Data that can be returned from search. */
@@ -39,5 +42,5 @@ export type SearchResults = {
   artist: SearchArtist[];
   // folder: unknown[];
   playlist: SearchPlaylist[];
-  track: SearchTrack[];
+  track: SearchTrackWithAlbum[];
 };

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -24,7 +24,7 @@ export type SearchPlaylist = Pick<Playlist, "name" | "artwork"> & {
 /** Minimum data returned for track for search. */
 export type SearchTrack = Pick<Track, "id" | "name" | "artistName" | "artwork">;
 export type SearchTrackWithAlbum = SearchTrack & {
-  album: { artwork: Artwork } | null;
+  album: { name: string; artwork: Artwork } | null;
 };
 
 /** Functions that can be triggered on the categories of media. */

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -1,29 +1,43 @@
-import type {
-  AlbumWithTracks,
-  ArtistWithTracks,
-  PlaylistWithTracks,
-  TrackWithAlbum,
-} from "~/db/schema";
+import type { Album, Artist, Playlist, Track } from "~/db/schema";
 
 import type { MediaType } from "~/modules/media/types";
+
+//#region Slim Types
+type Artwork = string | null;
+type TrackArtwork = { artwork: Artwork; album?: { artwork: Artwork } | null };
+//#endregion
 
 /** Categories of media that can be returned by search. */
 export type SearchCategories = ReadonlyArray<Exclude<MediaType, "folder">>;
 
+/** Minimum data returned for album for search. */
+export type SearchAlbum = Pick<Album, "id" | "name" | "artistName" | "artwork">;
+/** Minimum data returned for artist for search. */
+export type SearchArtist = Pick<Artist, "name" | "artwork">;
+/** Minimum data returned for playlist for search. */
+export type SearchPlaylist = Pick<Playlist, "name" | "artwork"> & {
+  tracks: TrackArtwork[];
+};
+/** Minimum data returned for track for search. */
+export type SearchTrack = Pick<
+  Track,
+  "id" | "name" | "artistName" | "artwork"
+> & { album?: Artwork };
+
 /** Functions that can be triggered on the categories of media. */
 export type SearchCallbacks = {
-  album: (album: AlbumWithTracks) => void | Promise<void>;
-  artist: (artist: ArtistWithTracks) => void | Promise<void>;
+  album: (album: SearchAlbum) => void | Promise<void>;
+  artist: (artist: SearchArtist) => void | Promise<void>;
   // folder: (folder: unknown) => void | Promise<void>;
-  playlist: (playlist: PlaylistWithTracks) => void | Promise<void>;
-  track: (track: TrackWithAlbum) => void | Promise<void>;
+  playlist: (playlist: SearchPlaylist) => void | Promise<void>;
+  track: (track: SearchTrack) => void | Promise<void>;
 };
 
 /** Data that can be returned from search. */
 export type SearchResults = {
-  album: AlbumWithTracks[];
-  artist: ArtistWithTracks[];
+  album: SearchAlbum[];
+  artist: SearchArtist[];
   // folder: unknown[];
-  playlist: PlaylistWithTracks[];
-  track: TrackWithAlbum[];
+  playlist: SearchPlaylist[];
+  track: SearchTrack[];
 };

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -1,46 +1,29 @@
-import type { Album, Artist, Playlist, Track } from "~/db/schema";
+import type {
+  SlimAlbumWithTracks,
+  SlimArtist,
+  SlimPlaylistWithTracks,
+  SlimTrackWithAlbum,
+} from "~/db/slimTypes";
 
 import type { MediaType } from "~/modules/media/types";
-
-//#region Slim Types
-type Artwork = string | null;
-type TrackArtwork = { artwork: Artwork; album?: { artwork: Artwork } | null };
-//#endregion
 
 /** Categories of media that can be returned by search. */
 export type SearchCategories = ReadonlyArray<Exclude<MediaType, "folder">>;
 
-/** Minimum data returned for album for search. */
-export type SearchAlbum = Pick<
-  Album,
-  "id" | "name" | "artistName" | "artwork"
-> & { tracks: SearchTrack[] };
-/** Minimum data returned for artist for search. */
-export type SearchArtist = Pick<Artist, "name" | "artwork">;
-/** Minimum data returned for playlist for search. */
-export type SearchPlaylist = Pick<Playlist, "name" | "artwork"> & {
-  tracks: TrackArtwork[];
-};
-/** Minimum data returned for track for search. */
-export type SearchTrack = Pick<Track, "id" | "name" | "artistName" | "artwork">;
-export type SearchTrackWithAlbum = SearchTrack & {
-  album: { name: string; artwork: Artwork } | null;
-};
-
 /** Functions that can be triggered on the categories of media. */
 export type SearchCallbacks = {
-  album: (album: SearchAlbum) => void | Promise<void>;
-  artist: (artist: SearchArtist) => void | Promise<void>;
+  album: (album: SlimAlbumWithTracks) => void | Promise<void>;
+  artist: (artist: SlimArtist) => void | Promise<void>;
   // folder: (folder: unknown) => void | Promise<void>;
-  playlist: (playlist: SearchPlaylist) => void | Promise<void>;
-  track: (track: SearchTrackWithAlbum) => void | Promise<void>;
+  playlist: (playlist: SlimPlaylistWithTracks) => void | Promise<void>;
+  track: (track: SlimTrackWithAlbum) => void | Promise<void>;
 };
 
 /** Data that can be returned from search. */
 export type SearchResults = {
-  album: SearchAlbum[];
-  artist: SearchArtist[];
+  album: SlimAlbumWithTracks[];
+  artist: SlimArtist[];
   // folder: unknown[];
-  playlist: SearchPlaylist[];
-  track: SearchTrackWithAlbum[];
+  playlist: SlimPlaylistWithTracks[];
+  track: SlimTrackWithAlbum[];
 };

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
-import type { TrackWithAlbum, playlists } from "~/db/schema";
+import type { playlists } from "~/db/schema";
 import {
   getPlaylistCover,
   formatForCurrentScreen,
@@ -65,8 +65,10 @@ export function usePlaylistsForCards() {
 export function useCreatePlaylist() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (args: { playlistName: string; tracks?: TrackWithAlbum[] }) =>
-      createPlaylist({ name: args.playlistName, tracks: args.tracks }),
+    mutationFn: (args: {
+      playlistName: string;
+      tracks?: Array<{ id: string }>;
+    }) => createPlaylist({ name: args.playlistName, tracks: args.tracks }),
     onSuccess: () => {
       // Invalidate all playlist & track queries.
       queryClient.invalidateQueries({ queryKey: q.playlists._def });
@@ -128,7 +130,7 @@ export function useUpdatePlaylist(playlistName: string) {
     mutationFn: (
       updatedValues: Partial<
         Omit<typeof playlists.$inferInsert, "isFavorite">
-      > & { tracks?: TrackWithAlbum[] },
+      > & { tracks?: Array<{ id: string }> },
     ) => updatePlaylist(playlistName, updatedValues),
     onSuccess: async (_, { name, artwork, tracks }) => {
       // Invalidate all playlist queries.

--- a/mobile/src/screens/ModifyPlaylist/context.tsx
+++ b/mobile/src/screens/ModifyPlaylist/context.tsx
@@ -4,7 +4,6 @@ import type { StoreApi } from "zustand";
 import { createStore, useStore } from "zustand";
 import { createComputed } from "zustand-computed";
 
-import type { TrackWithAlbum } from "~/db/schema";
 import { mergeTracks, sanitizePlaylistName } from "~/db/utils";
 
 import i18next from "~/modules/i18n";
@@ -12,22 +11,32 @@ import i18next from "~/modules/i18n";
 import { ToastOptions } from "~/lib/toast";
 import { moveArray } from "~/utils/object";
 import { wait } from "~/utils/promise";
-import type { SearchCallbacks } from "~/modules/search/types";
+import type {
+  SearchCallbacks,
+  SearchTrackWithAlbum,
+} from "~/modules/search/types";
 
 type StoreModeOptions =
   | { mode?: "create"; initialName?: never; initialTracks?: never }
-  | { mode: "edit"; initialName: string; initialTracks: TrackWithAlbum[] };
+  | {
+      mode: "edit";
+      initialName: string;
+      initialTracks: SearchTrackWithAlbum[];
+    };
 
 export type InitStoreProps = StoreModeOptions & {
   usedNames: string[];
-  onSubmit: (playlistName: string, tracks: TrackWithAlbum[]) => Promise<void>;
+  onSubmit: (
+    playlistName: string,
+    tracks: SearchTrackWithAlbum[],
+  ) => Promise<void>;
 };
 
 type PlaylistStore = InitStoreProps & {
   playlistName: string;
   setPlaylistName: (newName: string) => void;
 
-  tracks: TrackWithAlbum[];
+  tracks: SearchTrackWithAlbum[];
   moveTrack: (fromIndex: number, toIndex: number) => void;
   removeTrack: (id: string) => void;
 

--- a/mobile/src/screens/ModifyPlaylist/context.tsx
+++ b/mobile/src/screens/ModifyPlaylist/context.tsx
@@ -4,6 +4,7 @@ import type { StoreApi } from "zustand";
 import { createStore, useStore } from "zustand";
 import { createComputed } from "zustand-computed";
 
+import type { SlimTrackWithAlbum } from "~/db/slimTypes";
 import { mergeTracks, sanitizePlaylistName } from "~/db/utils";
 
 import i18next from "~/modules/i18n";
@@ -11,24 +12,21 @@ import i18next from "~/modules/i18n";
 import { ToastOptions } from "~/lib/toast";
 import { moveArray } from "~/utils/object";
 import { wait } from "~/utils/promise";
-import type {
-  SearchCallbacks,
-  SearchTrackWithAlbum,
-} from "~/modules/search/types";
+import type { SearchCallbacks } from "~/modules/search/types";
 
 type StoreModeOptions =
   | { mode?: "create"; initialName?: never; initialTracks?: never }
   | {
       mode: "edit";
       initialName: string;
-      initialTracks: SearchTrackWithAlbum[];
+      initialTracks: SlimTrackWithAlbum[];
     };
 
 export type InitStoreProps = StoreModeOptions & {
   usedNames: string[];
   onSubmit: (
     playlistName: string,
-    tracks: SearchTrackWithAlbum[],
+    tracks: SlimTrackWithAlbum[],
   ) => Promise<void>;
 };
 
@@ -36,7 +34,7 @@ type PlaylistStore = InitStoreProps & {
   playlistName: string;
   setPlaylistName: (newName: string) => void;
 
-  tracks: SearchTrackWithAlbum[];
+  tracks: SlimTrackWithAlbum[];
   moveTrack: (fromIndex: number, toIndex: number) => void;
   removeTrack: (id: string) => void;
 

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -6,8 +6,6 @@ import { BackHandler, Modal, Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
 import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
 
-import type { TrackWithAlbum } from "~/db/schema";
-
 import { Add } from "~/icons/Add";
 import { Cancel } from "~/icons/Cancel";
 import { CheckCircle } from "~/icons/CheckCircle";
@@ -30,6 +28,7 @@ import type { SwipeableRef } from "~/components/Swipeable";
 import { Swipeable } from "~/components/Swipeable";
 import { StyledText, TStyledText } from "~/components/Typography/StyledText";
 import { SearchResult } from "~/modules/search/components/SearchResult";
+import type { SearchTrackWithAlbum } from "~/modules/search/types";
 
 /** Resuable screen to modify (create or edit) a playlist. */
 export function ModifyPlaylist(props: InitStoreProps) {
@@ -78,7 +77,7 @@ function ScreenConfig() {
 
 //#region Page Content
 /** Items rendered in the `<DragList />`. */
-type RenderItemProps = DragListRenderItemInfo<TrackWithAlbum>;
+type RenderItemProps = DragListRenderItemInfo<SearchTrackWithAlbum>;
 
 /** Contains the logic for editing the playlist name and tracks. */
 function PageContent() {

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -6,6 +6,8 @@ import { BackHandler, Modal, Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
 import type { DragListRenderItemInfo } from "react-native-draglist/dist/FlashList";
 
+import type { SlimTrackWithAlbum } from "~/db/slimTypes";
+
 import { Add } from "~/icons/Add";
 import { Cancel } from "~/icons/Cancel";
 import { CheckCircle } from "~/icons/CheckCircle";
@@ -28,7 +30,6 @@ import type { SwipeableRef } from "~/components/Swipeable";
 import { Swipeable } from "~/components/Swipeable";
 import { StyledText, TStyledText } from "~/components/Typography/StyledText";
 import { SearchResult } from "~/modules/search/components/SearchResult";
-import type { SearchTrackWithAlbum } from "~/modules/search/types";
 
 /** Resuable screen to modify (create or edit) a playlist. */
 export function ModifyPlaylist(props: InitStoreProps) {
@@ -77,7 +78,7 @@ function ScreenConfig() {
 
 //#region Page Content
 /** Items rendered in the `<DragList />`. */
-type RenderItemProps = DragListRenderItemInfo<SearchTrackWithAlbum>;
+type RenderItemProps = DragListRenderItemInfo<SlimTrackWithAlbum>;
 
 /** Contains the logic for editing the playlist name and tracks. */
 function PageContent() {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

Similar to the issue with launch performance tanking due to returning more data than necessary, this issue also occurs when opening the search modal for tracks while on the create/modify playlists screen. This is because we fetch all types of media data (albums, artists, playlists, and tracks) without slimming it down.

Essentially, what's happening is that fetching the data is blocking the modal appear animation from running until that task is done. This issue doesn't occur on the "Search" screen.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
