### PR TITLE
chore: Option to use "old" v1 vinyl design on the "Now Playing" screen

### DIFF
--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -87,6 +87,7 @@ function RootLayoutNav() {
           options={{
             animation: "slide_from_bottom",
             header: TopAppBarMarquee,
+            headerTransparent: true,
             headerShown: true,
             headerTitle: "",
           }}

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -19,6 +19,7 @@ import { useUserPreferencesStore } from "~/services/UserPreferences";
 import { mutateGuard } from "~/lib/react-query";
 import { formatSeconds } from "~/utils/number";
 import { Marquee } from "~/components/Containment/Marquee";
+import { SafeContainer } from "~/components/Containment/SafeContainer";
 import { IconButton } from "~/components/Form/Button";
 import { Slider } from "~/components/Form/Slider";
 import { Back } from "~/components/Transition/Back";
@@ -59,14 +60,16 @@ export default function NowPlayingScreen() {
           ),
         }}
       />
-      <NowPlayingArtwork artwork={track.artwork} />
-      <View className="gap-2 p-4">
-        <Metadata name={track.name} artistName={track.artistName} />
-        <SeekBar duration={track.duration} />
-        <PlaybackControls />
-        <VolumeSlider />
-        <BottomAppBar trackId={track.id} />
-      </View>
+      <SafeContainer additionalTopOffset={56} className="flex-1">
+        <NowPlayingArtwork artwork={track.artwork} />
+        <View className="gap-2 p-4">
+          <Metadata name={track.name} artistName={track.artistName} />
+          <SeekBar duration={track.duration} />
+          <PlaybackControls />
+          <VolumeSlider />
+          <BottomAppBar trackId={track.id} />
+        </View>
+      </SafeContainer>
     </>
   );
 }

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -1,10 +1,7 @@
 import { Stack } from "expo-router";
-import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { View, useWindowDimensions } from "react-native";
+import { View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
-import { GestureDetector } from "react-native-gesture-handler";
-import Animated from "react-native-reanimated";
 import { useProgress } from "react-native-track-player";
 
 import { Favorite } from "~/icons/Favorite";
@@ -16,7 +13,7 @@ import { useFavoriteTrack, useTrack } from "~/queries/track";
 import { useMusicStore } from "~/modules/media/services/Music";
 import { MusicControls } from "~/modules/media/services/Playback";
 import { useSeekStore } from "~/screens/NowPlaying/SeekService";
-import { useVinylSeekbar } from "~/screens/NowPlaying/useVinylSeekbar";
+import { NowPlayingArtwork } from "~/screens/NowPlaying/Artwork";
 import { useUserPreferencesStore } from "~/services/UserPreferences";
 
 import { mutateGuard } from "~/lib/react-query";
@@ -33,8 +30,6 @@ import {
   RepeatButton,
   ShuffleButton,
 } from "~/modules/media/components/MediaControls";
-import { MediaImage } from "~/modules/media/components/MediaImage";
-import { Vinyl } from "~/modules/media/components/Vinyl";
 
 /** Screen for `/now-playing` route. */
 export default function NowPlayingScreen() {
@@ -64,7 +59,7 @@ export default function NowPlayingScreen() {
           ),
         }}
       />
-      <Artwork artwork={track.artwork} />
+      <NowPlayingArtwork artwork={track.artwork} />
       <View className="gap-2 p-4">
         <Metadata name={track.name} artistName={track.artistName} />
         <SeekBar duration={track.duration} />
@@ -75,50 +70,6 @@ export default function NowPlayingScreen() {
     </>
   );
 }
