### PR TITLE
chore: Restructure "Music" store & fix some flakey code

### DIFF
--- a/mobile/src/modules/media/helpers/data.ts
+++ b/mobile/src/modules/media/helpers/data.ts
@@ -3,11 +3,9 @@
  * Player Interface.
  */
 
-import { inArray } from "drizzle-orm";
 import type { AddTrack } from "react-native-track-player";
 
 import type { TrackWithAlbum } from "~/db/schema";
-import { tracks } from "~/db/schema";
 import { getTrackCover } from "~/db/utils";
 
 import i18next from "~/modules/i18n";
@@ -15,7 +13,6 @@ import { getAlbum } from "~/api/album";
 import { getArtist } from "~/api/artist";
 import { getFolderTracks } from "~/api/folder";
 import { getPlaylist, getSpecialPlaylist } from "~/api/playlist";
-import { getTracks } from "~/api/track";
 
 import type { ReservedPlaylistName } from "../constants";
 import { ReservedNames, ReservedPlaylists } from "../constants";
@@ -89,13 +86,4 @@ export async function getTrackList({ type, id }: PlayListSource) {
   } catch {}
 
   return sortedTracks;
-}
-
-/** Get list of tracks from track ids. */
-export async function getTracksFromIds(trackIds: string[]) {
-  if (trackIds.length === 0) return [];
-  const unorderedTracks = await getTracks({
-    where: [inArray(tracks.id, trackIds)],
-  });
-  return trackIds.map((tId) => unorderedTracks.find(({ id }) => id === tId));
 }

--- a/mobile/src/modules/media/helpers/data.ts
+++ b/mobile/src/modules/media/helpers/data.ts
@@ -97,5 +97,5 @@ export async function getTracksFromIds(trackIds: string[]) {
   const unorderedTracks = await getTracks({
     where: [inArray(tracks.id, trackIds)],
   });
-  return trackIds.map((tId) => unorderedTracks.find(({ id }) => id === tId)!);
+  return trackIds.map((tId) => unorderedTracks.find(({ id }) => id === tId));
 }

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -416,13 +416,14 @@ export class RNTPManager {
     }
     const playingTrack = await TrackPlayer.getActiveTrack();
     const { activeTrack, isInQueue, repeat } = musicStore.getState();
+    if (!activeTrack) return;
     // Update the current playing track (or restart the track).
