### PR TITLE
chore: Modified "Now Playing" design

### DIFF
--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -11,7 +11,8 @@ import { AppProvider } from "~/providers";
 
 import "~/resources/global.css";
 import "~/modules/i18n"; // Make sure translations are bundled.
-import { TopAppBar, TopAppBarMarquee } from "~/components/TopAppBar";
+import { TopAppBar } from "~/components/TopAppBar";
+import { NowPlayingTopAppBar } from "~/screens/NowPlaying/TopAppBar";
 
 // Catch any errors thrown by the Layout component.
 export { ErrorBoundary };
@@ -86,7 +87,7 @@ function RootLayoutNav() {
           name="now-playing"
           options={{
             animation: "slide_from_bottom",
-            header: TopAppBarMarquee,
+            header: NowPlayingTopAppBar,
             headerTransparent: true,
             headerShown: true,
             headerTitle: "",

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -65,9 +65,7 @@ function Metadata({ track }: { track: TrackWithAlbum }) {
     <View className="flex-row items-center gap-4">
       <View className="shrink grow gap-1">
         <Marquee>
-          <StyledText className="text-xl leading-[1.125]">
-            {track.name}
-          </StyledText>
+          <StyledText className="text-xl/[1.125]">{track.name}</StyledText>
         </Marquee>
         <MarqueeLink href={`/artist/${track.artistName}`} className="text-red">
           {track.artistName}
@@ -89,6 +87,20 @@ function Metadata({ track }: { track: TrackWithAlbum }) {
         >
           <MoreVert size={32} />
         </IconButton>
+      </View>
+      {/*
+        "Spacer" to prevent layout shift when missing album or artist name.
+        There needs to be some content within the text to have the line height
+        take effect.
+      */}
+      <View
+        aria-hidden
+        pointerEvents="none"
+        className="invisible -ml-4 w-0 gap-1"
+      >
+        <StyledText className="text-xl/[1.125]"> </StyledText>
+        <StyledText className="text-sm/[1.125]"> </StyledText>
+        <StyledText className="text-sm/[1.125]"> </StyledText>
       </View>
     </View>
   );
@@ -120,15 +132,16 @@ function FavoriteButton(props: { trackId: string }) {
 function MarqueeLink({
   href,
   className,
+  children,
   ...rest
 }: React.ComponentProps<typeof StyledText> & { href: Href }) {
+  if (!children) return null;
   return (
     <Marquee>
       <Pressable onPress={() => router.navigate(href)}>
-        <StyledText
-          className={cn("text-sm leading-[1.125]", className)}
-          {...rest}
-        />
+        <StyledText className={cn("text-sm/[1.125]", className)} {...rest}>
+          {children}
+        </StyledText>
       </Pressable>
     </Marquee>
   );

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -1,5 +1,5 @@
 import type { Href } from "expo-router";
-import { Stack, router } from "expo-router";
+import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 import { SheetManager } from "react-native-actions-sheet";
@@ -9,6 +9,7 @@ import type { TrackWithAlbum } from "~/db/schema";
 
 import { Favorite } from "~/icons/Favorite";
 import { InstantMix } from "~/icons/InstantMix";
+import { KeyboardArrowDown } from "~/icons/KeyboardArrowDown";
 import { LibraryMusic } from "~/icons/LibraryMusic";
 import { MoreVert } from "~/icons/MoreVert";
 import { useFavoriteTrack, useTrack } from "~/queries/track";
@@ -37,23 +38,17 @@ import {
 /** Screen for `/now-playing` route. */
 export default function NowPlayingScreen() {
   const track = useMusicStore((state) => state.activeTrack);
-  const listName = useMusicStore((state) => state.sourceName);
-
   if (!track) return <Back />;
-
   return (
-    <>
-      <Stack.Screen options={{ headerTitle: listName }} />
-      <SafeContainer additionalTopOffset={56} className="flex-1 gap-8">
-        <NowPlayingArtwork artwork={track.artwork} />
-        <View className="gap-6 px-4">
-          <Metadata track={track} />
-          <SeekBar duration={track.duration} />
-          <PlaybackControls />
-        </View>
-        <BottomAppBar />
-      </SafeContainer>
-    </>
+    <SafeContainer additionalTopOffset={56} className="flex-1 gap-8">
+      <NowPlayingArtwork artwork={track.artwork} />
+      <View className="gap-6 px-4">
+        <Metadata track={track} />
+        <SeekBar duration={track.duration} />
+        <PlaybackControls />
+      </View>
+      <BottomAppBar />
+    </SafeContainer>
   );
 }
 
@@ -200,25 +195,37 @@ function PlaybackControls() {
 function BottomAppBar() {
   const { t } = useTranslation();
   return (
-    <View className="flex-row items-center justify-end gap-4 p-4">
+    <View className="flex-row items-center justify-between gap-4 p-4">
       <IconButton
         kind="ripple"
-        accessibilityLabel={t("feat.playback.extra.options")}
-        onPress={() => SheetManager.show("PlaybackOptionsSheet")}
+        accessibilityLabel={t("form.back")}
+        onPress={() => router.back()}
         rippleRadius={24}
         className="p-2"
       >
-        <InstantMix size={32} />
+        <KeyboardArrowDown size={32} />
       </IconButton>
-      <IconButton
-        kind="ripple"
-        accessibilityLabel={t("term.upcoming")}
-        onPress={() => SheetManager.show("TrackUpcomingSheet")}
-        rippleRadius={24}
-        className="p-2"
-      >
-        <LibraryMusic size={32} />
-      </IconButton>
+
+      <View className="flex-row items-center gap-4">
+        <IconButton
+          kind="ripple"
+          accessibilityLabel={t("feat.playback.extra.options")}
+          onPress={() => SheetManager.show("PlaybackOptionsSheet")}
+          rippleRadius={24}
+          className="p-2"
+        >
+          <InstantMix size={32} />
+        </IconButton>
+        <IconButton
+          kind="ripple"
+          accessibilityLabel={t("term.upcoming")}
+          onPress={() => SheetManager.show("TrackUpcomingSheet")}
+          rippleRadius={24}
+          className="p-2"
+        >
+          <LibraryMusic size={32} />
+        </IconButton>
+      </View>
     </View>
   );
 }

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -15,6 +15,7 @@ import { MoreVert } from "~/icons/MoreVert";
 import { useFavoriteTrack, useTrack } from "~/queries/track";
 import { useMusicStore } from "~/modules/media/services/Music";
 import { MusicControls } from "~/modules/media/services/Playback";
+import { useUserPreferencesStore } from "~/services/UserPreferences";
 import { useSeekStore } from "~/screens/NowPlaying/SeekService";
 import { NowPlayingArtwork } from "~/screens/NowPlaying/Artwork";
 
@@ -145,7 +146,7 @@ function MarqueeLink({
 
 //#region Seek Bar
 /** Allows us to change the current positon of the playing track. */
-export function SeekBar({ duration }: { duration: number }) {
+function SeekBar({ duration }: { duration: number }) {
   const { position } = useProgress(200);
   const sliderPos = useSeekStore((state) => state.sliderPos);
   const setSliderPos = useSeekStore((state) => state.setSliderPos);
@@ -196,16 +197,7 @@ function BottomAppBar() {
   const { t } = useTranslation();
   return (
     <View className="flex-row items-center justify-between gap-4 p-4">
-      <IconButton
-        kind="ripple"
-        accessibilityLabel={t("form.back")}
-        onPress={() => router.back()}
-        rippleRadius={24}
-        className="p-2"
-      >
-        <KeyboardArrowDown size={32} />
-      </IconButton>
-
+      <BackButton />
       <View className="flex-row items-center gap-4">
         <IconButton
           kind="ripple"
@@ -227,6 +219,29 @@ function BottomAppBar() {
         </IconButton>
       </View>
     </View>
+  );
+}
+
+/**
+ * Conditionally render the back button in the bottom app bar if we're
+ * using the `Vinyl (Legacy)` design.
+ */
+function BackButton() {
+  const { t } = useTranslation();
+  const usedDesign = useUserPreferencesStore((state) => state.nowPlayingDesign);
+
+  if (usedDesign !== "vinylOld") return <View />;
+
+  return (
+    <IconButton
+      kind="ripple"
+      accessibilityLabel={t("form.back")}
+      onPress={() => router.back()}
+      rippleRadius={24}
+      className="p-2"
+    >
+      <KeyboardArrowDown size={32} />
+    </IconButton>
   );
 }
 //#endregion

--- a/mobile/src/app/now-playing.tsx
+++ b/mobile/src/app/now-playing.tsx
@@ -155,7 +155,7 @@ function SeekBar({ duration }: { duration: number }) {
   const clampedPos = displayedPos > duration ? duration : displayedPos;
 
   return (
-    <View className="gap-2">
+    <View>
       <Slider
         value={clampedPos}
         max={duration}

--- a/mobile/src/components/Containment/Marquee.tsx
+++ b/mobile/src/components/Containment/Marquee.tsx
@@ -38,6 +38,16 @@ export function Marquee({
 }) {
   const { canvasAlt } = useTheme();
   const shadowColor = useMemo(() => color ?? canvasAlt, [color, canvasAlt]);
+  // This will enable support of hexadecimal colors with opacity.
+  const startColor = useMemo(
+    () =>
+      `${shadowColor.length === 7 ? shadowColor : shadowColor.slice(0, 7)}00`,
+    [shadowColor],
+  );
+  const endColor = useMemo(
+    () => (shadowColor.length === 7 ? `${shadowColor}E6` : shadowColor),
+    [shadowColor],
+  );
 
   const offset = useSharedValue(0);
   const [containerWidth, setContainerWidth] = useState(-1);
@@ -116,20 +126,14 @@ export function Marquee({
         style={isLeftVisible}
         className={cn("absolute left-0 h-full", { hidden: isStatic })}
       >
-        <LinearGradient
-          colors={[`${shadowColor}E6`, `${shadowColor}00`]}
-          {...ShadowProps}
-        />
+        <LinearGradient colors={[endColor, startColor]} {...ShadowProps} />
       </Animated.View>
       <Animated.View
         pointerEvents="none"
         style={isRightVisible}
         className={cn("absolute right-0 h-full", { hidden: isStatic })}
       >
-        <LinearGradient
-          colors={[`${shadowColor}00`, `${shadowColor}E6`]}
-          {...ShadowProps}
-        />
+        <LinearGradient colors={[startColor, endColor]} {...ShadowProps} />
       </Animated.View>
     </View>
   );

--- a/mobile/src/components/Form/Slider.tsx
+++ b/mobile/src/components/Form/Slider.tsx
@@ -32,7 +32,7 @@ export function Slider(props: {
       thumbTintColor={Colors.red}
       thumbStyle={{ height: props.thumbSize, width: props.thumbSize }}
       trackStyle={{ height: props.thumbSize / 2, borderRadius: 999 }}
-      containerStyle={{ height: props.thumbSize }}
+      containerStyle={{ height: props.thumbSize + 16 }}
     />
   );
 }

--- a/mobile/src/components/Form/Slider.tsx
+++ b/mobile/src/components/Form/Slider.tsx
@@ -32,6 +32,7 @@ export function Slider(props: {
       thumbTintColor={Colors.red}
       thumbStyle={{ height: props.thumbSize, width: props.thumbSize }}
       trackStyle={{ height: props.thumbSize / 2, borderRadius: 999 }}
+      containerStyle={{ height: props.thumbSize }}
     />
   );
 }

--- a/mobile/src/components/TopAppBar.tsx
+++ b/mobile/src/components/TopAppBar.tsx
@@ -1,20 +1,15 @@
 import { getHeaderTitle } from "@react-navigation/elements";
 import type { NativeStackHeaderProps } from "@react-navigation/native-stack";
-import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { ArrowBack } from "~/icons/ArrowBack";
-import { useTheme } from "~/hooks/useTheme";
 
-import { Marquee } from "./Containment/Marquee";
 import { SafeContainer } from "./Containment/SafeContainer";
 import { IconButton } from "./Form/Button";
 import { StyledText } from "./Typography/StyledText";
 
-//#region Normal
 /**
  * Custom header bar for React Navigation. The "title" can span at most
  * 2 lines before it gets ellipsized.
@@ -48,49 +43,3 @@ export function TopAppBar({ options, route }: NativeStackHeaderProps) {
     </SafeContainer>
   );
 }
-//#endregion
-
-//#region With Marquee
-/**
- * Custom header bar for React Navigation. The "title" will span across
- * a single line through a `<Marquee />`.
- */
-export function TopAppBarMarquee({ options, route }: NativeStackHeaderProps) {
-  const insets = useSafeAreaInsets();
-  const { t } = useTranslation();
-  const { canvas, theme } = useTheme();
-  const title = getHeaderTitle(options, route.name);
-
-  return (
-    <SafeContainer className="relative">
-      <LinearGradient
-        colors={[`${canvas}${theme === "light" ? "B3" : "00"}`, `${canvas}FF`]}
-        start={{ x: 0.0, y: 1.0 }}
-        end={{ x: 0.0, y: 0.0 }}
-        style={{ height: insets.top + 56 }}
-        className="absolute left-0 top-0 w-full"
-      />
-      <View className="h-14 flex-row items-center justify-between gap-4 p-1">
-        <IconButton
-          kind="ripple"
-          accessibilityLabel={t("form.back")}
-          disabled={!!options.headerLeft}
-          onPress={() => router.back()}
-        >
-          <ArrowBack />
-        </IconButton>
-
-        <Marquee color={canvas} center wrapperClassName="shrink">
-          <StyledText className="text-xs">{title}</StyledText>
-        </Marquee>
-
-        {options.headerRight ? (
-          options.headerRight({ canGoBack: true })
-        ) : (
-          <View className="size-12" />
-        )}
-      </View>
-    </SafeContainer>
-  );
-}
-//#endregion

--- a/mobile/src/icons/KeyboardArrowDown.tsx
+++ b/mobile/src/icons/KeyboardArrowDown.tsx
@@ -1,0 +1,14 @@
+import Svg, { Path } from "react-native-svg";
+
+import { useTheme } from "~/hooks/useTheme";
+import type { Icon } from "./type";
+
+export function KeyboardArrowDown({ size = 24, color }: Icon) {
+  const { foreground } = useTheme();
+  const usedColor = color ?? foreground;
+  return (
+    <Svg width={size} height={size} viewBox="0 -960 960 960" fill={usedColor}>
+      <Path d="m480-361.89-221.31-221.3 39.73-38.92L480-440.54l181.58-181.57 39.73 38.92L480-361.89Z" />
+    </Svg>
+  );
+}

--- a/mobile/src/screens/NowPlaying/Artwork.tsx
+++ b/mobile/src/screens/NowPlaying/Artwork.tsx
@@ -17,7 +17,10 @@ import { useVinylSeekbar } from "./useVinylSeekbar";
 import { MediaImage } from "~/modules/media/components/MediaImage";
 import { Vinyl } from "~/modules/media/components/Vinyl";
 
-/** Renders the artwork of the current playing track. */
+/**
+ * Renders the artwork of the current playing track (with a minimum 16px
+ * of padding around the artwork).
+ */
 export function NowPlayingArtwork(props: { artwork: string | null }) {
   const { width } = useWindowDimensions();
   const [areaHeight, setAreaHeight] = useState<number | null>(null);

--- a/mobile/src/screens/NowPlaying/Artwork.tsx
+++ b/mobile/src/screens/NowPlaying/Artwork.tsx
@@ -32,7 +32,7 @@ export function NowPlayingArtwork(props: { artwork: string | null }) {
   return (
     <View
       onLayout={({ nativeEvent }) => setAreaHeight(nativeEvent.layout.height)}
-      className="flex-1 items-center justify-center pt-8"
+      className="flex-1 items-center justify-center"
     >
       {size !== undefined ? (
         <ArtworkPicker source={props.artwork} size={size} />

--- a/mobile/src/screens/NowPlaying/TopAppBar.tsx
+++ b/mobile/src/screens/NowPlaying/TopAppBar.tsx
@@ -1,6 +1,8 @@
+import type { Href } from "expo-router";
+import { router } from "expo-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
+import { Pressable, View } from "react-native";
 
 import { useUserPreferencesStore } from "~/services/UserPreferences";
 import { useMusicStore } from "~/modules/media/services/Music";
@@ -9,6 +11,7 @@ import { useTheme } from "~/hooks/useTheme";
 import { Marquee } from "~/components/Containment/Marquee";
 import { SafeContainer } from "~/components/Containment/SafeContainer";
 import { StyledText } from "~/components/Typography/StyledText";
+import { ReservedPlaylists } from "~/modules/media/constants";
 
 /**
  * Header bar design for "Now Playing" screen which automatically displays
@@ -17,6 +20,7 @@ import { StyledText } from "~/components/Typography/StyledText";
 export function NowPlayingTopAppBar() {
   const { t } = useTranslation();
   const { canvas } = useTheme();
+  const playingSource = useMusicStore((state) => state.playingSource);
   const listName = useMusicStore((state) => state.sourceName);
   const usedDesign = useUserPreferencesStore((state) => state.nowPlayingDesign);
 
@@ -25,12 +29,23 @@ export function NowPlayingTopAppBar() {
     [canvas, usedDesign],
   );
 
+  const listHref = useMemo(() => {
+    if (!playingSource || playingSource.type === "folder") return undefined;
+    const { type, id } = playingSource;
+    if (type === "playlist" && id === ReservedPlaylists.tracks) return "/track";
+    return `/${type}/${encodeURIComponent(id)}` satisfies Href;
+  }, [playingSource]);
+
   return (
     <SafeContainer className="relative">
       <View className="h-14 flex-row items-center justify-between gap-4 p-1">
         <View className="size-12" />
 
-        <View className="shrink gap-0.5 rounded bg-canvas/75 px-4 py-2 dark:bg-canvas/60">
+        <Pressable
+          onPress={() => (listHref ? router.navigate(listHref) : undefined)}
+          disabled={listHref === undefined}
+          className="shrink gap-0.5 rounded bg-canvas/75 px-4 py-2 dark:bg-canvas/60"
+        >
           <Marquee color={shadowColor} center wrapperClassName="shrink">
             <StyledText className="text-xxs/[1.125]" dim>
               {t("term.playingFrom")}
@@ -39,7 +54,7 @@ export function NowPlayingTopAppBar() {
           <Marquee color={shadowColor} center wrapperClassName="shrink">
             <StyledText className="text-xs/[1.125]">{listName}</StyledText>
           </Marquee>
-        </View>
+        </Pressable>
 
         <View className="size-12" />
       </View>

--- a/mobile/src/screens/NowPlaying/TopAppBar.tsx
+++ b/mobile/src/screens/NowPlaying/TopAppBar.tsx
@@ -4,12 +4,14 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 
+import { ArrowBack } from "~/icons/ArrowBack";
 import { useUserPreferencesStore } from "~/services/UserPreferences";
 import { useMusicStore } from "~/modules/media/services/Music";
 import { useTheme } from "~/hooks/useTheme";
 
 import { Marquee } from "~/components/Containment/Marquee";
 import { SafeContainer } from "~/components/Containment/SafeContainer";
+import { IconButton } from "~/components/Form/Button";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ReservedPlaylists } from "~/modules/media/constants";
 
@@ -18,16 +20,22 @@ import { ReservedPlaylists } from "~/modules/media/constants";
  * the list being played without setting the `title` prop.
  */
 export function NowPlayingTopAppBar() {
+  return (
+    <SafeContainer className="relative">
+      <View className="h-14 flex-row items-center justify-between gap-4 p-1">
+        <AppBarContent />
+      </View>
+    </SafeContainer>
+  );
+}
+
+/** Conditionally render the header content depending on the design used. */
+function AppBarContent() {
   const { t } = useTranslation();
   const { canvas } = useTheme();
   const playingSource = useMusicStore((state) => state.playingSource);
   const listName = useMusicStore((state) => state.sourceName);
   const usedDesign = useUserPreferencesStore((state) => state.nowPlayingDesign);
-
-  const shadowColor = useMemo(
-    () => (usedDesign === "vinylOld" ? `${canvas}00` : canvas),
-    [canvas, usedDesign],
-  );
 
   const listHref = useMemo(() => {
     if (!playingSource || playingSource.type === "folder") return undefined;
@@ -36,28 +44,32 @@ export function NowPlayingTopAppBar() {
     return `/${type}/${encodeURIComponent(id)}` satisfies Href;
   }, [playingSource]);
 
+  if (usedDesign === "vinylOld") return null;
+
   return (
-    <SafeContainer className="relative">
-      <View className="h-14 flex-row items-center justify-between gap-4 p-1">
-        <View className="size-12" />
-
-        <Pressable
-          onPress={() => (listHref ? router.navigate(listHref) : undefined)}
-          disabled={listHref === undefined}
-          className="shrink gap-0.5 rounded bg-canvas/75 px-4 py-2 dark:bg-canvas/60"
-        >
-          <Marquee color={shadowColor} center wrapperClassName="shrink">
-            <StyledText className="text-xxs/[1.125]" dim>
-              {t("term.playingFrom")}
-            </StyledText>
-          </Marquee>
-          <Marquee color={shadowColor} center wrapperClassName="shrink">
-            <StyledText className="text-xs/[1.125]">{listName}</StyledText>
-          </Marquee>
-        </Pressable>
-
-        <View className="size-12" />
-      </View>
-    </SafeContainer>
+    <>
+      <IconButton
+        kind="ripple"
+        accessibilityLabel={t("form.back")}
+        onPress={() => router.back()}
+      >
+        <ArrowBack />
+      </IconButton>
+      <Pressable
+        onPress={() => (listHref ? router.navigate(listHref) : undefined)}
+        disabled={listHref === undefined}
+        className="shrink gap-0.5"
+      >
+        <Marquee color={canvas} center wrapperClassName="shrink">
+          <StyledText className="text-xxs/[1.125]" dim>
+            {t("term.playingFrom")}
+          </StyledText>
+        </Marquee>
+        <Marquee color={canvas} center wrapperClassName="shrink">
+          <StyledText className="text-xs/[1.125]">{listName}</StyledText>
+        </Marquee>
+      </Pressable>
+      <View className="size-12" />
+    </>
   );
 }

--- a/mobile/src/screens/NowPlaying/TopAppBar.tsx
+++ b/mobile/src/screens/NowPlaying/TopAppBar.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { View } from "react-native";
+
+import { useUserPreferencesStore } from "~/services/UserPreferences";
+import { useMusicStore } from "~/modules/media/services/Music";
+import { useTheme } from "~/hooks/useTheme";
+
+import { Marquee } from "~/components/Containment/Marquee";
+import { SafeContainer } from "~/components/Containment/SafeContainer";
+import { StyledText } from "~/components/Typography/StyledText";
+
+/**
+ * Header bar design for "Now Playing" screen which automatically displays
+ * the list being played without setting the `title` prop.
+ */
+export function NowPlayingTopAppBar() {
+  const { t } = useTranslation();
+  const { canvas } = useTheme();
+  const listName = useMusicStore((state) => state.sourceName);
+  const usedDesign = useUserPreferencesStore((state) => state.nowPlayingDesign);
+
+  const shadowColor = useMemo(
+    () => (usedDesign === "vinylOld" ? `${canvas}00` : canvas),
+    [canvas, usedDesign],
+  );
+
+  return (
+    <SafeContainer className="relative">
+      <View className="h-14 flex-row items-center justify-between gap-4 p-1">
+        <View className="size-12" />
+
+        <View className="shrink gap-0.5 rounded bg-canvas/75 px-4 py-2 dark:bg-canvas/60">
+          <Marquee color={shadowColor} center wrapperClassName="shrink">
+            <StyledText className="text-xxs/[1.125]" dim>
+              {t("term.playingFrom")}
+            </StyledText>
+          </Marquee>
+          <Marquee color={shadowColor} center wrapperClassName="shrink">
+            <StyledText className="text-xs/[1.125]">{listName}</StyledText>
+          </Marquee>
+        </View>
+
+        <View className="size-12" />
+      </View>
+    </SafeContainer>
+  );
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR modifies the "Now Playing" screen to:
- Support for going directly to the current list being played by clicking the "Playing From" at the top.
  - Folders are not supported as of now.
- Improve one-hand usability by moving buttons down.
- Improve the design when using the `Vinyl (Legacy)` artwork design.
  - Moves the back button to the bottom left corner and hides the "Playing From" text.
- Support for going directly to the track's album or artist page by clicking on the displayed album or artist name.

![Now Playing Design Changes](https://github.com/user-attachments/assets/42755443-877a-4969-9e10-dea8ab234693)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