-
-//#region Artwork
-/** Renders the artwork of the current playing track. */
-function Artwork({ artwork: source }: { artwork: string | null }) {
-  const { width } = useWindowDimensions();
-  const [areaHeight, setAreaHeight] = useState<number | null>(null);
-  const nowPlayingDesign = useUserPreferencesStore(
-    (state) => state.nowPlayingDesign,
-  );
-
-  /* Get the height for the artwork that maximizes the space. */
-  const size = useMemo(() => {
-    if (areaHeight === null) return undefined;
-    // Exclude the padding around the image depending on which measurement is used.
-    return (areaHeight > width ? width : areaHeight) - 32;
-  }, [areaHeight, width]);
-
-  return (
-    <View
-      onLayout={({ nativeEvent }) => setAreaHeight(nativeEvent.layout.height)}
-      className="flex-1 items-center pt-8"
-    >
-      {size !== undefined &&
-        (nowPlayingDesign === "vinyl" ? (
-          <VinylSeekBar {...{ source, size }} />
-        ) : (
-          <MediaImage type="track" {...{ source, size }} />
-        ))}
-    </View>
-  );
-}
-
-/** Seekbar variant that uses the vinyl artwork. */
-function VinylSeekBar(props: { source: string | null; size: number }) {
-  const { initCenter, vinylStyle, seekGesture } = useVinylSeekbar();
-  return (
-    <GestureDetector gesture={seekGesture}>
-      <Animated.View onLayout={initCenter} style={vinylStyle}>
-        <Vinyl onPress={MusicControls.playToggle} {...props} />
-      </Animated.View>
-    </GestureDetector>
-  );
-}
-//#endregion
 
 //#region Metadata
 /** Renders the name & artist of the current playing track. */

--- a/mobile/src/components/Containment/SafeContainer.tsx
+++ b/mobile/src/components/Containment/SafeContainer.tsx
@@ -4,23 +4,29 @@ import type { AnimatedProps } from "react-native-reanimated";
 import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+type ContainerProps = { additionalTopOffset?: number } & (
+  | ({ animated: true } & AnimatedProps<ViewProps>)
+  | ({ animated?: false } & ViewProps)
+);
+
 /**
  * Regular or animated `<View />` with default top padding to account for
- * status bar. `paddingTop` style not supported.
+ * status bar. `paddingTop` style not supported — use `additionalTopOffset`
+ * prop instead.
  */
 export function SafeContainer({
   animated = false,
+  additionalTopOffset = 0,
   style,
   ...props
-}:
-  | ({ animated: true } & AnimatedProps<ViewProps>)
-  | ({ animated?: false } & ViewProps)) {
+}: ContainerProps) {
   const insets = useSafeAreaInsets();
+  const paddingTop = insets.top + additionalTopOffset;
   // Note: Last style has precedence.
   return animated ? (
-    <Animated.View {...props} style={[style, { paddingTop: insets.top }]} />
+    <Animated.View {...props} style={[style, { paddingTop }]} />
   ) : (
     // @ts-expect-error ts(2769) — Unreasonable conflict with `style` prop.
-    <View {...props} style={[style, { paddingTop: insets.top }]} />
+    <View {...props} style={[style, { paddingTop }]} />
   );
 }

