### PR TITLE
feat: Support for "overriding" album artwork

### DIFF
--- a/mobile/src/api/utils.ts
+++ b/mobile/src/api/utils.ts
@@ -22,8 +22,9 @@ type WithTracksOptions = {
  * Determines if the `tracks` relation is used along with each track's
  * `album` relation.
  *
- * **Note:** The type assertion on the result when it may not even be that
- * is to prevent an error being thrown with the `QueryOneWithTracksFn` type.
+ * **Note:** The typing is very loose as to support the various use case of
+ * `QueryOneWithTracksFn` (we ensure what's returned complies with what's
+ * expected).
  */
 export function withTracks(
   trackOptions: WithTracksOptions,
@@ -51,13 +52,12 @@ type WithAlbumOptions = {
  * Creates the relations through the `with` operator for the `tracks`
  * field.
  *
- * **Note:** The type assertion on the result when it may not even be that
- * is to prevent an error being thrown with the `QueryOneWithTracksFn` type.
+ * **Note:** The typing is very loose as to support the various use case of
+ * `QueryOneWithTracksFn` (we ensure what's returned complies with what's
+ * expected).
  */
 export function withAlbum(options: WithAlbumOptions) {
-  return (
-    (options.withAlbum ?? options.defaultWithAlbum) === true
-      ? { with: { album: { columns: getColumns(options.albumColumns) } } }
-      : {}
-  ) as { with: { album: { columns: ReturnType<typeof getColumns> } } };
+  return ((options.withAlbum ?? options.defaultWithAlbum) === true
+    ? { with: { album: { columns: getColumns(options.albumColumns) } } }
+    : {}) as unknown as { with: { album: true } };
 }

--- a/mobile/src/db/drizzle/0007_cooing_the_stranger.sql
+++ b/mobile/src/db/drizzle/0007_cooing_the_stranger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `albums` ADD `alt_artwork` text;

--- a/mobile/src/db/drizzle/meta/0007_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,467 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bf10b95e-6764-42cd-b031-df23e3bb31f7",
+  "prevId": "35a319be-980b-43c4-af1f-a8217a06258c",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": -1
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "albums_name_artist_name_release_year_unique": {
+          "name": "albums_name_artist_name_release_year_unique",
+          "columns": [
+            "name",
+            "artist_name",
+            "release_year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1738535238286,
       "tag": "0006_wild_gabe_jones",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1741378747816,
+      "tag": "0007_cooing_the_stranger",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -8,6 +8,7 @@ import m0003 from "./0003_breezy_wolverine.sql";
 import m0004 from "./0004_past_starfox.sql";
 import m0005 from "./0005_equal_cerise.sql";
 import m0006 from "./0006_wild_gabe_jones.sql";
+import m0007 from "./0007_cooing_the_stranger.sql";
 
 export default {
   journal,
@@ -19,5 +20,6 @@ export default {
     m0004,
     m0005,
     m0006,
+    m0007,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -39,6 +39,7 @@ export const albums = sqliteTable(
     */
     releaseYear: integer("release_year").default(-1),
     artwork: text(),
+    altArtwork: text(),
     isFavorite: integer({ mode: "boolean" }).notNull().default(false),
   },
   (t) => [unique().on(t.name, t.artistName, t.releaseYear)],

--- a/mobile/src/db/slimTypes.ts
+++ b/mobile/src/db/slimTypes.ts
@@ -6,11 +6,14 @@ export type Artwork = string | null;
 /** Minimum fields required to get `artwork` from tracks. */
 export type TrackArtwork = {
   artwork: Artwork;
-  album?: { artwork: Artwork } | null;
+  album?: { artwork: Artwork; altArtwork: Artwork } | null;
 };
 
 /** Minimum data typically used from `Album`. */
-export type SlimAlbum = Pick<Album, "id" | "name" | "artistName" | "artwork">;
+export type SlimAlbum = Pick<
+  Album,
+  "id" | "name" | "artistName" | "artwork" | "altArtwork"
+>;
 export type SlimAlbumWithTracks = SlimAlbum & { tracks: SlimTrack[] };
 
 /** Minimum data typically used from `Artist`. */
@@ -23,5 +26,5 @@ export type SlimPlaylistWithTracks = SlimPlaylist & { tracks: TrackArtwork[] };
 /** Minimum data typically used from `Track`. */
 export type SlimTrack = Pick<Track, "id" | "name" | "artistName" | "artwork">;
 export type SlimTrackWithAlbum = SlimTrack & {
-  album: { name: string; artwork: Artwork } | null;
+  album: { name: string; artwork: Artwork; altArtwork: Artwork } | null;
 };

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -49,14 +49,12 @@ export function CurrentListLayout(
   const { canvas, foreground } = useTheme();
   const primaryFont = useUserPreferencesStore((state) => state.primaryFont);
 
-  const isFavorite = getIsFavoritePlaylist(props.title, props.mediaSource.type);
+  const isFavorite = getIsFavoritePlaylist(props.mediaSource);
 
   return (
     <>
       <View className="flex-row gap-2 pr-4">
-        <ContentImage
-          {...pickKeys(props, ["title", "mediaSource", "imageSource"])}
-        />
+        <ContentImage {...pickKeys(props, ["mediaSource", "imageSource"])} />
         <View className="shrink grow justify-end">
           <TEm
             dim
@@ -104,15 +102,10 @@ export function CurrentListLayout(
 }
 
 /** Determines the look and features of the image displayed. */
-function ContentImage({
-  title,
-  ...props
-}: { title: string } & AnimatedVinylProps) {
+function ContentImage(props: AnimatedVinylProps) {
   const { t } = useTranslation();
 
-  const type = props.mediaSource.type;
-
-  if (getIsFavoritePlaylist(title, type) || type === "album")
+  if (getIsFavoritePlaylist(props.mediaSource))
     return <AnimatedVinyl {...props} />;
 
   return (
@@ -120,13 +113,13 @@ function ContentImage({
       aria-label={t("feat.artwork.extra.change")}
       delayLongPress={100}
       onLongPress={() => {
-        SheetManager.show(`${capitalize(type)}ArtworkSheet`, {
-          payload: { id: title },
+        SheetManager.show(`${capitalize(props.mediaSource.type)}ArtworkSheet`, {
+          payload: { id: props.mediaSource.id },
         });
       }}
       className="group"
     >
-      {type === "artist" ? (
+      {props.mediaSource.type === "artist" ? (
         <MediaImage
           type="artist"
           source={props.imageSource as string | null}
@@ -207,6 +200,6 @@ function AnimatedVinyl(props: AnimatedVinylProps) {
 }
 
 /** Determine if whether this layout is for the "Favorite Playlists" page. */
-function getIsFavoritePlaylist(title: string, type: SupportedMedia) {
-  return title === ReservedPlaylists.favorites && type === "playlist";
+function getIsFavoritePlaylist({ type, id }: MediaListSource) {
+  return id === ReservedPlaylists.favorites && type === "playlist";
 }

--- a/mobile/src/modules/media/services/RecentList.ts
+++ b/mobile/src/modules/media/services/RecentList.ts
@@ -69,7 +69,7 @@ recentListStore.subscribe(
       try {
         if (type === "album") {
           const data = await getAlbum(id, {
-            columns: ["id", "name", "artistName", "artwork"],
+            columns: ["id", "name", "artistName", "artwork", "altArtwork"],
             trackColumns: ["id"],
           });
           entry = formatForMediaCard({ type: "album", data, t: i18next.t });
@@ -101,7 +101,7 @@ recentListStore.subscribe(
             data = await getPlaylist(id, {
               columns: ["name", "artwork"],
               trackColumns: ["artwork"],
-              albumColumns: ["artwork"],
+              albumColumns: ["artwork", "altArtwork"],
             });
           }
           entry = formatForMediaCard({ type: "playlist", data, t: i18next.t });

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -137,14 +137,18 @@ async function saveSinglesArtwork(
 export async function cleanupImages() {
   // Get all the uris of images saved in the database.
   const usedUris = (
-    await Promise.all(
-      [albums, artists, playlists, tracks].map((schema) =>
+    await Promise.all([
+      ...[albums, artists, playlists, tracks].map((schema) =>
         db
           .select({ artwork: schema.artwork })
           .from(schema)
           .where(isNotNull(schema.artwork)),
       ),
-    )
+      db
+        .select({ artwork: albums.altArtwork })
+        .from(albums)
+        .where(isNotNull(albums.altArtwork)),
+    ])
   )
     .flat()
     .map(({ artwork }) => artwork!);

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -165,10 +165,10 @@ type MediaRelations =
   | { type: "track"; data: SlimTrackWithAlbum };
 
 /** Get the artwork of the media that'll be displayed. */
-function getArtwork(props: MediaRelations) {
-  if (props.type === "album") return props.data.artwork;
-  if (props.type === "artist") return props.data.artwork;
-  if (props.type === "playlist") return getPlaylistCover(props.data);
-  return getTrackCover(props.data);
+function getArtwork({ type, data }: MediaRelations) {
+  if (type === "album") return data.altArtwork ?? data.artwork;
+  if (type === "artist") return data.artwork;
+  if (type === "playlist") return getPlaylistCover(data);
+  return getTrackCover(data);
 }
 //#endregion

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -43,7 +43,7 @@ export function useSearch<TScope extends SearchCategories>(
 async function getAllMedia() {
   return {
     album: await getAlbums({
-      columns: ["id", "name", "artistName", "artwork"],
+      columns: ["id", "name", "artistName", "artwork", "altArtwork"],
       trackColumns: ["id", "name", "artistName", "artwork"],
     }),
     artist: await getArtists({
@@ -53,11 +53,11 @@ async function getAllMedia() {
     playlist: await getPlaylists({
       columns: ["name", "artwork"],
       trackColumns: ["artwork"],
-      albumColumns: ["artwork"],
+      albumColumns: ["artwork", "altArtwork"],
     }),
     track: await getTracks({
       columns: ["id", "name", "artistName", "artwork"],
-      albumColumns: ["name", "artwork"],
+      albumColumns: ["name", "artwork", "altArtwork"],
     }),
   } satisfies SearchResults;
 }

--- a/mobile/src/queries/album.ts
+++ b/mobile/src/queries/album.ts
@@ -3,13 +3,20 @@ import { useTranslation } from "react-i18next";
 
 import { formatForCurrentScreen, formatForMediaCard } from "~/db/utils";
 
-import { favoriteAlbum } from "~/api/album";
+import { favoriteAlbum, updateAlbum } from "~/api/album";
+import { Resynchronize } from "~/modules/media/services/Resynchronize";
 import { queries as q } from "./keyStore";
 
+import { clearAllQueries } from "~/lib/react-query";
 import { pickKeys } from "~/utils/object";
 import { wait } from "~/utils/promise";
 
 //#region Queries
+/** Get specified album. */
+export function useAlbum(albumId: string) {
+  return useQuery({ ...q.albums.detail(albumId) });
+}
+
 /** Format album information for album's `(current)` screen. */
 export function useAlbumForScreen(albumId: string) {
   const { t } = useTranslation();
@@ -49,6 +56,20 @@ export function useFavoriteAlbum(albumId: string) {
       // Invalidate all album queries and the favorite lists query.
       queryClient.invalidateQueries({ queryKey: q.albums._def });
       queryClient.invalidateQueries({ queryKey: q.favorites.lists.queryKey });
+    },
+  });
+}
+
+/** Update specified album artwork. */
+export function useUpdateAlbumArtwork(albumId: string) {
+  return useMutation({
+    mutationFn: ({ artwork }: { artwork?: string | null }) =>
+      updateAlbum(albumId, { altArtwork: artwork }),
+    onSuccess: () => {
+      // Changing the album artwork affects a lot of things, so we'll just
+      // clear all the queries.
+      clearAllQueries();
+      Resynchronize.onImage();
     },
   });
 }

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -25,7 +25,7 @@ export const queries = createQueryKeyStore({
       queryKey: null,
       queryFn: () =>
         getAlbums({
-          columns: ["id", "name", "artistName", "artwork"],
+          columns: ["id", "name", "artistName", "artwork", "altArtwork"],
           trackColumns: ["id"],
         }),
     },
@@ -78,7 +78,7 @@ export const queries = createQueryKeyStore({
         getPlaylists({
           columns: ["name", "artwork"],
           trackColumns: ["artwork"],
-          albumColumns: ["artwork"],
+          albumColumns: ["artwork", "altArtwork"],
         }),
     },
     detail: (playlistName: string) => ({
@@ -100,7 +100,7 @@ export const queries = createQueryKeyStore({
             "artwork",
             "modificationTime",
           ],
-          albumColumns: ["name", "artistName", "artwork"],
+          albumColumns: ["name", "artistName", "artwork", "altArtwork"],
         }),
     },
     detail: (trackId: string) => ({
@@ -147,14 +147,14 @@ async function getFavoriteLists() {
   const [favAlbums, favPlaylists] = await Promise.all([
     getAlbums({
       where: [eq(albums.isFavorite, true)],
-      columns: ["id", "name", "artistName", "artwork"],
+      columns: ["id", "name", "artistName", "artwork", "altArtwork"],
       trackColumns: ["id"],
     }),
     getPlaylists({
       where: [eq(playlists.isFavorite, true)],
       columns: ["name", "artwork"],
       trackColumns: ["artwork"],
-      albumColumns: ["artwork"],
+      albumColumns: ["artwork", "altArtwork"],
     }),
   ]);
   return { albums: favAlbums, playlists: favPlaylists };

--- a/mobile/src/screens/ModifyPlaylist/context.tsx
+++ b/mobile/src/screens/ModifyPlaylist/context.tsx
@@ -122,9 +122,11 @@ export function PlaylistStoreProvider({
             set((prev) => ({
               tracks: mergeTracks(
                 prev.tracks,
-                tracks.map(({ artwork, ...t }) => {
-                  return { ...t, artwork: album.artwork ?? artwork, album };
-                }),
+                tracks.map(({ artwork, ...t }) => ({
+                  ...t,
+                  artwork: album.altArtwork ?? album.artwork ?? artwork,
+                  album,
+                })),
               ),
             }));
             toast(

--- a/mobile/src/screens/ModifyPlaylist/context.tsx
+++ b/mobile/src/screens/ModifyPlaylist/context.tsx
@@ -5,7 +5,7 @@ import { createStore, useStore } from "zustand";
 import { createComputed } from "zustand-computed";
 
 import type { SlimTrackWithAlbum } from "~/db/slimTypes";
-import { mergeTracks, sanitizePlaylistName } from "~/db/utils";
+import { getTrackCover, mergeTracks, sanitizePlaylistName } from "~/db/utils";
 
 import i18next from "~/modules/i18n";
 
@@ -122,9 +122,9 @@ export function PlaylistStoreProvider({
             set((prev) => ({
               tracks: mergeTracks(
                 prev.tracks,
-                tracks.map(({ artwork, ...t }) => ({
+                tracks.map((t) => ({
                   ...t,
-                  artwork: album.altArtwork ?? album.artwork ?? artwork,
+                  artwork: getTrackCover({ ...t, album }),
                   album,
                 })),
               ),

--- a/mobile/src/screens/Sheets/Artwork.tsx
+++ b/mobile/src/screens/Sheets/Artwork.tsx
@@ -2,6 +2,7 @@ import type { UseMutationResult } from "@tanstack/react-query";
 import { useState } from "react";
 import { View, useWindowDimensions } from "react-native";
 
+import { useAlbum, useUpdateAlbumArtwork } from "~/queries/album";
 import { useArtist, useUpdateArtist } from "~/queries/artist";
 import { usePlaylist, useUpdatePlaylist } from "~/queries/playlist";
 
@@ -13,7 +14,27 @@ import { TStyledText } from "~/components/Typography/StyledText";
 import { MediaImage } from "~/modules/media/components/MediaImage";
 import type { MediaType } from "~/modules/media/types";
 
-/** Sheet allowing us to change the artwork of a artist. */
+/** Sheet allowing us to change the artwork of an album. */
+export function AlbumArtworkSheet(props: { payload: { id: string } }) {
+  const { data } = useAlbum(props.payload.id);
+  const updateAlbumArtwork = useUpdateAlbumArtwork(props.payload.id);
+
+  return (
+    <Sheet
+      id="AlbumArtworkSheet"
+      contentContainerClassName="items-center gap-6"
+    >
+      <BaseArtworkSheetContent
+        type="album"
+        imageSource={data?.altArtwork ?? data?.artwork ?? null}
+        mutationResult={updateAlbumArtwork}
+        disabled={data?.altArtwork === null}
+      />
+    </Sheet>
+  );
+}
+
+/** Sheet allowing us to change the artwork of an artist. */
 export function ArtistArtworkSheet(props: { payload: { id: string } }) {
   const { data } = useArtist(props.payload.id);
   const updateArtist = useUpdateArtist(props.payload.id);
@@ -56,6 +77,7 @@ function BaseArtworkSheetContent(props: {
   type: MediaType;
   imageSource: MediaImage.ImageSource | MediaImage.ImageSource[];
   mutationResult: UseMutationResult<any, Error, { artwork?: string | null }>;
+  disabled?: boolean;
 }) {
   const { height, width } = useWindowDimensions();
   const [disabled, setDisabled] = useState(false);
@@ -77,6 +99,7 @@ function BaseArtworkSheetContent(props: {
             setDisabled(false);
           }}
           disabled={
+            props.disabled ||
             disabled ||
             props.imageSource === null ||
             Array.isArray(props.imageSource)

--- a/mobile/src/screens/Sheets/TrackUpcoming/store.ts
+++ b/mobile/src/screens/Sheets/TrackUpcoming/store.ts
@@ -2,12 +2,12 @@ import { inArray } from "drizzle-orm";
 import { createStore, useStore } from "zustand";
 
 import { tracks } from "~/db/schema";
-import type { Artwork, SlimTrack } from "~/db/slimTypes";
+import type { SlimTrack, TrackArtwork } from "~/db/slimTypes";
 
 import { getTracks } from "~/api/track";
 import { musicStore } from "~/modules/media/services/Music";
 
-type PartialTrack = SlimTrack & { album: { artwork: Artwork } | null };
+type PartialTrack = SlimTrack & Required<TrackArtwork>;
 
 interface UpcomingStore {
   currentTrackList: Array<PartialTrack | undefined>;
@@ -74,7 +74,7 @@ async function getTracksFromIds(trackIds: string[]) {
   const unorderedTracks = await getTracks({
     where: [inArray(tracks.id, trackIds)],
     columns: ["id", "name", "artistName", "artwork"],
-    albumColumns: ["artwork"],
+    albumColumns: ["artwork", "altArtwork"],
   });
   return trackIds.map((tId) => unorderedTracks.find(({ id }) => id === tId));
 }

--- a/mobile/src/screens/Sheets/index.ts
+++ b/mobile/src/screens/Sheets/index.ts
@@ -2,7 +2,11 @@ import type { SheetDefinition } from "react-native-actions-sheet";
 import { registerSheet } from "react-native-actions-sheet";
 
 import AddMusicSheet from "./AddMusic";
-import { ArtistArtworkSheet, PlaylistArtworkSheet } from "./Artwork";
+import {
+  AlbumArtworkSheet,
+  ArtistArtworkSheet,
+  PlaylistArtworkSheet,
+} from "./Artwork";
 import BackupSheet from "./Backup";
 import { FontAccentSheet, FontPrimarySheet } from "./Font";
 import LanguageSheet from "./Language";
@@ -24,6 +28,7 @@ import type { SearchCallbacks } from "~/modules/search/types";
   appears, the sheet won't render as it expects a sheet on initial render.
 */
 registerSheet("AddMusicSheet", AddMusicSheet);
+registerSheet("AlbumArtworkSheet", AlbumArtworkSheet);
 registerSheet("ArtistArtworkSheet", ArtistArtworkSheet);
 registerSheet("BackupSheet", BackupSheet);
 registerSheet("FontAccentSheet", FontAccentSheet);
@@ -47,6 +52,7 @@ declare module "react-native-actions-sheet" {
     AddMusicSheet: SheetDefinition<{
       payload: { callbacks: Pick<SearchCallbacks, "album" | "track"> };
     }>;
+    AlbumArtworkSheet: SheetDefinition<{ payload: { id: string } }>;
     ArtistArtworkSheet: SheetDefinition<{ payload: { id: string } }>;
     BackupSheet: SheetDefinition;
     FontAccentSheet: SheetDefinition;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This adds support for "overriding" the artwork used for an album (the original found artwork will still be saved on the device; just the overriding artwork being displayed). This uses the same UI as when changing the artwork for artists & playlists.

Do note that:
- The artwork for the "active track" won't change immediately if that album's artwork gets changed.
- The artwork of the tracks in the "Upcoming" modal won't change if any of the albums those tracks belong to change (since the values are cached from when we first opened the modal).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
