### PR TITLE
chore: Utilize new translation structure

### DIFF
--- a/mobile/@types/i18next.d.ts
+++ b/mobile/@types/i18next.d.ts
@@ -1,14 +1,12 @@
-import type en from "../src/modules/i18n/translations/_legacy/en.json";
+import type { resources } from "../src/modules/i18n/translations/resources";
 
 declare module "i18next" {
   interface CustomTypeOptions {
-    resources: {
-      /*
-        Note that interpolation keys inside the translation aren't
-        type-safe (except the built-in `count`). This is due to the
-        contents of the JSON file not being imported "as const".
-      */
-      translation: typeof en;
-    };
+    /*
+      Note that interpolation keys inside the translation aren't
+      type-safe (except the built-in `count`). This is due to the
+      contents of the JSON file not being imported "as const".
+    */
+    resources: (typeof resources)["en"];
   }
 }

--- a/mobile/@types/i18next.d.ts
+++ b/mobile/@types/i18next.d.ts
@@ -3,9 +3,8 @@ import type { resources } from "../src/modules/i18n/translations/resources";
 declare module "i18next" {
   interface CustomTypeOptions {
     /*
-      Note that interpolation keys inside the translation aren't
-      type-safe (except the built-in `count`). This is due to the
-      contents of the JSON file not being imported "as const".
+      Note that interpolation keys can't be inferred from JSON file (yet).
+        - See: https://www.i18next.com/overview/typescript#not-working-interpolation-values
     */
     resources: (typeof resources)["en"];
   }

--- a/mobile/scripts/translation-migration/newStructure.json
+++ b/mobile/scripts/translation-migration/newStructure.json
@@ -30,7 +30,6 @@
     "settings": null,
     "upcoming": null,
 
-    "clear": null,
     "disc": null
   },
 
@@ -66,6 +65,8 @@
     "unsaved": null,
     "stay": null,
     "leave": null,
+
+    "clear": null,
 
     "validation": {
       "unique": null

--- a/mobile/src/api/album.ts
+++ b/mobile/src/api/album.ts
@@ -24,7 +24,7 @@ const _getAlbum: QueryOneWithTracksFn<Album, false> =
         { defaultWithAlbum: false, ...options },
       ),
     });
-    if (!album) throw new Error(i18next.t("response.noAlbums"));
+    if (!album) throw new Error(i18next.t("err.msg.noAlbums"));
     return album;
   };
 

--- a/mobile/src/api/artist.ts
+++ b/mobile/src/api/artist.ts
@@ -20,7 +20,7 @@ const _getArtist: QueryOneWithTracksFn<Artist> = () => async (id, options) => {
       { defaultWithAlbum: true, ...options },
     ),
   });
-  if (!artist) throw new Error(i18next.t("response.noArtists"));
+  if (!artist) throw new Error(i18next.t("err.msg.noArtists"));
   return artist;
 };
 

--- a/mobile/src/api/playlist.ts
+++ b/mobile/src/api/playlist.ts
@@ -38,7 +38,7 @@ const _getPlaylist: QueryOneWithTracksFn<Playlist> =
         },
       },
     });
-    if (!playlist) throw new Error(i18next.t("response.noPlaylists"));
+    if (!playlist) throw new Error(i18next.t("err.msg.noPlaylists"));
     return fixPlaylistJunction(playlist);
   };
 
@@ -193,7 +193,7 @@ export async function updatePlaylist(
     } catch (err) {
       if (!(err as Error).message.includes("No values to set")) {
         // If we tried to change the playlist name that's already in use.
-        throw new Error(i18next.t("response.usedName"));
+        throw new Error(i18next.t("err.msg.usedName"));
       }
     }
     // Ensure track relationship is preserved.

--- a/mobile/src/api/track.ts
+++ b/mobile/src/api/track.ts
@@ -31,7 +31,7 @@ export async function getTrack<
     columns: getColumns(options?.columns),
     ...withAlbum({ defaultWithAlbum: true, ...options }),
   });
-  if (!track) throw new Error(i18next.t("response.noTracks"));
+  if (!track) throw new Error(i18next.t("err.msg.noTracks"));
   const hasArtwork =
     options?.columns === undefined ||
     options?.columns.includes("artwork" as TCols);

--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -45,7 +45,7 @@ export default function CurrentAlbumScreen() {
           headerRight: () => (
             <IconButton
               kind="ripple"
-              accessibilityLabel={t(`common.${isToggled ? "unF" : "f"}avorite`)}
+              accessibilityLabel={t(`term.${isToggled ? "unF" : "f"}avorite`)}
               onPress={() => mutateGuard(favoriteAlbum, !data.isFavorite)}
             >
               <Favorite filled={isToggled} />
@@ -68,7 +68,7 @@ export default function CurrentAlbumScreen() {
             <>
               {item.disc !== null && discLocation[item.disc] === index ? (
                 <Em dim className={index === 0 ? "mb-2" : "mt-4"}>
-                  {t("common.disc", { count: item.disc })}
+                  {t("term.disc", { count: item.disc })}
                 </Em>
               ) : null}
               <Track

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -64,7 +64,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
 
   return (
     <>
-      <TEm dim textKey="common.albums" className="mx-4 mb-2" />
+      <TEm dim textKey="term.albums" className="mx-4 mb-2" />
       <FlashList
         estimatedItemSize={width + 12} // Column width + gap from padding left
         horizontal
@@ -83,7 +83,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
         )}
         contentContainerClassName="px-4"
       />
-      <TEm dim textKey="common.tracks" className="m-4 mb-2" />
+      <TEm dim textKey="term.tracks" className="m-4 mb-2" />
     </>
   );
 }

--- a/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
@@ -20,7 +20,7 @@ export default function FavoriteTracksScreen() {
   const { isPending, error, data } = useFavoriteTracksForScreen();
   const listPresets = useTrackListPreset({
     ...{ data: data?.tracks, trackSource },
-    emptyMsgKey: "response.noTracks",
+    emptyMsgKey: "err.msg.noTracks",
   });
 
   if (isPending || error) return <PagePlaceholder {...{ isPending }} />;

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -77,16 +77,14 @@ export default function CurrentPlaylistScreen() {
             <View className="flex-row gap-1">
               <IconButton
                 kind="ripple"
-                accessibilityLabel={t(
-                  `common.${isToggled ? "unF" : "f"}avorite`,
-                )}
+                accessibilityLabel={t(`term.${isToggled ? "unF" : "f"}avorite`)}
                 onPress={() => mutateGuard(favoritePlaylist, !data.isFavorite)}
               >
                 <Favorite filled={isToggled} />
               </IconButton>
               <IconButton
                 kind="ripple"
-                accessibilityLabel={t("playlist.edit")}
+                accessibilityLabel={t("feat.playlist.extra.edit")}
                 onPress={() =>
                   router.navigate(
                     `/playlist/modify?id=${encodeURIComponent(id)}`,
@@ -113,7 +111,7 @@ export default function CurrentPlaylistScreen() {
           onReordered={onReordered}
           contentContainerClassName="pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
-          emptyMsgKey="response.noTracks"
+          emptyMsgKey="err.msg.noTracks"
         />
       </CurrentListLayout>
     </>

--- a/mobile/src/app/(main)/(current)/playlist/create.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/create.tsx
@@ -26,7 +26,7 @@ export default function CreatePlaylistScreen() {
               router.replace(`/playlist/${encodeURIComponent(playlistName)}`);
             },
             onError: () => {
-              toast.error(t("errorScreen.generic"), ToastOptions);
+              toast.error(t("err.flow.generic.title"), ToastOptions);
             },
           },
         );

--- a/mobile/src/app/(main)/(current)/playlist/modify.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/modify.tsx
@@ -54,7 +54,7 @@ export default function ModifyPlaylistScreen() {
               }
             },
             onError: () => {
-              toast.error(t("errorScreen.generic"), ToastOptions);
+              toast.error(t("err.flow.generic.title"), ToastOptions);
             },
           },
         );