--- a/mobile/src/components/TopAppBar.tsx
+++ b/mobile/src/components/TopAppBar.tsx
@@ -59,7 +59,7 @@ export function TopAppBarMarquee({ options, route }: NativeStackHeaderProps) {
   const title = getHeaderTitle(options, route.name);
 
   return (
-    <SafeContainer className="bg-canvas">
+    <SafeContainer className="bg-canvas/80">
       <View className="h-14 flex-row items-center justify-between gap-4 p-1">
         <IconButton
           kind="ripple"

--- a/mobile/src/components/TopAppBar.tsx
+++ b/mobile/src/components/TopAppBar.tsx
@@ -1,8 +1,10 @@
 import { getHeaderTitle } from "@react-navigation/elements";
 import type { NativeStackHeaderProps } from "@react-navigation/native-stack";
+import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { ArrowBack } from "~/icons/ArrowBack";
 import { useTheme } from "~/hooks/useTheme";
@@ -54,12 +56,20 @@ export function TopAppBar({ options, route }: NativeStackHeaderProps) {
  * a single line through a `<Marquee />`.
  */
 export function TopAppBarMarquee({ options, route }: NativeStackHeaderProps) {
+  const insets = useSafeAreaInsets();
   const { t } = useTranslation();
-  const { canvas } = useTheme();
+  const { canvas, theme } = useTheme();
   const title = getHeaderTitle(options, route.name);
 
   return (
-    <SafeContainer className="bg-canvas/80">
+    <SafeContainer className="relative">
+      <LinearGradient
+        colors={[`${canvas}${theme === "light" ? "B3" : "00"}`, `${canvas}FF`]}
+        start={{ x: 0.0, y: 1.0 }}
+        end={{ x: 0.0, y: 0.0 }}
+        style={{ height: insets.top + 56 }}
+        className="absolute left-0 top-0 w-full"
+      />
       <View className="h-14 flex-row items-center justify-between gap-4 p-1">
         <IconButton
           kind="ripple"

--- a/mobile/src/screens/NowPlaying/Artwork.tsx
+++ b/mobile/src/screens/NowPlaying/Artwork.tsx
@@ -2,7 +2,12 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View, useWindowDimensions } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
-import Animated from "react-native-reanimated";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from "react-native-reanimated";
 
 import { useMusicStore } from "~/modules/media/services/Music";
 import { MusicControls } from "~/modules/media/services/Playback";
@@ -44,7 +49,8 @@ function ArtworkPicker(props: ArtworkProps) {
 
   if (usedDesign === "plain") return <PlainArtwork {...props} />;
   else if (usedDesign === "vinyl") return <VinylSeekBar {...props} />;
-  else return null;
+  else if (usedDesign === "vinylOld") return <VinylLegacy {...props} />;
+  return null;
 }
 
 /** Plain artwork design. */
@@ -70,5 +76,33 @@ function VinylSeekBar(props: ArtworkProps) {
         <Vinyl onPress={MusicControls.playToggle} {...props} />
       </Animated.View>
     </GestureDetector>
+  );
+}
+
+/** Similar artwork design seen in v1, but with the new features. */
+function VinylLegacy(props: ArtworkProps) {
+  const coverPosition = useSharedValue(0);
+  const coverStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: coverPosition.value }],
+  }));
+  return (
+    <View
+      onLayout={() => {
+        coverPosition.value = withDelay(
+          50,
+          withTiming(-props.size / 2, { duration: 500 }),
+        );
+      }}
+      className="relative"
+    >
+      <VinylSeekBar {...props} />
+      <Animated.View
+        pointerEvents="none"
+        style={coverStyle}
+        className="absolute left-0 top-0 z-10"
+      >
+        <MediaImage type="track" {...props} />
+      </Animated.View>
+    </View>
   );
 }