-    if (playingTrack?.id !== activeTrack?.id || args?.restart) {
+    if (playingTrack?.id !== activeTrack.id || args?.restart) {
       // Identify how we'll load the track.
       const trackStatus: TrackStatus =
         repeat === "repeat-one" ? "REPEAT" : isInQueue ? "QUEUE" : "RELOAD";
       await TrackPlayer.load({
-        ...formatTrackforPlayer(activeTrack!),
+        ...formatTrackforPlayer(activeTrack),
         "music::status": trackStatus,
       });
       await TrackPlayer.seekTo(0);

--- a/mobile/src/modules/media/services/Playback.ts
+++ b/mobile/src/modules/media/services/Playback.ts
@@ -105,7 +105,7 @@ export async function playFromMediaList({
   source: PlayListSource;
   trackId?: string;
 }) {
-  const { shuffle, playingSource, activeId, activeTrack, currentPlayingList } =
+  const { shuffle, playingSource, activeId, activeTrack, currentList } =
     musicStore.getState();
 
   // 1. See if we're playing from a new media list.
@@ -118,7 +118,7 @@ export async function playFromMediaList({
     if (!!trackId && isDiffTrack) {
       // Find index of new track in list (let the `activeId` subscription
       // handle updating `activeTrack`).
-      const listIndex = currentPlayingList.findIndex((id) => id === trackId);
+      const listIndex = currentList.findIndex((id) => id === trackId);
       musicStore.setState({
         activeId: trackId,
         listIdx: listIndex,

--- a/mobile/src/modules/media/services/Playback.ts
+++ b/mobile/src/modules/media/services/Playback.ts
@@ -44,7 +44,7 @@ export class MusicControls {
 
   /** Play the previous track. */
   static async prev() {
-    const prevTrack = RNTPManager.getPrevTrack();
+    const prevTrack = await RNTPManager.getPrevTrack();
     // If no track is found, reset the state.
     if (prevTrack.activeTrack === undefined) {
       return await musicStore.getState().reset();
@@ -69,7 +69,7 @@ export class MusicControls {
   /** Play the next track. */
   static async next() {
     const repeatMode = musicStore.getState().repeat;
-    const { listIdx, ...nextTrack } = RNTPManager.getNextTrack();
+    const { listIdx, ...nextTrack } = await RNTPManager.getNextTrack();
     // Make sure we reset if we play from a source with no tracks left.
     if (!nextTrack.activeId) return await musicStore.getState().reset();
     musicStore.setState({
@@ -105,7 +105,7 @@ export async function playFromMediaList({
   source: PlayListSource;
   trackId?: string;
 }) {
-  const { shuffle, playingSource, activeId, activeTrack, currentTrackList } =
+  const { shuffle, playingSource, activeId, activeTrack, currentPlayingList } =
     musicStore.getState();
 
   // 1. See if we're playing from a new media list.
@@ -116,11 +116,11 @@ export async function playFromMediaList({
   if (isSameSource) {
     // Case where we play a different track in this media list.
     if (!!trackId && isDiffTrack) {
-      // Find index of new track in list.
-      const listIndex = currentTrackList.findIndex(({ id }) => id === trackId);
+      // Find index of new track in list (let the `activeId` subscription
+      // handle updating `activeTrack`).
+      const listIndex = currentPlayingList.findIndex((id) => id === trackId);
       musicStore.setState({
         activeId: trackId,
-        activeTrack: currentTrackList[listIndex],
         listIdx: listIndex,
         isInQueue: false,
       });

--- a/mobile/src/modules/media/services/_subscriptions.ts
+++ b/mobile/src/modules/media/services/_subscriptions.ts
@@ -1,13 +1,14 @@
-import { shallow } from "zustand/shallow";
-
-import { musicStore } from "./Music";
-import { sortPreferencesStore, sortTracks } from "./SortPreferences";
-
-import { ReservedPlaylists } from "../constants";
-
 /*
   Where we put subscriptions to avoid require cycles.
 */
+
+import { shallow } from "zustand/shallow";
+
+import { getSpecialPlaylist } from "~/api/playlist";
+import { musicStore } from "./Music";
+import { sortPreferencesStore } from "./SortPreferences";
+
+import { ReservedPlaylists } from "../constants";
 
 //#region Sort Preferences Store
 /**
@@ -16,16 +17,20 @@ import { ReservedPlaylists } from "../constants";
  */
 sortPreferencesStore.subscribe(
   (state) => ({ isAsc: state.isAsc, orderedBy: state.orderedBy }),
-  () => {
-    const { playingSource, listIdx, playingList, trackList, shuffle } =
+  async () => {
+    const { playingSource, listIdx, playingList, shuffle } =
       musicStore.getState();
     // Only trigger if we're playing all tracks.
     if (playingSource?.id !== ReservedPlaylists.tracks) return;
-    const sortedPlayingList = sortTracks(trackList).map(({ id }) => id);
+    const updatedTrackListInfo = await getSpecialPlaylist(
+      ReservedPlaylists.tracks,
+      { columns: [], trackColumns: ["id"], withAlbum: false },
+    );
+    const sortedPlayingList = updatedTrackListInfo.tracks.map((t) => t.id);
     // Compare if `playingList` is the same as `sortedPlayingList`.
     if (shallow(playingList, sortedPlayingList)) return;
     // We don't need to update `shuffledPlayingList` as order doesn't matter.
-    const prevId = playingList[listIdx]!;
+    const prevId = playingList[listIdx];
     const newListIdx = sortedPlayingList.findIndex((tId) => tId === prevId);
     musicStore.setState({
       playingList: sortedPlayingList,

--- a/mobile/src/providers/index.tsx
+++ b/mobile/src/providers/index.tsx
@@ -6,12 +6,11 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import "~/screens/Sheets";
+import { UpcomingStoreProvider } from "~/screens/Sheets/TrackUpcoming/context";
 import { RouteHandlers } from "./RouteHandlers";
 import { ThemeProvider } from "./ThemeProvider";
 
 import { queryClient } from "~/lib/react-query";
-
-import { UpcomingStoreProvider } from "~/screens/Sheets/TrackUpcoming/context";
 
 /** All providers used by the app. */
 export function AppProvider(props: { children: React.ReactNode }) {

--- a/mobile/src/providers/index.tsx
+++ b/mobile/src/providers/index.tsx
@@ -11,6 +11,8 @@ import { ThemeProvider } from "./ThemeProvider";
 
 import { queryClient } from "~/lib/react-query";
 
+import { UpcomingStoreProvider } from "~/screens/Sheets/TrackUpcoming/context";
+
 /** All providers used by the app. */
 export function AppProvider(props: { children: React.ReactNode }) {
   // NOTE: `expo-router` automatically adds `<SafeAreaProvider />`
@@ -20,10 +22,12 @@ export function AppProvider(props: { children: React.ReactNode }) {
       <GestureHandlerRootView>
         <QueryClientProvider client={queryClient}>
           <RouteHandlers />
-          <SheetProvider context="global">
-            <ChildrenWrapper {...props} />
-            <Toasts />
-          </SheetProvider>
+          <UpcomingStoreProvider>
+            <SheetProvider context="global">
+              <ChildrenWrapper {...props} />
+              <Toasts />
+            </SheetProvider>
+          </UpcomingStoreProvider>
         </QueryClientProvider>
       </GestureHandlerRootView>
     </ThemeProvider>

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -17,7 +17,7 @@ import { SearchResult } from "~/modules/search/components/SearchResult";
   FIXME: Temporary fix for now as we get rid of storing all tracks in the
   Zustand store.
     - If we were to have an "TrackWithAlbum[]", it'll probably sync with
-    `currentPlayingList`.
+    `currentList`.
 */
 import type { TrackWithAlbum } from "~/db/schema";
 const trackList: TrackWithAlbum[] = [];

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -21,6 +21,7 @@ import { SearchResult } from "~/modules/search/components/SearchResult";
 */
 import type { TrackWithAlbum } from "~/db/schema";
 const trackList: TrackWithAlbum[] = [];
+const queueList: TrackWithAlbum[] = [];
 
 /**
  * Sheet allowing us to see the upcoming tracks and remove tracks from
@@ -29,7 +30,7 @@ const trackList: TrackWithAlbum[] = [];
 export default function TrackUpcomingSheet() {
   const { t } = useTranslation();
   // const trackList = useMusicStore((state) => state.currentTrackList);
-  const queueList = useMusicStore((state) => state.queuedTrackList);
+  // const queueList = useMusicStore((state) => state.queuedTrackList);
   const listIndex = useMusicStore((state) => state.listIdx);
   const repeat = useMusicStore((state) => state.repeat);
 

--- a/mobile/src/screens/Sheets/TrackUpcoming.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming.tsx
@@ -13,13 +13,22 @@ import { Sheet } from "~/components/Sheet";
 import { Swipeable } from "~/components/Swipeable";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
+/*
+  FIXME: Temporary fix for now as we get rid of storing all tracks in the
+  Zustand store.
+    - If we were to have an "TrackWithAlbum[]", it'll probably sync with
+    `currentPlayingList`.
+*/
+import type { TrackWithAlbum } from "~/db/schema";
+const trackList: TrackWithAlbum[] = [];
+
 /**
  * Sheet allowing us to see the upcoming tracks and remove tracks from
  * the queue.
  */
 export default function TrackUpcomingSheet() {
   const { t } = useTranslation();
-  const trackList = useMusicStore((state) => state.currentTrackList);
+  // const trackList = useMusicStore((state) => state.currentTrackList);
   const queueList = useMusicStore((state) => state.queuedTrackList);
   const listIndex = useMusicStore((state) => state.listIdx);
   const repeat = useMusicStore((state) => state.repeat);

--- a/mobile/src/screens/Sheets/TrackUpcoming/context.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming/context.tsx
@@ -1,0 +1,84 @@
+import { inArray } from "drizzle-orm";
+import { createContext, useContext, useEffect, useRef } from "react";
+import type { StoreApi } from "zustand";
+import { createStore, useStore } from "zustand";
+
+import { tracks } from "~/db/schema";
+import type { Artwork, SlimTrack } from "~/db/slimTypes";
+
+import { getTracks } from "~/api/track";
+import { musicStore } from "~/modules/media/services/Music";
+
+type PartialTrack = SlimTrack & { album: { artwork: Artwork } | null };
+
+interface UpcomingStore {
+  currentTrackList: Array<PartialTrack | undefined>;
+  queuedTrackList: Array<PartialTrack | undefined>;
+}
+
+const UpcomingStoreContext = createContext<StoreApi<UpcomingStore>>(
+  null as never,
+);
+
+export function UpcomingStoreProvider(props: { children: React.ReactNode }) {
+  const storeRef = useRef<StoreApi<UpcomingStore>>();
+  if (!storeRef.current) {
+    storeRef.current = createStore<UpcomingStore>()(() => ({
+      currentTrackList: [],
+      queuedTrackList: [],
+    }));
+  }
+
+  useEffect(() => {
+    const unsubscribeCurrentList = musicStore.subscribe(
+      (state) => state.currentList,
+      async (currentList) => {
+        const listTracks = await getTracksFromIds(currentList);
+        storeRef.current?.setState({ currentTrackList: listTracks });
+      },
+      { fireImmediately: true },
+    );
+    const unsubscribeQueueList = musicStore.subscribe(
+      (state) => state.queueList,
+      async (queueList) => {
+        const listTracks = await getTracksFromIds(queueList);
+        storeRef.current?.setState({ queuedTrackList: listTracks });
+      },
+      { fireImmediately: true },
+    );
+
+    return () => {
+      unsubscribeCurrentList();
+      unsubscribeQueueList();
+    };
+  }, []);
+
+  return (
+    <UpcomingStoreContext.Provider value={storeRef.current}>
+      {props.children}
+    </UpcomingStoreContext.Provider>
+  );
+}
+
+export function useUpcomingStore<T>(selector: (state: UpcomingStore) => T) {
+  const store = useContext(UpcomingStoreContext);
+  if (!store) {
+    throw new Error(
+      "useUpcomingStore must be called within a UpcomingStoreProvider.",
+    );
+  }
+  return useStore(store, selector);
+}
+
+//#region Internal Helpers
+/** Get list of tracks from track ids. */
+async function getTracksFromIds(trackIds: string[]) {
+  if (trackIds.length === 0) return [];
+  const unorderedTracks = await getTracks({
+    where: [inArray(tracks.id, trackIds)],
+    columns: ["id", "name", "artistName", "artwork"],
+    albumColumns: ["artwork"],
+  });
+  return trackIds.map((tId) => unorderedTracks.find(({ id }) => id === tId));
+}
+//#endregion

--- a/mobile/src/screens/Sheets/TrackUpcoming/index.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming/index.tsx
@@ -4,6 +4,7 @@ import { getTrackCover } from "~/db/utils";
 
 import { Remove } from "~/icons/Remove";
 import { Queue, useMusicStore } from "~/modules/media/services/Music";
+import { useUpcomingStore } from "./context";
 
 import { Colors } from "~/constants/Styles";
 import { cn } from "~/lib/style";
@@ -13,24 +14,14 @@ import { Sheet } from "~/components/Sheet";
 import { Swipeable } from "~/components/Swipeable";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
-/*
-  FIXME: Temporary fix for now as we get rid of storing all tracks in the
-  Zustand store.
-    - If we were to have an "TrackWithAlbum[]", it'll probably sync with
-    `currentList`.
-*/
-import type { TrackWithAlbum } from "~/db/schema";
-const trackList: TrackWithAlbum[] = [];
-const queueList: TrackWithAlbum[] = [];
-
 /**
  * Sheet allowing us to see the upcoming tracks and remove tracks from
  * the queue.
  */
 export default function TrackUpcomingSheet() {
   const { t } = useTranslation();
-  // const trackList = useMusicStore((state) => state.currentTrackList);
-  // const queueList = useMusicStore((state) => state.queuedTrackList);
+  const trackList = useUpcomingStore((state) => state.currentTrackList);
+  const queueList = useUpcomingStore((state) => state.queuedTrackList);
   const listIndex = useMusicStore((state) => state.listIdx);
   const repeat = useMusicStore((state) => state.repeat);
 
@@ -56,8 +47,10 @@ export default function TrackUpcomingSheet() {
       <SheetsFlashList
         estimatedItemSize={52} // 48px Height + 4px Margin Top
         data={data}
-        keyExtractor={({ name }, index) => `${name}_${index}`}
+        keyExtractor={(item, index) => `${item?.name ?? ""}_${index}`}
         renderItem={({ item, index }) => {
+          if (item === undefined) return null;
+
           const itemContent = {
             title: item.name,
             description: item.artistName ?? "—",

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -46,7 +46,7 @@ export async function PlaybackService() {
   TrackPlayer.addEventListener(Event.PlaybackActiveTrackChanged, async (e) => {
     if (e.index === undefined || e.track === undefined) return;
 
-    const { repeat, queuedTrackList } = musicStore.getState();
+    const { repeat, queueList } = musicStore.getState();
     const activeTrack = e.track;
     const trackStatus: TrackStatus = activeTrack["music::status"];
 
@@ -56,13 +56,10 @@ export async function PlaybackService() {
       // Remove 1st item in `queueList` if they're the same (doesn't
       // fire if we manually forced the next track to play - which would
       // cause `e.index` to be `0`).
-      if (e.index > 0 && activeTrack.id === queuedTrackList[0]?.id) {
-        // Update the displayed track.
-        musicStore.setState({
-          activeId: activeTrack.id,
-          activeTrack: queuedTrackList[0],
-          isInQueue: true,
-        });
+      if (e.index > 0 && activeTrack.id === queueList[0]) {
+        // Update the displayed track (let the `activeId` subscription
+        // handle updating `activeTrack`).
+        musicStore.setState({ activeId: activeTrack.id, isInQueue: true });
         await Queue.removeAtIndex(0);
       } else {
         musicStore.setState({ isInQueue: true });

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -73,7 +73,7 @@ export async function PlaybackService() {
 
       // Since we played this track naturally, the index hasn't been updated
       // in the store.
-      const nextTrack = RNTPManager.getNextTrack();
+      const nextTrack = await RNTPManager.getNextTrack();
       musicStore.setState(nextTrack);
 
       // Check if we should pause after looping logic.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

One of the potential areas that I mentioned I wanted to improve on in #155 for performance was the changing the store that tracks the list of tracks we want to play. As it stands current, we load all the tracks in the list we're currently playing, which might become an issue if we have thousands of tracks and are currently playing "All Tracks".

This also gives us the opportunity to fix some other issues caught by Sentry, most noticeably, an issue where `getTracksFromIds()` returns `undefined` for some reason, which gets consumed somewhere in `Music.ts` (ie: a subscription) and breaks things.

What this PR does is:
- Address some of the issues caught by Sentry.
- Lean into referencing the list of track ids instead of the list of Track objects for logic in `Music.ts`.

This is mainly accomplished by creating a separate store that'll be used by the Upcoming Tracks sheet, which renders the list of tracks, accounting for potential `undefined` value.
- Having this store in a context and a separate subscription from the main Music store allows the track sort modal actions be a bit faster.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