--- a/mobile/src/app/(main)/(home)/album.tsx
+++ b/mobile/src/app/(main)/(home)/album.tsx
@@ -8,8 +8,8 @@ export default function AlbumScreen() {
   const { isPending, data } = useAlbumsForCards();
   const presets = useMediaCardListPreset({
     ...{ data, isPending },
-    emptyMsgKey: "response.noAlbums",
+    emptyMsgKey: "err.msg.noAlbums",
   });
 
-  return <StickyActionListLayout titleKey="common.albums" {...presets} />;
+  return <StickyActionListLayout titleKey="term.albums" {...presets} />;
 }

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -12,12 +12,12 @@ export default function ArtistScreen() {
   const { isPending, data } = useArtistsForIndex();
   const listPresets = useListPresets({
     isPending,
-    emptyMsgKey: "response.noArtists",
+    emptyMsgKey: "err.msg.noArtists",
   });
 
   return (
     <StickyActionListLayout
-      titleKey="common.artists"
+      titleKey="term.artists"
       estimatedItemSize={56} // 48px Height + 8px Margin Top
       data={data}
       keyExtractor={(item) => (typeof item === "string" ? item : item.name)}

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -79,7 +79,7 @@ export default function FolderScreen() {
   return (
     <StickyActionListLayout
       listRef={listRef}
-      titleKey="common.folders"
+      titleKey="term.folders"
       estimatedItemSize={56} // 48px Height + 8px Margin Top
       data={[data?.subDirectories ?? [], data?.tracks ?? []].flat()}
       keyExtractor={(_, index) => `${index}`}

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -26,10 +26,10 @@ import {
 /** Screen for `/` route. */
 export default function HomeScreen() {
   return (
-    <StickyActionScrollLayout titleKey="header.home">
-      <TEm textKey="home.playedRecent" className="-mb-4" />
+    <StickyActionScrollLayout titleKey="term.home">
+      <TEm textKey="feat.playedRecent.title" className="-mb-4" />
       <RecentlyPlayed />
-      <TEm textKey="home.favorites" className="-mb-4" />
+      <TEm textKey="term.favorites" className="-mb-4" />
       <Favorites />
     </StickyActionScrollLayout>
   );
@@ -79,7 +79,7 @@ function RecentlyPlayed() {
       ListEmptyComponent={
         <TStyledText
           onLayout={() => setInitNoData(true)}
-          textKey="response.noRecents"
+          textKey="feat.playedRecent.extra.empty"
           className="my-4"
         />
       }
@@ -125,7 +125,7 @@ function FavoriteTracks(props: { size: number; className: string }) {
       <AccentText className="text-[3rem] text-neutral100">
         {trackCount}
       </AccentText>
-      <TStyledText textKey="common.tracks" className="text-neutral100" />
+      <TStyledText textKey="term.tracks" className="text-neutral100" />
     </Button>
   );
 }

--- a/mobile/src/app/(main)/(home)/playlist.tsx
+++ b/mobile/src/app/(main)/(home)/playlist.tsx
@@ -15,12 +15,12 @@ export default function PlaylistScreen() {
   const { isPending, data } = usePlaylistsForCards();
   const presets = useMediaCardListPreset({
     ...{ data, isPending },
-    emptyMsgKey: "response.noPlaylists",
+    emptyMsgKey: "err.msg.noPlaylists",
   });
 
   return (
     <StickyActionListLayout
-      titleKey="common.playlists"
+      titleKey="term.playlists"
       StickyAction={<PlaylistActions />}
       estimatedActionSize={48}
       {...presets}
@@ -35,7 +35,7 @@ function PlaylistActions() {
   return (
     <View className="rounded-md bg-canvas">
       <IconButton
-        accessibilityLabel={t("playlist.create")}
+        accessibilityLabel={t("feat.playlist.extra.create")}
         onPress={() => router.navigate("/playlist/create")}
         className="bg-red"
       >

--- a/mobile/src/app/(main)/(home)/track.tsx
+++ b/mobile/src/app/(main)/(home)/track.tsx
@@ -22,12 +22,12 @@ export default function TrackScreen() {
   const { isPending, data } = useTracksForTrackCard();
   const listPresets = useTrackListPreset({
     ...{ data, trackSource, isPending },
-    emptyMsgKey: "response.noTracks",
+    emptyMsgKey: "err.msg.noTracks",
   });
 
   return (
     <StickyActionListLayout
-      titleKey="common.tracks"
+      titleKey="term.tracks"
       StickyAction={<TrackActions />}
       estimatedActionSize={48}
       {...listPresets}
@@ -43,7 +43,7 @@ function TrackActions() {
     <View className="w-full flex-row items-center justify-between rounded-md bg-surface">
       <IconButton
         kind="ripple"
-        accessibilityLabel={t("title.sort")}
+        accessibilityLabel={t("feat.modalSort.title")}
         onPress={() => SheetManager.show("TrackSortSheet")}
       >
         <Sort />

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -1,5 +1,6 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { Stack, router, useRootNavigationState } from "expo-router";
+import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useRef } from "react";
 import { FlatList, View } from "react-native";
@@ -100,15 +101,18 @@ function NavigationList() {
 
   // Buttons for the routes we can navigate to on the "home" screen, whose
   // order can be customized.
-  const NavRoutes = useMemo(
-    () => [
-      { href: "/", key: "term.home", name: "index" },
-      ...displayedTabs.map((tabKey) => {
-        return { href: `/${tabKey}`, key: `term.${tabKey}s`, name: tabKey };
-      }),
-    ],
-    [displayedTabs],
-  );
+  const NavRoutes: Array<{ href: string; key: ParseKeys; name: string }> =
+    useMemo(
+      () => [
+        { href: "/", key: "term.home", name: "index" },
+        ...displayedTabs.map((tabKey) => ({
+          href: `/${tabKey}`,
+          key: `term.${tabKey}s` satisfies ParseKeys,
+          name: tabKey,
+        })),
+      ],
+      [displayedTabs],
+    );
 
   // Name of the current route.
   const routeName = useMemo(() => {

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -70,14 +70,14 @@ function TabBar({ stacked = false, hidden = false }) {
       <NavigationList />
       <IconButton
         kind="ripple"
-        accessibilityLabel={t("header.search")}
+        accessibilityLabel={t("feat.search.title")}
         onPress={() => router.navigate("/search")}
       >
         <Search />
       </IconButton>
       <IconButton
         kind="ripple"
-        accessibilityLabel={t("header.settings")}
+        accessibilityLabel={t("term.settings")}
         onPress={() => router.navigate("/setting")}
         className="relative"
       >

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -102,9 +102,9 @@ function NavigationList() {
   // order can be customized.
   const NavRoutes = useMemo(
     () => [
-      { href: "/", key: "header.home", name: "index" },
+      { href: "/", key: "term.home", name: "index" },
       ...displayedTabs.map((tabKey) => {
-        return { href: `/${tabKey}`, key: `common.${tabKey}s`, name: tabKey };
+        return { href: `/${tabKey}`, key: `term.${tabKey}s`, name: tabKey };
       }),
     ],
     [displayedTabs],

--- a/mobile/src/app/+not-found.tsx
+++ b/mobile/src/app/+not-found.tsx
@@ -14,14 +14,18 @@ export default function NotFoundScreen() {
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <IssueLayout issueType="unmatched">
+      <IssueLayout issueType="route">
         <List>
           <ListItem
-            titleKey="errorScreen.missing"
+            titleKey="err.flow.route.extra.missing"
             description={pathname}
             first
           />
-          <ListItem titleKey="errorScreen.from" description={prevRoute} last />
+          <ListItem
+            titleKey="err.flow.route.extra.from"
+            description={prevRoute}
+            last
+          />
         </List>
       </IssueLayout>
     </>

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -224,7 +224,7 @@ function BottomAppBar({ trackId }: { trackId: string }) {
     <View className="flex-row items-center justify-end gap-2 pt-2">
       <IconButton
         kind="ripple"
-        accessibilityLabel={t(`common.${isFav ? "unF" : "f"}avorite`)}
+        accessibilityLabel={t(`term.${isFav ? "unF" : "f"}avorite`)}
         onPress={() => mutateGuard(favoriteTrack, !data?.isFavorite)}
         rippleRadius={24}
         className="p-2"
@@ -233,7 +233,7 @@ function BottomAppBar({ trackId }: { trackId: string }) {
       </IconButton>
       <IconButton
         kind="ripple"
-        accessibilityLabel={t("title.upcoming")}
+        accessibilityLabel={t("term.upcoming")}
         onPress={() => SheetManager.show("TrackUpcomingSheet")}
         rippleRadius={24}
         className="p-2"

--- a/mobile/src/app/search.tsx
+++ b/mobile/src/app/search.tsx
@@ -14,7 +14,7 @@ export default function SearchScreen() {
   const { t } = useTranslation();
   return (
     <View className="grow gap-6 px-4 pt-2">
-      <AccentText className="text-4xl">{t("header.search")}</AccentText>
+      <AccentText className="text-4xl">{t("feat.search.title")}</AccentText>
       <SearchEngine searchScope={searchScope} callbacks={searchCallbacks} />
     </View>
   );

--- a/mobile/src/app/setting/_layout.tsx
+++ b/mobile/src/app/setting/_layout.tsx
@@ -7,28 +7,34 @@ export default function SettingsLayout() {
   const { t } = useTranslation();
   return (
     <Stack screenOptions={{ animation: "fade", header: TopAppBar }}>
-      <Stack.Screen name="index" options={{ title: t("header.settings") }} />
-      <Stack.Screen name="update" options={{ title: t("header.appUpdate") }} />
+      <Stack.Screen name="index" options={{ title: t("term.settings") }} />
+      <Stack.Screen
+        name="update"
+        options={{ title: t("feat.appUpdate.title") }}
+      />
       <Stack.Screen
         name="appearance/index"
-        options={{ title: t("header.appearance") }}
+        options={{ title: t("feat.appearance.title") }}
       />
       <Stack.Screen
         name="appearance/home-tabs-order"
-        options={{ title: t("title.homeTabsOrder") }}
+        options={{ title: t("feat.homeTabsOrder.title") }}
       />
       <Stack.Screen
         name="insights/index"
-        options={{ title: t("header.insights") }}
+        options={{ title: t("feat.insights.title") }}
       />
       <Stack.Screen
         name="insights/save-errors"
-        options={{ title: t("header.saveErrors") }}
+        options={{ title: t("feat.saveErrors.title") }}
       />
-      <Stack.Screen name="scanning" options={{ title: t("header.scanning") }} />
+      <Stack.Screen
+        name="scanning"
+        options={{ title: t("feat.scanning.title") }}
+      />
       <Stack.Screen
         name="third-party/index"
-        options={{ title: t("header.thirdParty") }}
+        options={{ title: t("feat.thirdParty.title") }}
       />
       <Stack.Screen name="third-party/[id]" options={{ title: "" }} />
     </Stack>

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -17,7 +17,7 @@ import { cn } from "~/lib/style";
 import { FlashDragList } from "~/components/Defaults";
 import { Divider } from "~/components/Divider";
 import { IconButton } from "~/components/Form/Button";
-import { TStyledText } from "~/components/Typography/StyledText";
+import { StyledText, TStyledText } from "~/components/Typography/StyledText";
 
 type RenderItemProps = DragListRenderItemInfo<OrderableTab>;
 
@@ -47,13 +47,14 @@ export default function HomeTabsOrderScreen() {
 }
 
 function ListHeaderComponent() {
+  const { t } = useTranslation();
   return (
     <>
-      <TStyledText
-        textKey="settings.description.homeTabsOrder"
-        dim
-        className="text-center text-sm"
-      />
+      <StyledText dim className="text-center text-sm">
+        {t("feat.homeTabsOrder.description.line1")}
+        {"\n\n"}
+        {t("feat.homeTabsOrder.description.line2")}
+      </StyledText>
       <Divider className="my-6" />
     </>
   );
@@ -72,7 +73,7 @@ const RenderItem = memo(
 
     const isVisible = tabsVisibility[item];
     const Icon = isVisible ? Eye : EyeOff;
-    const tabNameKey = `common.${item}s` as const;
+    const tabNameKey = `term.${item}s` as const;
 
     return (
       <Pressable
@@ -92,7 +93,7 @@ const RenderItem = memo(
         <IconButton
           kind="ripple"
           accessibilityLabel={t(
-            isVisible ? "template.hideEntry" : "template.showEntry",
+            isVisible ? "template.entryHide" : "template.entryShow",
             { name: t(tabNameKey) },
           )}
           onPress={() => toggleVisibility(item)}

--- a/mobile/src/app/setting/appearance/index.tsx
+++ b/mobile/src/app/setting/appearance/index.tsx
@@ -20,14 +20,14 @@ export default function AppearanceScreen() {
     <StandardScrollLayout>
       <List>
         <ListItem
-          titleKey="title.font"
+          titleKey="feat.accentFont.title"
           description={accentFont}
           onPress={() => SheetManager.show("FontSheet")}
           first
         />
         <ListItem
-          titleKey="title.theme"
-          description={t(`settings.related.${theme}`)}
+          titleKey="feat.theme.title"
+          description={t(`feat.theme.extra.${theme}`)}
           onPress={() => SheetManager.show("ThemeSheet")}
           last
         />
@@ -35,14 +35,14 @@ export default function AppearanceScreen() {
 
       <List>
         <ListItem
-          titleKey="title.homeTabsOrder"
-          description={t("settings.brief.homeTabsOrder")}
+          titleKey="feat.homeTabsOrder.title"
+          description={t("feat.homeTabsOrder.brief")}
           onPress={() => router.navigate("/setting/appearance/home-tabs-order")}
           first
         />
         <ListItem
-          titleKey="title.nowPlayingDesign"
-          description={t(`common.${nowPlayingDesign}`)}
+          titleKey="feat.nowPlayingDesign.title"
+          description={t(`feat.nowPlayingDesign.extra.${nowPlayingDesign}`)}
           onPress={() => SheetManager.show("NowPlayingDesignSheet")}
           last
         />

--- a/mobile/src/app/setting/index.tsx
+++ b/mobile/src/app/setting/index.tsx
@@ -23,8 +23,8 @@ export default function SettingScreen() {
     <StandardScrollLayout>
       {hasNewUpdate && (
         <ListItem
-          titleKey="header.appUpdate"
-          description={t("settings.brief.appUpdate")}
+          titleKey="feat.appUpdate.title"
+          description={t("feat.appUpdate.brief")}
           onPress={() => router.navigate("/setting/update")}
           className="rounded-full bg-yellow"
           textColor="text-neutral0"
@@ -33,13 +33,13 @@ export default function SettingScreen() {
 
       <List>
         <ListItem
-          titleKey="header.appearance"
-          description={t("settings.brief.appearance")}
+          titleKey="feat.appearance.title"
+          description={t("feat.appearance.brief")}
           onPress={() => router.navigate("/setting/appearance")}
           first
         />
         <ListItem
-          titleKey="title.language"
+          titleKey="feat.language.title"
           description={currLang ?? "English"}
           onPress={() => SheetManager.show("LanguageSheet")}
           last
@@ -48,27 +48,27 @@ export default function SettingScreen() {
 
       <List>
         <ListItem
-          titleKey="title.backup"
-          description={t("settings.brief.backup")}
+          titleKey="feat.backup.title"
+          description={t("feat.backup.brief")}
           onPress={() => SheetManager.show("BackupSheet")}
           first
         />
         <ListItem
-          titleKey="header.insights"
-          description={t("settings.brief.insights")}
+          titleKey="feat.insights.title"
+          description={t("feat.insights.brief")}
           onPress={() => router.navigate("/setting/insights")}
         />
         <ListItem
-          titleKey="settings.interactions"
-          description={t("settings.brief.interactions")}
+          titleKey="feat.interactions.title"
+          description={t("feat.interactions.brief")}
           icon={<OpenInNew />}
           onPress={() =>
             WebBrowser.openBrowserAsync(LINKS.NOTHING_INTERACTIONS)
           }
         />
         <ListItem
-          titleKey="header.scanning"
-          description={t("settings.brief.scanning")}
+          titleKey="feat.scanning.title"
+          description={t("feat.scanning.brief")}
           onPress={() => router.navigate("/setting/scanning")}
           last
         />
@@ -76,34 +76,38 @@ export default function SettingScreen() {
 
       <List>
         <ListItem
-          titleKey="settings.translate"
-          description={t("settings.brief.translate")}
+          titleKey="feat.translate.title"
+          description={t("feat.translate.brief")}
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.TRANSLATIONS)}
           first
         />
         <ListItem
-          titleKey="settings.code"
-          description={t("settings.brief.code")}
+          titleKey="feat.code.title"
+          description={t("feat.code.brief")}
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.GITHUB)}
         />
         <ListItem
-          titleKey="settings.license"
+          titleKey="feat.license.title"
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.LICENSE)}
         />
         <ListItem
-          titleKey="settings.privacy"
+          titleKey="feat.privacy.title"
           icon={<OpenInNew />}
           onPress={() => WebBrowser.openBrowserAsync(LINKS.PRIVACY_POLICY)}
         />
         <ListItem
-          titleKey="header.thirdParty"
-          description={t("settings.brief.thirdParty")}
+          titleKey="feat.thirdParty.title"
+          description={t("feat.thirdParty.brief")}
           onPress={() => router.navigate("/setting/third-party")}
         />
-        <ListItem titleKey="settings.version" description={APP_VERSION} last />
+        <ListItem
+          titleKey="feat.version.title"
+          description={APP_VERSION}
+          last
+        />
       </List>
     </StandardScrollLayout>
   );

--- a/mobile/src/app/setting/insights/index.tsx
+++ b/mobile/src/app/setting/insights/index.tsx
@@ -23,8 +23,8 @@ export default function InsightsScreen() {
       </List>
 
       <ListItem
-        titleKey="header.saveErrors"
-        description={t("settings.brief.saveErrors")}
+        titleKey="feat.saveErrors.title"
+        description={t("feat.saveErrors.brief")}
         onPress={() => router.navigate("/setting/insights/save-errors")}
         {...{ first: true, last: true }}
       />
@@ -52,28 +52,28 @@ function StorageWidget() {
       />
       <Legend className="py-2">
         <LegendItem
-          nameKey="settings.related.images"
+          nameKey="feat.insights.extra.images"
           value={abbreviateSize(data.images)}
           color={Colors.red}
         />
         <LegendItem
-          nameKey="settings.related.database"
+          nameKey="feat.insights.extra.database"
           value={abbreviateSize(data.database)}
           color={Colors.yellow}
         />
         <LegendItem
-          nameKey="settings.related.other"
+          nameKey="feat.insights.extra.other"
           value={abbreviateSize(data.other)}
           color="#4142BE"
         />
         <LegendItem
-          nameKey="settings.related.cache"
+          nameKey="feat.insights.extra.cache"
           value={abbreviateSize(data.cache)}
           color={`${foreground}40`} // 25% Opacity
         />
       </Legend>
       <LegendItem
-        nameKey="settings.related.total"
+        nameKey="feat.insights.extra.total"
         value={abbreviateSize(data.total)}
       />
     </Card>
@@ -87,15 +87,15 @@ function DBSummaryWidget() {
   return (
     <Card className="gap-2 rounded-t-sm">
       <Legend className="pb-2">
-        <LegendItem nameKey="common.albums" value={data.albums} />
-        <LegendItem nameKey="common.artists" value={data.artists} />
-        <LegendItem nameKey="settings.related.images" value={data.images} />
-        <LegendItem nameKey="common.playlists" value={data.playlists} />
-        <LegendItem nameKey="common.tracks" value={data.tracks} />
-        <LegendItem nameKey="header.saveErrors" value={data.saveErrors} />
+        <LegendItem nameKey="term.albums" value={data.albums} />
+        <LegendItem nameKey="term.artists" value={data.artists} />
+        <LegendItem nameKey="feat.insights.extra.images" value={data.images} />
+        <LegendItem nameKey="term.playlists" value={data.playlists} />
+        <LegendItem nameKey="term.tracks" value={data.tracks} />
+        <LegendItem nameKey="feat.saveErrors.title" value={data.saveErrors} />
       </Legend>
       <LegendItem
-        nameKey="settings.related.totalDuration"
+        nameKey="feat.insights.extra.totalDuration"
         value={formatSeconds(data.totalDuration, false)}
       />
     </Card>

--- a/mobile/src/app/setting/insights/save-errors.tsx
+++ b/mobile/src/app/setting/insights/save-errors.tsx
@@ -15,7 +15,7 @@ export default function SaveErrorsScreen() {
           getTitle: (item) => item.uri,
           getDescription: (item) => `[${item.errorName}] ${item.errorMessage}`,
         }}
-        emptyMsgKey="response.noErrors"
+        emptyMsgKey="err.msg.noErrors"
       />
     </StandardScrollLayout>
   );

--- a/mobile/src/app/setting/scanning.tsx
+++ b/mobile/src/app/setting/scanning.tsx
@@ -20,15 +20,15 @@ export default function ScanningScreen() {
     <StandardScrollLayout>
       <List>
         <ListItem
-          titleKey="settings.rescan"
-          description={t("settings.brief.rescan")}
+          titleKey="feat.rescan.title"
+          description={t("feat.rescan.brief")}
           disabled={rescan.isPending}
           onPress={() => mutateGuard(rescan, undefined)}
           first
         />
         <ListItem
-          titleKey="settings.deepRescan"
-          description={t("settings.brief.deepRescan")}
+          titleKey="feat.deepRescan.title"
+          description={t("feat.deepRescan.brief")}
           disabled={rescan.isPending}
           onPress={() => mutateGuard(rescan, true)}
           last
@@ -37,7 +37,7 @@ export default function ScanningScreen() {
 
       <List>
         <ListItem
-          titleKey="title.listAllow"
+          titleKey="feat.listAllow.title"
           description={t("plural.entry", { count: allowList.length })}
           onPress={() =>
             SheetManager.show("ScanFilterListSheet", {
@@ -47,7 +47,7 @@ export default function ScanningScreen() {
           first
         />
         <ListItem
-          titleKey="title.listBlock"
+          titleKey="feat.listBlock.title"
           description={t("plural.entry", { count: blockList.length })}
           onPress={() =>
             SheetManager.show("ScanFilterListSheet", {
@@ -56,7 +56,7 @@ export default function ScanningScreen() {
           }
         />
         <ListItem
-          titleKey="title.ignoreDuration"
+          titleKey="feat.ignoreDuration.title"
           description={t("plural.second", { count: ignoreDuration })}
           onPress={() => SheetManager.show("MinDurationSheet")}
           last

--- a/mobile/src/app/setting/update.tsx
+++ b/mobile/src/app/setting/update.tsx
@@ -102,7 +102,7 @@ export default function AppUpdateScreen() {
         >
           <LogoGitHub />
           <TStyledText
-            textKey="settings.related.appDownload"
+            textKey="feat.appUpdate.extra.downloadAPK"
             className="text-center text-xs"
           />
         </Button>
@@ -113,7 +113,7 @@ export default function AppUpdateScreen() {
           >
             <LogoPlayStore />
             <TStyledText
-              textKey="settings.related.appUpdate"
+              textKey="feat.appUpdate.extra.updateGoogle"
               className="text-center text-xs"
             />
           </Button>

--- a/mobile/src/components/Transition/Placeholder.tsx
+++ b/mobile/src/components/Transition/Placeholder.tsx
@@ -13,7 +13,7 @@ export function ContentPlaceholder(props: {
   return props.isPending ? (
     <Loading />
   ) : (
-    <TStyledText textKey={props.errMsgKey ?? "response.noContent"} center />
+    <TStyledText textKey={props.errMsgKey ?? "err.msg.noContent"} center />
   );
 }
 

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -153,8 +153,8 @@ export function sanitizePlaylistName(name: string) {
   const sanitized = name.trim();
 
   let errMsg: string | undefined;
-  if (ReservedNames.has(sanitized)) errMsg = i18next.t("response.usedName");
-  if (sanitized.length === 0) errMsg = i18next.t("response.noContent");
+  if (ReservedNames.has(sanitized)) errMsg = i18next.t("err.msg.usedName");
+  if (sanitized.length === 0) errMsg = i18next.t("err.msg.noContent");
 
   if (errMsg) throw new Error(errMsg);
 

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -57,12 +57,12 @@ export function CurrentListLayout(
         <View className="shrink grow justify-end">
           <TEm
             dim
-            textKey={`common.${toLowerCase(props.mediaSource.type)}`}
+            textKey={`term.${toLowerCase(props.mediaSource.type)}`}
             style={{ fontSize: 8 }}
           />
           <Marquee color={canvas}>
             <StyledText>
-              {isFavorite ? t("common.favoriteTracks") : props.title}
+              {isFavorite ? t("term.favoriteTracks") : props.title}
             </StyledText>
           </Marquee>
           {props.artist ? (
@@ -113,7 +113,7 @@ function ContentImage({
 
   return (
     <Pressable
-      aria-label={t("playlist.artworkChange")}
+      aria-label={t("feat.artwork.extra.change")}
       delayLongPress={100}
       onLongPress={() => {
         SheetManager.show(`${capitalize(type)}ArtworkSheet`, {

--- a/mobile/src/layouts/Issue.tsx
+++ b/mobile/src/layouts/Issue.tsx
@@ -15,7 +15,7 @@ import { TStyledText } from "~/components/Typography/StyledText";
 
 /** Layout used for the "error" screens (route & unexpected errors). */
 export function IssueLayout(props: {
-  issueType: "unmatched" | "generic";
+  issueType: "route" | "generic";
   children: React.ReactNode;
 }) {
   const { t } = useTranslation();
@@ -35,11 +35,11 @@ export function IssueLayout(props: {
         {...ScrollPresets}
       >
         <AccentText style={{ paddingTop: top + 16 }} className="text-4xl">
-          {t(`errorScreen.${props.issueType}`)}
+          {t(`err.flow.${props.issueType}.title`)}
         </AccentText>
         <TStyledText
           dim
-          textKey={`errorScreen.${props.issueType}Brief`}
+          textKey={`err.flow.${props.issueType}.brief`}
           className="text-base"
         />
 
@@ -58,11 +58,11 @@ export function IssueLayout(props: {
           className="bg-red"
         >
           <TStyledText
-            textKey="errorScreen.report"
+            textKey="err.flow.report.title"
             className="text-center text-neutral100"
           />
           <TStyledText
-            textKey="errorScreen.screenshot"
+            textKey="err.flow.report.brief"
             className="text-center text-xs text-neutral100/80"
           />
         </Button>

--- a/mobile/src/modules/i18n/index.ts
+++ b/mobile/src/modules/i18n/index.ts
@@ -1,31 +1,7 @@
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 
-import ca from "./translations/_legacy/ca.json";
-import de from "./translations/_legacy/de.json";
-import en from "./translations/_legacy/en.json";
-import es from "./translations/_legacy/es.json";
-import fr from "./translations/_legacy/fr.json";
-import hi from "./translations/_legacy/hi.json";
-import id from "./translations/_legacy/id.json";
-import ja from "./translations/_legacy/ja.json";
-import ru from "./translations/_legacy/ru.json";
-import tr from "./translations/_legacy/tr.json";
-import zhHans from "./translations/_legacy/zh-Hans.json";
-
-const resources = {
-  ca: { translation: ca },
-  de: { translation: de },
-  en: { translation: en },
-  es: { translation: es },
-  fr: { translation: fr },
-  hi: { translation: hi },
-  id: { translation: id },
-  ja: { translation: ja },
-  ru: { translation: ru },
-  tr: { translation: tr },
-  "zh-Hans": { translation: zhHans },
-};
+import { resources } from "./translations/resources";
 
 i18next.use(initReactI18next).init({
   lng: "en",

--- a/mobile/src/modules/i18n/translations/ca.json
+++ b/mobile/src/modules/i18n/translations/ca.json
@@ -30,7 +30,6 @@
     "settings": "Ajusts",
     "upcoming": "Pròxima",
 
-    "clear": null,
     "disc": "Disc {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "Poder tens canvis sense desar.",
     "stay": "Queda't",
     "leave": "Eixir",
+
+    "clear": null,
 
     "validation": {
       "unique": "Únic"

--- a/mobile/src/modules/i18n/translations/de.json
+++ b/mobile/src/modules/i18n/translations/de.json
@@ -30,7 +30,6 @@
     "settings": "Einstellungen",
     "upcoming": "Bevorstehend",
 
-    "clear": null,
     "disc": "CD {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "Möglicherweise hast du noch nicht gespeicherte Änderungen.",
     "stay": "Bleiben",
     "leave": "Verlassen",
+
+    "clear": null,
 
     "validation": {
       "unique": "Einzigartig"

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -30,7 +30,6 @@
     "settings": "Settings",
     "upcoming": "Upcoming",
 
-    "clear": "Clear",
     "disc": "Disc {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "You may have unsaved changes.",
     "stay": "Stay",
     "leave": "Leave",
+
+    "clear": "Clear",
 
     "validation": {
       "unique": "Unique"

--- a/mobile/src/modules/i18n/translations/es.json
+++ b/mobile/src/modules/i18n/translations/es.json
@@ -30,7 +30,6 @@
     "settings": "Configuración",
     "upcoming": "Próximamente",
 
-    "clear": null,
     "disc": null
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "Puede que tengas cambios sin guardar.",
     "stay": "Permanecer",
     "leave": "Salir",
+
+    "clear": null,
 
     "validation": {
       "unique": "Único"

--- a/mobile/src/modules/i18n/translations/fr.json
+++ b/mobile/src/modules/i18n/translations/fr.json
@@ -30,7 +30,6 @@
     "settings": "Paramètres",
     "upcoming": "À venir",
 
-    "clear": null,
     "disc": "CD {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "Vous avez des modifications non enregistrées.",
     "stay": "Rester",
     "leave": "Quitter",
+
+    "clear": null,
 
     "validation": {
       "unique": "Unique"

--- a/mobile/src/modules/i18n/translations/hi.json
+++ b/mobile/src/modules/i18n/translations/hi.json
@@ -30,7 +30,6 @@
     "settings": "सेटिंग्स",
     "upcoming": "आगामी",
 
-    "clear": null,
     "disc": "डिस्क {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "आपके पास कुछ असहेजित परिवर्तन हो सकते हैं।",
     "stay": "रहें",
     "leave": "छोड़ें",
+
+    "clear": null,
 
     "validation": {
       "unique": "अद्वितीय"

--- a/mobile/src/modules/i18n/translations/id.json
+++ b/mobile/src/modules/i18n/translations/id.json
@@ -30,7 +30,6 @@
     "settings": "Pengaturan",
     "upcoming": "Yang akan Datang",
 
-    "clear": null,
     "disc": null
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "Anda masih memiliki perubahan yang belum disimpan.",
     "stay": "Tetap disini",
     "leave": "Keluar",
+
+    "clear": null,
 
     "validation": {
       "unique": "Unik"

--- a/mobile/src/modules/i18n/translations/ja.json
+++ b/mobile/src/modules/i18n/translations/ja.json
@@ -30,7 +30,6 @@
     "settings": "設定",
     "upcoming": "次に再生",
 
-    "clear": null,
     "disc": "ディスク {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "変更が保存されていません。",
     "stay": "留まる",
     "leave": "離れる",
+
+    "clear": null,
 
     "validation": {
       "unique": "ユニーク"

--- a/mobile/src/modules/i18n/translations/resources.ts
+++ b/mobile/src/modules/i18n/translations/resources.ts
@@ -1,0 +1,25 @@
+import ca from "./ca.json";
+import de from "./de.json";
+import en from "./en.json";
+import es from "./es.json";
+import fr from "./fr.json";
+import hi from "./hi.json";
+import id from "./id.json";
+import ja from "./ja.json";
+import ru from "./ru.json";
+import tr from "./tr.json";
+import zhHans from "./zh-Hans.json";
+
+export const resources = {
+  ca: { translation: ca },
+  de: { translation: de },
+  en: { translation: en },
+  es: { translation: es },
+  fr: { translation: fr },
+  hi: { translation: hi },
+  id: { translation: id },
+  ja: { translation: ja },
+  ru: { translation: ru },
+  tr: { translation: tr },
+  "zh-Hans": { translation: zhHans },
+} satisfies Record<string, Record<"translation", any>>;

--- a/mobile/src/modules/i18n/translations/ru.json
+++ b/mobile/src/modules/i18n/translations/ru.json
@@ -30,7 +30,6 @@
     "settings": "Настройки",
     "upcoming": "Развитие",
 
-    "clear": null,
     "disc": "Диск {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "У вас могут быть несохраненные изменения.",
     "stay": "Остаться",
     "leave": "Оставлять",
+
+    "clear": null,
 
     "validation": {
       "unique": "Уникальный"

--- a/mobile/src/modules/i18n/translations/tr.json
+++ b/mobile/src/modules/i18n/translations/tr.json
@@ -30,7 +30,6 @@
     "settings": "Ayarlar",
     "upcoming": "Yaklaşan",
 
-    "clear": null,
     "disc": "Disk {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "Kaydedilmemiş değişiklikler olabilir.",
     "stay": "Kal",
     "leave": "Ayrıl",
+
+    "clear": null,
 
     "validation": {
       "unique": "Benzersiz"

--- a/mobile/src/modules/i18n/translations/zh-Hans.json
+++ b/mobile/src/modules/i18n/translations/zh-Hans.json
@@ -30,7 +30,6 @@
     "settings": "设置",
     "upcoming": "即将播放",
 
-    "clear": null,
     "disc": "碟片 {{count}}"
   },
 
@@ -66,6 +65,8 @@
     "unsaved": "可能有未保存的更改。",
     "stay": "留在此处",
     "leave": "离开",
+
+    "clear": null,
 
     "validation": {
       "unique": "唯一"

--- a/mobile/src/modules/media/components/MediaControls.tsx
+++ b/mobile/src/modules/media/components/MediaControls.tsx
@@ -28,7 +28,7 @@ export function RepeatButton({ size = 32 }: MediaControlProps) {
     <IconButton
       kind="ripple"
       accessibilityLabel={t(
-        `common.repeat${repeatMode === "repeat-one" ? "One" : ""}`,
+        `term.repeat${repeatMode === "repeat-one" ? "One" : ""}`,
       )}
       onPress={cycleRepeat}
       rippleRadius={size * 0.75}
@@ -50,7 +50,7 @@ export function ShuffleButton({ size = 32 }: MediaControlProps) {
   return (
     <IconButton
       kind="ripple"
-      accessibilityLabel={t("common.shuffle")}
+      accessibilityLabel={t("term.shuffle")}
       onPress={() => setShuffle(!isActive)}
       rippleRadius={size * 0.75}
       className="p-2"
@@ -67,7 +67,7 @@ export function PlayToggleButton({ size = 32, className = "" }) {
   const Icon = isPlaying ? Pause : PlayArrow;
   return (
     <IconButton
-      accessibilityLabel={t(`common.${isPlaying ? "pause" : "play"}`)}
+      accessibilityLabel={t(`term.${isPlaying ? "pause" : "play"}`)}
       onPress={MusicControls.playToggle}
       className={cn(
         "bg-red p-2",
@@ -86,7 +86,7 @@ export function NextButton({ size = 32 }: MediaControlProps) {
   return (
     <IconButton
       kind="ripple"
-      accessibilityLabel={t("common.next")}
+      accessibilityLabel={t("term.next")}
       onPress={MusicControls.next}
       rippleRadius={size * 0.75}
       className="p-2"
@@ -102,7 +102,7 @@ export function PreviousButton({ size = 32 }: MediaControlProps) {
   return (
     <IconButton
       kind="ripple"
-      accessibilityLabel={t("common.prev")}
+      accessibilityLabel={t("term.prev")}
       onPress={MusicControls.prev}
       rippleRadius={size * 0.75}
       className="p-2"

--- a/mobile/src/modules/media/components/MediaListControls.tsx
+++ b/mobile/src/modules/media/components/MediaListControls.tsx
@@ -44,7 +44,7 @@ function PlayMediaListButton({ trackSource }: { trackSource: PlayListSource }) {
 
   return (
     <IconButton
-      accessibilityLabel={t(`common.${displayPause ? "pause" : "play"}`)}
+      accessibilityLabel={t(`term.${displayPause ? "pause" : "play"}`)}
       onPress={
         displayPause
           ? MusicControls.pause

--- a/mobile/src/modules/media/components/MiniPlayer.tsx
+++ b/mobile/src/modules/media/components/MiniPlayer.tsx
@@ -66,7 +66,7 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
           <PreviousButton />
           <IconButton
             kind="ripple"
-            accessibilityLabel={t(`common.${isPlaying ? "pause" : "play"}`)}
+            accessibilityLabel={t(`term.${isPlaying ? "pause" : "play"}`)}
             onPress={MusicControls.playToggle}
             rippleRadius={24}
             className="p-2"

--- a/mobile/src/modules/media/helpers/data.ts
+++ b/mobile/src/modules/media/helpers/data.ts
@@ -47,7 +47,7 @@ export async function getSourceName({ type, id }: PlayListSource) {
   try {
     if (ReservedNames.has(id)) {
       const tKey = id === ReservedPlaylists.tracks ? "t" : "favoriteT";
-      name = i18next.t(`common.${tKey}racks`);
+      name = i18next.t(`term.${tKey}racks`);
     } else if (type === "artist" || type === "playlist") {
       name = id;
     } else if (type === "folder") {

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -240,7 +240,7 @@ export class Queue {
   /** Add a track id at the end of the current queue. */
   static async add({ id, name }: { id: string; name: string }) {
     musicStore.setState((prev) => ({ queueList: [...prev.queueList, id] }));
-    toast(i18next.t("response.queueAdd", { name }), ToastOptions);
+    toast(i18next.t("feat.modalTrack.extra.queueAdd", { name }), ToastOptions);
     await RNTPManager.reloadNextTrack();
   }
 

--- a/mobile/src/modules/media/services/RecentList.ts
+++ b/mobile/src/modules/media/services/RecentList.ts
@@ -109,7 +109,7 @@ recentListStore.subscribe(
           // Translate the names of these special playlists.
           if (entry && ReservedNames.has(id)) {
             const tKey = id === ReservedPlaylists.tracks ? "t" : "favoriteT";
-            entry.title = i18next.t(`common.${tKey}racks`);
+            entry.title = i18next.t(`term.${tKey}racks`);
           }
         }
         if (entry) newRecentList.push(entry);

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -18,7 +18,7 @@ import { savePathComponents } from "./folder";
 
 /** Look through our library for any new or updated tracks. */
 export async function rescanForTracks(deepScan = false) {
-  const toastId = toast(i18next.t("response.scanStart"), {
+  const toastId = toast(i18next.t("feat.rescan.extra.start"), {
     ...ToastOptions,
     duration: Infinity,
   });
@@ -70,14 +70,14 @@ export async function rescanForTracks(deepScan = false) {
     // Make sure the "recents" list is correct.
     RecentList.refresh();
 
-    toast(i18next.t("response.scanSuccess"), {
+    toast(i18next.t("feat.rescan.extra.success"), {
       ...ToastOptions,
       id: toastId,
       duration: 4000,
     });
   } catch (err) {
     console.log(err);
-    toast.error(i18next.t("response.scanFail"), {
+    toast.error(i18next.t("feat.rescan.extra.fail"), {
       ...ToastOptions,
       id: toastId,
       duration: 4000,

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -69,7 +69,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
         />
         <IconButton
           kind="ripple"
-          accessibilityLabel={t("template.entryRemove", { name: query })}
+          accessibilityLabel={t("form.clear")}
           onPress={() => {
             inputRef?.current?.clear();
             setQuery("");

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -64,7 +64,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
         <TextInput
           ref={inputRef}
           onChangeText={(text) => setQuery(text)}
-          placeholder={t("form.placeholder.searchMedia")}
+          placeholder={t("feat.search.extra.searchMedia")}
           className="shrink grow"
         />
         <IconButton
@@ -90,7 +90,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
             if (typeof item === "string") {
               return (
                 <TEm
-                  textKey={`common.${item}`}
+                  textKey={`term.${item}`}
                   className={index > 0 ? "mt-4" : undefined}
                 />
               );
@@ -112,7 +112,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
           }}
           ListEmptyComponent={
             query.length > 0 ? (
-              <TStyledText textKey="response.noResults" center />
+              <TStyledText textKey="err.msg.noResults" center />
             ) : undefined
           }
           contentContainerClassName="pb-4 pt-6"

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -57,7 +57,7 @@ function ScreenConfig() {
   return (
     <Stack.Screen
       options={{
-        headerTitle: t(`playlist.${mode ?? "create"}`),
+        headerTitle: t(`feat.playlist.extra.${mode ?? "create"}`),
         // Hacky solution to disable the back button when submitting.
         headerLeft: isSubmitting ? () => undefined : undefined,
         headerRight: () => (
@@ -123,7 +123,7 @@ function PageContent() {
         onReordered={moveTrack}
         ListHeaderComponent={ListHeaderComponent}
         contentContainerClassName="py-4" // Applies to the internal `<FlashList />`.
-        emptyMsgKey="response.noTracks"
+        emptyMsgKey="err.msg.noTracks"
       />
     </View>
   );
@@ -211,7 +211,7 @@ function ListHeaderComponent() {
           editable={!isSubmitting}
           defaultValue={initialName}
           onChangeText={setPlaylistName}
-          placeholder={t("form.placeholder.playlistName")}
+          placeholder={t("feat.playlist.extra.name")}
           className="shrink grow border-b border-foreground/60"
         />
         <View
@@ -224,10 +224,10 @@ function ListHeaderComponent() {
         </View>
       </View>
       <View className="mb-2 ml-4 mr-1 mt-6 shrink grow flex-row items-center justify-between">
-        <TStyledText textKey="common.tracks" />
+        <TStyledText textKey="term.tracks" />
         <IconButton
           kind="ripple"
-          accessibilityLabel={t("playlist.add")}
+          accessibilityLabel={t("feat.modalTrack.extra.addToPlaylist")}
           disabled={isSubmitting}
           onPress={() =>
             SheetManager.show("AddMusicSheet", {
@@ -308,11 +308,14 @@ function DeleteWorkflow() {
         className="min-h-12 justify-center bg-surface disabled:opacity-25"
       >
         <StyledText className="text-center text-sm text-red">
-          {t("playlist.delete").toLocaleUpperCase()}
+          {t("feat.playlist.extra.delete").toLocaleUpperCase()}
         </StyledText>
       </Pressable>
       <ModalBase visible={lastChance}>
-        <TStyledText textKey="playlist.delete" className="pt-8 text-center" />
+        <TStyledText
+          textKey="feat.playlist.extra.delete"
+          className="pt-8 text-center"
+        />
         <View className="flex-row justify-end gap-4">
           <ModalButton
             textKey="form.cancel"

--- a/mobile/src/screens/Onboarding.tsx
+++ b/mobile/src/screens/Onboarding.tsx
@@ -57,18 +57,18 @@ function OnboardingPhase() {
   if (store.phase === "preprocess") {
     return (
       <>
-        <TStyledText textKey="onboardingScreen.preprocess" />
-        <TStyledText dim textKey="onboardingScreen.preprocessBrief" />
+        <TStyledText textKey="feat.onboardPreprocess.title" />
+        <TStyledText dim textKey="feat.onboardPreprocess.brief" />
       </>
     );
   } else if (store.phase === "tracks") {
     return (
       <>
-        <TStyledText textKey="onboardingScreen.track" />
+        <TStyledText textKey="feat.onboardTracks.title" />
         <StyledText dim>
-          {`${t("onboardingScreen.prevSaved", { amount: store.prevSaved })}\n\n`}
-          {`${t("onboardingScreen.saved", { amount: store.staged, total: store.unstaged })}\n`}
-          {`${t("onboardingScreen.errors", { amount: store.saveErrors })}`}
+          {`${t("feat.onboardTracks.extra.prevSaved", { amount: store.prevSaved })}\n\n`}
+          {`${t("feat.onboardTracks.extra.saved", { amount: store.staged, total: store.unstaged })}\n`}
+          {`${t("feat.onboardTracks.extra.errors", { amount: store.saveErrors })}`}
         </StyledText>
       </>
     );
@@ -76,10 +76,10 @@ function OnboardingPhase() {
 
   return (
     <>
-      <TStyledText textKey="onboardingScreen.image" />
+      <TStyledText textKey="feat.onboardImages.title" />
       <StyledText dim>
-        {`${t("onboardingScreen.checked", { amount: store.checked, total: store.unchecked })}\n`}
-        {`${t("onboardingScreen.found", { amount: store.found })}`}
+        {`${t("feat.onboardImages.extra.checked", { amount: store.checked, total: store.unchecked })}\n`}
+        {`${t("feat.onboardImages.extra.found", { amount: store.found })}`}
       </StyledText>
     </>
   );

--- a/mobile/src/screens/Sheets/AddMusic.tsx
+++ b/mobile/src/screens/Sheets/AddMusic.tsx
@@ -13,7 +13,7 @@ export default function AddMusicSheet(props: {
 }) {
   const { canvasAlt } = useTheme();
   return (
-    <Sheet id="AddMusicSheet" titleKey="title.musicAdd" snapTop>
+    <Sheet id="AddMusicSheet" titleKey="feat.search.extra.musicAdd" snapTop>
       <SearchEngine
         searchScope={searchScope}
         callbacks={props.payload.callbacks}

--- a/mobile/src/screens/Sheets/Artwork.tsx
+++ b/mobile/src/screens/Sheets/Artwork.tsx
@@ -84,7 +84,7 @@ function BaseArtworkSheetContent(props: {
           className="flex-1"
         >
           <TStyledText
-            textKey="playlist.artworkRemove"
+            textKey="feat.artwork.extra.remove"
             bold
             className="text-center text-sm"
           />
@@ -101,7 +101,7 @@ function BaseArtworkSheetContent(props: {
           className="flex-1"
         >
           <TStyledText
-            textKey="playlist.artworkChange"
+            textKey="feat.artwork.extra.change"
             bold
             className="text-center text-sm"
           />

--- a/mobile/src/screens/Sheets/Backup/data.ts
+++ b/mobile/src/screens/Sheets/Backup/data.ts
@@ -104,7 +104,7 @@ async function exportBackup() {
   // save this backup file.
   const downloadDir = SAF.getUriForDirectoryInRoot("Download");
   const perms = await SAF.requestDirectoryPermissionsAsync(downloadDir);
-  if (!perms.granted) throw new Error(i18next.t("response.actionCancel"));
+  if (!perms.granted) throw new Error(i18next.t("err.msg.actionCancel"));
 
   // Create a new file in specified directory & write contents.
   const fileUri = await SAF.createFileAsync(
@@ -133,9 +133,9 @@ async function importBackup() {
   const { assets, canceled } = await DocumentPicker.getDocumentAsync({
     type: ["application/json", "application/octet-stream"],
   });
-  if (canceled) throw new Error(i18next.t("response.actionCancel"));
+  if (canceled) throw new Error(i18next.t("err.msg.actionCancel"));
   const document = assets[0];
-  if (!document) throw new Error(i18next.t("response.noSelect"));
+  if (!document) throw new Error(i18next.t("err.msg.noSelect"));
 
   // Read, parse, and validate file contents.
   const docContents = await FileSystem.readAsStringAsync(document.uri);
@@ -146,7 +146,7 @@ async function importBackup() {
   } catch (err) {
     // Delete cached file before throwing a more readable error.
     await FileSystem.deleteAsync(document.uri);
-    throw new Error(i18next.t("response.invalidStructure"));
+    throw new Error(i18next.t("err.msg.invalidStructure"));
   }
 
   const allPlaylists = await getPlaylists();
@@ -213,7 +213,7 @@ export const useExportBackup = () => {
     mutationFn: exportBackup,
     onSuccess: () => {
       RecentList.refresh();
-      toast(t("response.exportSuccess"), ToastOptions);
+      toast(t("feat.backup.extra.exportSuccess"), ToastOptions);
     },
     onError: (err) => {
       toast.error(err.message, ToastOptions);
@@ -229,7 +229,7 @@ export const useImportBackup = () => {
     mutationFn: importBackup,
     onSuccess: () => {
       clearAllQueries(queryClient);
-      toast(t("response.importSuccess"), ToastOptions);
+      toast(t("feat.backup.extra.importSuccess"), ToastOptions);
     },
     onError: (err) => {
       toast.error(err.message, ToastOptions);

--- a/mobile/src/screens/Sheets/Backup/index.tsx
+++ b/mobile/src/screens/Sheets/Backup/index.tsx
@@ -17,12 +17,12 @@ export default function BackupSheet() {
   return (
     <Sheet
       id="BackupSheet"
-      titleKey="title.backup"
+      titleKey="feat.backup.title"
       contentContainerClassName="gap-4"
     >
       <TStyledText
         dim
-        textKey="settings.description.backup"
+        textKey="feat.backup.description"
         className="text-center text-sm"
       />
 
@@ -33,7 +33,7 @@ export default function BackupSheet() {
           className="flex-1"
         >
           <TStyledText
-            textKey="settings.related.export"
+            textKey="feat.backup.extra.export"
             bold
             className="text-center text-sm"
           />
@@ -44,7 +44,7 @@ export default function BackupSheet() {
           className="flex-1"
         >
           <TStyledText
-            textKey="settings.related.import"
+            textKey="feat.backup.extra.import"
             bold
             className="text-center text-sm"
           />

--- a/mobile/src/screens/Sheets/Font.tsx
+++ b/mobile/src/screens/Sheets/Font.tsx
@@ -18,7 +18,7 @@ export default function FontSheet() {
   return (
     <Sheet
       id="FontSheet"
-      titleKey="title.font"
+      titleKey="feat.accentFont.title"
       contentContainerClassName="pb-0"
     >
       <SheetsFlatList

--- a/mobile/src/screens/Sheets/Language.tsx
+++ b/mobile/src/screens/Sheets/Language.tsx
@@ -14,7 +14,7 @@ export default function LanguageSheet() {
   return (
     <Sheet
       id="LanguageSheet"
-      titleKey="title.language"
+      titleKey="feat.language.title"
       contentContainerClassName="pb-0"
     >
       <SheetsFlatList

--- a/mobile/src/screens/Sheets/MinDuration.tsx
+++ b/mobile/src/screens/Sheets/MinDuration.tsx
@@ -28,12 +28,12 @@ export default function MinDurationSheet() {
   return (
     <Sheet
       id="MinDurationSheet"
-      titleKey="title.ignoreDuration"
+      titleKey="feat.ignoreDuration.title"
       contentContainerClassName="gap-4"
     >
       <TStyledText
         dim
-        textKey="settings.description.ignoreDuration"
+        textKey="feat.ignoreDuration.description"
         className="text-center text-sm"
       />
       <NumericInput

--- a/mobile/src/screens/Sheets/NowPlayingDesign.tsx
+++ b/mobile/src/screens/Sheets/NowPlayingDesign.tsx
@@ -18,7 +18,7 @@ export default function NowPlayingDesignSheet() {
   );
 
   return (
-    <Sheet id="NowPlayingDesignSheet" titleKey="title.nowPlayingDesign">
+    <Sheet id="NowPlayingDesignSheet" titleKey="feat.nowPlayingDesign.title">
       <FlatList
         data={NowPlayingDesignOptions}
         keyExtractor={(design) => design}
@@ -27,7 +27,7 @@ export default function NowPlayingDesignSheet() {
             selected={nowPlayingDesign === design}
             onSelect={() => setNowPlayingDesign(design)}
           >
-            <TStyledText textKey={`common.${design}`} />
+            <TStyledText textKey={`feat.nowPlayingDesign.extra.${design}`} />
           </Radio>
         )}
         contentContainerClassName="gap-1"

--- a/mobile/src/screens/Sheets/ScanFilterList/data.ts
+++ b/mobile/src/screens/Sheets/ScanFilterList/data.ts
@@ -42,7 +42,7 @@ export function validatePath(path: string) {
 export async function pickPath() {
   const permissions = await SAF.requestDirectoryPermissionsAsync();
   if (!permissions.granted) {
-    toast.error(i18next.t("response.actionCancel"), ToastOptions);
+    toast.error(i18next.t("err.msg.actionCancel"), ToastOptions);
     return;
   }
 

--- a/mobile/src/screens/Sheets/ScanFilterList/index.tsx
+++ b/mobile/src/screens/Sheets/ScanFilterList/index.tsx
@@ -38,12 +38,12 @@ export default function ScanFilterListSheet(props: {
   return (
     <Sheet
       id="ScanFilterListSheet"
-      titleKey={`title.${listType}`}
+      titleKey={`feat.${listType}.title`}
       contentContainerClassName="gap-4 px-0"
       snapTop
     >
       <StyledText dim center className="px-4 text-sm">
-        {t(`settings.description.${listType}`)}
+        {t(`feat.${listType}.description`)}
         {listType === "listAllow" ? (
           <StyledText className="text-xs text-foreground/50">
             {"\n"}
@@ -82,7 +82,7 @@ export default function ScanFilterListSheet(props: {
           </Swipeable>
         )}
         contentContainerClassName="pb-4"
-        emptyMsgKey="response.noFilters"
+        emptyMsgKey="err.msg.noFilters"
       />
     </Sheet>
   );
@@ -126,7 +126,7 @@ function FilterForm(props: {
         />
         <IconButton
           kind="ripple"
-          accessibilityLabel={t("settings.related.pathSelect")}
+          accessibilityLabel={t("feat.directory.extra.select")}
           onPress={selectDirectory}
           disabled={onSubmit.isPending}
         >
@@ -134,7 +134,7 @@ function FilterForm(props: {
         </IconButton>
       </View>
       <IconButton
-        accessibilityLabel={t("settings.related.pathAdd")}
+        accessibilityLabel={t("feat.directory.extra.add")}
         onPress={() => {
           Keyboard.dismiss();
           mutateGuard(onSubmit, {

--- a/mobile/src/screens/Sheets/Theme.tsx
+++ b/mobile/src/screens/Sheets/Theme.tsx
@@ -17,7 +17,7 @@ export default function ThemeSheet() {
   const setTheme = useUserPreferencesStore((state) => state.setTheme);
 
   return (
-    <Sheet id="ThemeSheet" titleKey="title.theme">
+    <Sheet id="ThemeSheet" titleKey="feat.theme.title">
       <FlatList
         data={ThemeOptions}
         keyExtractor={(item) => item}
@@ -29,7 +29,7 @@ export default function ThemeSheet() {
               setTheme(item);
             }}
           >
-            <TStyledText textKey={`settings.related.${item}`} />
+            <TStyledText textKey={`feat.theme.extra.${item}`} />
           </Radio>
         )}
         contentContainerClassName="gap-1"

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -69,7 +69,7 @@ function TrackIntro({ data }: { data: TrackWithAlbum }) {
   return (
     <View className="flex-row gap-2">
       <Pressable
-        accessibilityLabel={t(`common.${isFav ? "unF" : "f"}avorite`)}
+        accessibilityLabel={t(`term.${isFav ? "unF" : "f"}avorite`)}
         onPress={() => mutateGuard(favoriteTrack, !data.isFavorite)}
         className="relative flex-row items-center rounded active:opacity-75"
       >
@@ -122,28 +122,31 @@ function Stats({ data }: { data: TrackWithAlbum }) {
     <View className="gap-2">
       <View className="flex-row gap-2">
         <StatItem
-          titleKey="trackModal.bitrate"
+          titleKey="feat.modalTrack.extra.bitrate"
           description={
             data.bitrate !== null ? abbreviateBitRate(data.bitrate) : "—"
           }
         />
         <StatItem
-          titleKey="trackModal.sampleRate"
+          titleKey="feat.modalTrack.extra.sampleRate"
           description={data.sampleRate !== null ? `${data.sampleRate} Hz` : "—"}
         />
       </View>
       <View className="flex-row gap-2">
         <StatItem
-          titleKey="trackModal.size"
+          titleKey="feat.modalTrack.extra.size"
           description={abbreviateSize(data.size)}
         />
         <StatItem
-          titleKey="trackModal.modified"
+          titleKey="feat.modalSort.extra.modified"
           description={formatEpoch(data.modificationTime)}
         />
       </View>
       <View className="flex-row">
-        <StatItem titleKey="trackModal.filePath" description={data.uri} />
+        <StatItem
+          titleKey="feat.modalTrack.extra.filePath"
+          description={data.uri}
+        />
       </View>
     </View>
   );
@@ -162,13 +165,13 @@ function AddActions({ data }: { data: TrackWithAlbum }) {
           })
         }
         Icon={<PlaylistAdd />}
-        textKey="playlist.add"
+        textKey="feat.modalTrack.extra.addToPlaylist"
         preventClose
       />
       <SheetButton
         onPress={() => Queue.add({ id: data.id, name: data.name })}
         Icon={<QueueMusic />}
-        textKey="trackModal.queueAdd"
+        textKey="feat.modalTrack.extra.addToQueue"
       />
     </View>
   );
@@ -198,14 +201,14 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
           <SheetButton
             onPress={() => router.navigate(`/artist/${data.artistName}`)}
             Icon={<Artist />}
-            textKey="common.artist"
+            textKey="term.artist"
           />
         ) : null}
         {data.album ? (
           <SheetButton
             onPress={() => router.navigate(`/album/${data.album?.id}`)}
             Icon={<Album />}
-            textKey="common.album"
+            textKey="term.album"
           />
         ) : null}
         {canShowPlaylistBtn && isInList ? (
@@ -218,7 +221,7 @@ function TrackLinks({ data }: { data: TrackWithAlbum }) {
               )
             }
             Icon={<List />}
-            textKey="common.playlist"
+            textKey="term.playlist"
           />
         ) : null}
       </View>

--- a/mobile/src/screens/Sheets/TrackSort.tsx
+++ b/mobile/src/screens/Sheets/TrackSort.tsx
@@ -20,11 +20,11 @@ export default function TrackSortSheet() {
   return (
     <Sheet
       id="TrackSortSheet"
-      titleKey="title.sort"
+      titleKey="feat.modalSort.title"
       contentContainerClassName="gap-4"
     >
       <Button onPress={toggleIsAsc} className="flex-row justify-between">
-        <TStyledText textKey="sortModal.asc" className="shrink" />
+        <TStyledText textKey="feat.modalSort.extra.asc" className="shrink" />
         <Switch enabled={isAsc} />
       </Button>
       <FlatList
@@ -35,7 +35,7 @@ export default function TrackSortSheet() {
             selected={item === orderedBy}
             onSelect={() => setOrderedBy(item)}
           >
-            <TStyledText textKey={`sortModal.${item}`} />
+            <TStyledText textKey={`feat.modalSort.extra.${item}`} />
           </Radio>
         )}
         contentContainerClassName="gap-1"

--- a/mobile/src/screens/Sheets/TrackToPlaylist.tsx
+++ b/mobile/src/screens/Sheets/TrackToPlaylist.tsx
@@ -28,7 +28,7 @@ export default function TrackToPlaylistSheet(props: {
   return (
     <Sheet
       id="TrackToPlaylistSheet"
-      titleKey="playlist.add"
+      titleKey="feat.modalTrack.extra.addToPlaylist"
       // Hide the Track sheet when we close this sheet since it's still open.
       onBeforeClose={() => SheetManager.hide("TrackSheet")}
       snapTop
@@ -58,7 +58,7 @@ export default function TrackToPlaylistSheet(props: {
           );
         }}
         contentContainerClassName="pb-4"
-        emptyMsgKey="response.noPlaylists"
+        emptyMsgKey="err.msg.noPlaylists"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackUpcoming/index.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming/index.tsx
@@ -48,7 +48,7 @@ export default function TrackUpcomingSheet() {
   return (
     <Sheet
       id="TrackUpcomingSheet"
-      titleKey="title.upcoming"
+      titleKey="term.upcoming"
       snapTop
       contentContainerClassName="px-0"
     >


### PR DESCRIPTION
# Summary

- Utilize new translation key structure in our code.
  - Ensured that the interpolation keys used are correct.
- Add note to official documentation on why interpolation type-safety doesn't work with JSON files.
- Utilize new translation for "Clear" for the clear input button in the search feature.
  - Moved from `term.clear` to `form.clear`.

Some other things we noticed include:
- We didn't use the `template.entryRemoved` key, but we'll leave it in as it might be used in the future to indicate when something gets removed.
- `<FlatList />` doesn't correct pass the inferred the type of its data to `keyExtractor` & `renderItem` (which I noticed when rendering the tabs in the navbar in `src/app/(main)/_layout.tsx`).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