--- a/mobile/src/screens/NowPlaying/Artwork.tsx
+++ b/mobile/src/screens/NowPlaying/Artwork.tsx
@@ -32,7 +32,7 @@ export function NowPlayingArtwork(props: { artwork: string | null }) {
   return (
     <View
       onLayout={({ nativeEvent }) => setAreaHeight(nativeEvent.layout.height)}
-      className="flex-1 items-center pt-8"
+      className="flex-1 items-center justify-center pt-8"
     >
       {size !== undefined ? (
         <ArtworkPicker source={props.artwork} size={size} />

--- a/mobile/src/screens/NowPlaying/Artwork.tsx
+++ b/mobile/src/screens/NowPlaying/Artwork.tsx
@@ -1,0 +1,63 @@
+import { useMemo, useState } from "react";
+import { View, useWindowDimensions } from "react-native";
+import { GestureDetector } from "react-native-gesture-handler";
+import Animated from "react-native-reanimated";
+
+import { MusicControls } from "~/modules/media/services/Playback";
+import { useUserPreferencesStore } from "~/services/UserPreferences";
+import { useVinylSeekbar } from "./useVinylSeekbar";
+
+import { MediaImage } from "~/modules/media/components/MediaImage";
+import { Vinyl } from "~/modules/media/components/Vinyl";
+
+/** Renders the artwork of the current playing track. */
+export function NowPlayingArtwork(props: { artwork: string | null }) {
+  const { width } = useWindowDimensions();
+  const [areaHeight, setAreaHeight] = useState<number | null>(null);
+
+  /* Get the height for the artwork that maximizes the space. */
+  const size = useMemo(() => {
+    if (areaHeight === null) return undefined;
+    // Exclude the padding around the image depending on which measurement is used.
+    return (areaHeight > width ? width : areaHeight) - 32;
+  }, [areaHeight, width]);
+
+  return (
+    <View
+      onLayout={({ nativeEvent }) => setAreaHeight(nativeEvent.layout.height)}
+      className="flex-1 items-center pt-8"
+    >
+      {size !== undefined ? (
+        <ArtworkPicker source={props.artwork} size={size} />
+      ) : null}
+    </View>
+  );
+}
+
+type ArtworkProps = { source: string | null; size: number };
+
+/** Determines which artwork is rendered. */
+function ArtworkPicker(props: ArtworkProps) {
+  const usedDesign = useUserPreferencesStore((state) => state.nowPlayingDesign);
+
+  if (usedDesign === "plain") return <PlainArtwork {...props} />;
+  else if (usedDesign === "vinyl") return <VinylSeekBar {...props} />;
+  else return null;
+}
+
+/** Plain artwork design. */
+function PlainArtwork(props: ArtworkProps) {
+  return <MediaImage type="track" {...props} />;
+}
+
+/** Seekbar variant that uses the vinyl artwork. */
+function VinylSeekBar(props: ArtworkProps) {
+  const { initCenter, vinylStyle, seekGesture } = useVinylSeekbar();
+  return (
+    <GestureDetector gesture={seekGesture}>
+      <Animated.View onLayout={initCenter} style={vinylStyle}>
+        <Vinyl onPress={MusicControls.playToggle} {...props} />
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/mobile/src/screens/NowPlaying/Artwork.tsx
+++ b/mobile/src/screens/NowPlaying/Artwork.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from "react";
-import { View, useWindowDimensions } from "react-native";
+import { useTranslation } from "react-i18next";
+import { Pressable, View, useWindowDimensions } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
 
+import { useMusicStore } from "~/modules/media/services/Music";
 import { MusicControls } from "~/modules/media/services/Playback";
 import { useUserPreferencesStore } from "~/services/UserPreferences";
 import { useVinylSeekbar } from "./useVinylSeekbar";
@@ -47,7 +49,16 @@ function ArtworkPicker(props: ArtworkProps) {
 
 /** Plain artwork design. */
 function PlainArtwork(props: ArtworkProps) {
-  return <MediaImage type="track" {...props} />;
+  const { t } = useTranslation();
+  const isPlaying = useMusicStore((state) => state.isPlaying);
+  return (
+    <Pressable
+      accessibilityLabel={t(`term.${isPlaying ? "pause" : "play"}`)}
+      onPress={MusicControls.playToggle}
+    >
+      <MediaImage type="track" {...props} />
+    </Pressable>
+  );
 }
 
 /** Seekbar variant that uses the vinyl artwork. */

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -19,7 +19,7 @@ export const ThemeOptions = ["light", "dark", "system"] as const;
 /** Options for app accent font. */
 export const FontOptions = ["NDot", "NType", "Roboto"] as const;
 /** Options for "Now Playing" screen designs. */
-export const NowPlayingDesignOptions = ["vinyl", "plain"] as const;
+export const NowPlayingDesignOptions = ["vinyl", "vinylOld", "plain"] as const;
 /** Options for the tabs we can reorder. */
 export type OrderableTab = "album" | "artist" | "folder" | "playlist" | "track";
 


### PR DESCRIPTION
# Summary

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

I've received a request a while back asking for whether we'll reintroduced the "old" vinyl design, which became feasible as after I sent `v2.1.0` for review, I just realized that I could copied the idea used for the "current" screens and have the cover move off-screen. This makes calculating the area easier as all we care about is getting a square instead of a rectangle (since prior, the vinyl moved), which also keeps the more "consistent" design across devices.

A quick summary of the design:
- We use the new vinyl design & logic instead of the original look (which was the one from the Nothing Recorder app), meaning we get the benefits of the new design (using it as a seekbar).
- The cover can go under the header.
  - This looks good in dark mode, but bad in light mode due to wanting to maintain a contrast such that you can still see what in the header (the back button, the name of the list we're playing, button to open a modal containing information about the current track).
  - **The appearance underneath the header might be improved whenever we switch to the New Architecture, which would allow us to use the "blur" filter, which might improve things.**

Internal Changes:
- Add tap to play/pause on "plain" artwork design.
- Enable the ability to pass a value for the top padding for `<SafeContainer />` via a new `additionalTopOffset` prop.
- Have `<TopAppBarMarquee />` use a linear gradient background (to make the artwork visible underneath the header on the "Now Playing" screen). This could also be applied to `<TopAppBar />`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
