### PR TITLE
refactor: Rendering data in lists

### DIFF
--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -39,7 +39,8 @@ export default function CurrentArtistScreen() {
         keyExtractor={({ id }) => id}
         renderItem={({ item, index }) => (
           <Track
-            {...{ ...item, trackSource }}
+            {...item}
+            trackSource={trackSource}
             className={cn("mx-4", { "mt-2": index > 0 })}
           />
         )}

--- a/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
@@ -1,9 +1,8 @@
-import { FlashList } from "@shopify/flash-list";
-
 import { useFavoriteTracksForScreen } from "~/queries/favorite";
 import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
+import { FlashList } from "~/components/Defaults";
 import { PagePlaceholder } from "~/components/Transition/Placeholder";
 import { ReservedPlaylists } from "~/modules/media/constants";
 import { useTrackListPreset } from "~/modules/media/components/Track";
@@ -18,10 +17,7 @@ export default function FavoriteTracksScreen() {
 
   const { bottomInset } = useBottomActionsContext();
   const { isPending, error, data } = useFavoriteTracksForScreen();
-  const listPresets = useTrackListPreset({
-    ...{ data: data?.tracks, trackSource },
-    emptyMsgKey: "err.msg.noTracks",
-  });
+  const presets = useTrackListPreset({ data: data?.tracks, trackSource });
 
   if (isPending || error) return <PagePlaceholder isPending={isPending} />;
 
@@ -33,10 +29,10 @@ export default function FavoriteTracksScreen() {
       mediaSource={trackSource}
     >
       <FlashList
-        {...listPresets}
         className="mx-4"
         contentContainerClassName="pt-4"
         contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
+        {...presets}
       />
     </CurrentListLayout>
   );

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -24,7 +24,10 @@ import { FlashDragList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import type { SwipeableRef } from "~/components/Swipeable";
 import { Swipeable } from "~/components/Swipeable";
-import { PagePlaceholder } from "~/components/Transition/Placeholder";
+import {
+  ContentPlaceholder,
+  PagePlaceholder,
+} from "~/components/Transition/Placeholder";
 import { Track } from "~/modules/media/components/Track";
 import type { PlayListSource } from "~/modules/media/types";
 
@@ -98,9 +101,11 @@ export default function CurrentPlaylistScreen() {
             <RenderItem {...args} trackSource={trackSource} />
           )}
           onReordered={onMove}
+          ListEmptyComponent={
+            <ContentPlaceholder errMsgKey="err.msg.noTracks" />
+          }
           contentContainerClassName="pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
-          emptyMsgKey="err.msg.noTracks"
         />
       </CurrentListLayout>
     </>

--- a/mobile/src/app/(main)/(home)/album.tsx
+++ b/mobile/src/app/(main)/(home)/album.tsx
@@ -8,7 +8,7 @@ export default function AlbumScreen() {
   const { isPending, data } = useAlbumsForCards();
   const presets = useMediaCardListPreset({
     ...{ data, isPending },
-    emptyMsgKey: "err.msg.noAlbums",
+    errMsgKey: "err.msg.noAlbums",
   });
 
   return <StickyActionListLayout titleKey="term.albums" {...presets} />;

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -3,18 +3,13 @@ import { router } from "expo-router";
 import { useArtistsForIndex } from "~/queries/artist";
 import { StickyActionListLayout } from "~/layouts/StickyActionScroll";
 
-import { useListPresets } from "~/components/Defaults";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { Em } from "~/components/Typography/StyledText";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
 /** Screen for `/artist` route. */
 export default function ArtistScreen() {
   const { isPending, data } = useArtistsForIndex();
-  const listPresets = useListPresets({
-    isPending,
-    emptyMsgKey: "err.msg.noArtists",
-  });
-
   return (
     <StickyActionListLayout
       titleKey="term.artists"
@@ -36,7 +31,12 @@ export default function ArtistScreen() {
           />
         )
       }
-      {...listPresets}
+      ListEmptyComponent={
+        <ContentPlaceholder
+          isPending={isPending}
+          errMsgKey="err.msg.noArtists"
+        />
+      }
     />
   );
 }

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -1,4 +1,4 @@
-import { FlashList } from "@shopify/flash-list";
+import { FlashList as SFlashList } from "@shopify/flash-list";
 import { router } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import { ScrollView } from "react-native-gesture-handler";
@@ -14,15 +14,15 @@ import { StandardScrollLayout } from "~/layouts/StandardScroll";
 
 import { cn } from "~/lib/style";
 import { abbreviateNum } from "~/utils/number";
-import { ScrollablePresets } from "~/components/Defaults";
+import { FlashList, ScrollablePresets } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
 import { AccentText } from "~/components/Typography/AccentText";
 import { TEm, TStyledText } from "~/components/Typography/StyledText";
 import { ReservedPlaylists } from "~/modules/media/constants";
 import {
   MediaCard,
-  MediaCardList,
   MediaCardPlaceholderContent,
+  useMediaCardListPreset,
 } from "~/modules/media/components/MediaCard";
 
 /** Screen for `/` route. */
@@ -50,7 +50,7 @@ function RecentlyPlayed() {
 
   const [initNoData, setInitNoData] = useState(false);
   const [itemHeight, setItemHeight] = useState(0);
-  const listRef = useRef<FlashList<MediaCard.Content>>(null);
+  const listRef = useRef<SFlashList<MediaCard.Content>>(null);
 
   useEffect(() => {
     // Fix incorrect `<FlashList />` height due to it only being calculated
@@ -72,7 +72,7 @@ function RecentlyPlayed() {
   return (
     <>
       <TEm textKey="feat.playedRecent.title" className="-mb-4" />
-      <FlashList
+      <SFlashList
         ref={listRef}
         estimatedItemSize={width + 12} // Column width + gap from padding left
         horizontal
@@ -106,12 +106,12 @@ function RecentlyPlayed() {
 /** Display list of content we've favorited. */
 function Favorites() {
   const { data } = useFavoriteListsForCards();
-  return (
-    <MediaCardList
-      data={[MediaCardPlaceholderContent, ...(data ?? [])]}
-      RenderFirst={FavoriteTracks}
-    />
-  );
+  const presets = useMediaCardListPreset({
+    data: [MediaCardPlaceholderContent, ...(data ?? [])],
+    RenderFirst: FavoriteTracks,
+  });
+
+  return <FlashList {...presets} />;
 }
 
 /**

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -14,6 +14,7 @@ import { StandardScrollLayout } from "~/layouts/StandardScroll";
 
 import { cn } from "~/lib/style";
 import { abbreviateNum } from "~/utils/number";
+import { ScrollablePresets } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
 import { AccentText } from "~/components/Typography/AccentText";
 import { TEm, TStyledText } from "~/components/Typography/StyledText";
@@ -92,8 +93,7 @@ function RecentlyPlayed() {
           />
         }
         renderScrollComponent={ScrollView}
-        overScrollMode="never"
-        showsHorizontalScrollIndicator={false}
+        {...ScrollablePresets}
         className="-mx-4"
         contentContainerClassName="px-4"
       />

--- a/mobile/src/app/(main)/(home)/playlist.tsx
+++ b/mobile/src/app/(main)/(home)/playlist.tsx
@@ -15,7 +15,7 @@ export default function PlaylistScreen() {
   const { isPending, data } = usePlaylistsForCards();
   const presets = useMediaCardListPreset({
     ...{ data, isPending },
-    emptyMsgKey: "err.msg.noPlaylists",
+    errMsgKey: "err.msg.noPlaylists",
   });
 
   return (

--- a/mobile/src/app/(main)/(home)/track.tsx
+++ b/mobile/src/app/(main)/(home)/track.tsx
@@ -20,17 +20,14 @@ const trackSource = {
 /** Screen for `/track` route. */
 export default function TrackScreen() {
   const { isPending, data } = useTracksForTrackCard();
-  const listPresets = useTrackListPreset({
-    ...{ data, trackSource, isPending },
-    emptyMsgKey: "err.msg.noTracks",
-  });
+  const presets = useTrackListPreset({ data, isPending, trackSource });
 
   return (
     <StickyActionListLayout
       titleKey="term.tracks"
       StickyAction={<TrackActions />}
       estimatedActionSize={48}
-      {...listPresets}
+      {...presets}
     />
   );
 }

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -17,6 +17,7 @@ import { useHasNewUpdate } from "~/hooks/useHasNewUpdate";
 import { useTheme } from "~/hooks/useTheme";
 
 import { cn } from "~/lib/style";
+import { ScrollablePresets } from "~/components/Defaults";
 import { Button, IconButton } from "~/components/Form/Button";
 import { StyledText } from "~/components/Typography/StyledText";
 import { MiniPlayer } from "~/modules/media/components/MiniPlayer";
@@ -159,8 +160,7 @@ function NavigationList() {
         // Suppresses error from `scrollToIndex` when we remount this layout
         // as a result of using the `push` navigation on the `/search` screen.
         onScrollToIndexFailed={() => {}}
-        overScrollMode="never"
-        showsHorizontalScrollIndicator={false}
+        {...ScrollablePresets}
         contentContainerClassName="px-2"
       />
       {/* Scroll Shadow */}

--- a/mobile/src/app/setting/insights/save-errors.tsx
+++ b/mobile/src/app/setting/insights/save-errors.tsx
@@ -19,6 +19,7 @@ export default function SaveErrorsScreen() {
     <FlashList
       keyExtractor={({ id }) => id}
       ListEmptyComponent={<ContentPlaceholder errMsgKey="err.msg.noErrors" />}
+      className="mx-4"
       contentContainerClassName="p-4"
       {...presets}
     />

--- a/mobile/src/app/setting/insights/save-errors.tsx
+++ b/mobile/src/app/setting/insights/save-errors.tsx
@@ -1,22 +1,26 @@
 import { useSaveErrors } from "~/queries/setting";
-import { StandardScrollLayout } from "~/layouts/StandardScroll";
 
-import { ListRenderer } from "~/components/Containment/List";
+import { useListPresets } from "~/components/Containment/List";
+import { FlashList } from "~/components/Defaults";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 
 /** Screen for `/setting/insights/save-errors` route. */
 export default function SaveErrorsScreen() {
   const { data } = useSaveErrors();
+  const presets = useListPresets({
+    data,
+    renderOptions: {
+      getTitle: (item) => item.uri,
+      getDescription: (item) => `[${item.errorName}] ${item.errorMessage}`,
+    },
+  });
+
   return (
-    <StandardScrollLayout>
-      <ListRenderer
-        data={data}
-        keyExtractor={({ id }) => id}
-        renderOptions={{
-          getTitle: (item) => item.uri,
-          getDescription: (item) => `[${item.errorName}] ${item.errorMessage}`,
-        }}
-        emptyMsgKey="err.msg.noErrors"
-      />
-    </StandardScrollLayout>
+    <FlashList
+      keyExtractor={({ id }) => id}
+      ListEmptyComponent={<ContentPlaceholder errMsgKey="err.msg.noErrors" />}
+      contentContainerClassName="p-4"
+      {...presets}
+    />
   );
 }

--- a/mobile/src/app/setting/third-party/index.tsx
+++ b/mobile/src/app/setting/third-party/index.tsx
@@ -1,26 +1,28 @@
 import { router } from "expo-router";
 
 import LicensesList from "~/resources/licenses.json";
-import { StandardScrollLayout } from "~/layouts/StandardScroll";
 
-import { ListRenderer } from "~/components/Containment/List";
+import { useListPresets } from "~/components/Containment/List";
+import { FlashList } from "~/components/Defaults";
 
 /** Screen for `/setting/third-party` route. */
 export default function ThirdPartyScreen() {
+  const presets = useListPresets({
+    data: Object.entries(LicensesList),
+    renderOptions: {
+      getTitle: ([_, item]) => item.name,
+      getDescription: ([_, item]) => `${item.license} (${item.version})`,
+      onPress:
+        ([id]) =>
+        () =>
+          router.navigate(`/setting/third-party/${encodeURIComponent(id)}`),
+    },
+  });
   return (
-    <StandardScrollLayout>
-      <ListRenderer
-        data={Object.entries(LicensesList)}
-        keyExtractor={([id]) => id}
-        renderOptions={{
-          getTitle: ([_, item]) => item.name,
-          getDescription: ([_, item]) => `${item.license} (${item.version})`,
-          onPress:
-            ([id]) =>
-            () =>
-              router.navigate(`/setting/third-party/${encodeURIComponent(id)}`),
-        }}
-      />
-    </StandardScrollLayout>
+    <FlashList
+      keyExtractor={([id]) => id}
+      contentContainerClassName="p-4"
+      {...presets}
+    />
   );
 }

--- a/mobile/src/app/setting/third-party/index.tsx
+++ b/mobile/src/app/setting/third-party/index.tsx
@@ -21,6 +21,7 @@ export default function ThirdPartyScreen() {
   return (
     <FlashList
       keyExtractor={([id]) => id}
+      className="mx-4"
       contentContainerClassName="p-4"
       {...presets}
     />

--- a/mobile/src/components/Containment/List.tsx
+++ b/mobile/src/components/Containment/List.tsx
@@ -1,12 +1,10 @@
-import type { FlashListProps } from "@shopify/flash-list";
 import type { ParseKeys } from "i18next";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, View } from "react-native";
 
 import type { TextColor } from "~/lib/style";
 import { cn } from "~/lib/style";
-import type { WithListEmptyProps } from "../Defaults";
-import { FlashList } from "../Defaults";
 import { Switch } from "../Form/Switch";
 import { StyledText } from "../Typography/StyledText";
 
@@ -19,40 +17,35 @@ export function List(props: { children: React.ReactNode; className?: string }) {
 }
 //#endregion
 
-//#region List Renderer
-/** Represent structured data as `<ListItem />` in a `<FlashList />`. */
-export function ListRenderer<TData extends Record<string, any>>({
+//#region useListPresets
+/** Presets used to render a list of `<ListItem />`. */
+export function useListPresets<TData extends Record<string, any>>({
   data,
   renderOptions: { getTitle, getDescription, onPress },
-  ...props
-}: WithListEmptyProps<
-  Omit<FlashListProps<TData>, "renderItem"> & {
-    renderOptions: {
-      getTitle: (item: TData) => string;
-      getDescription?: (item: TData) => string;
-      onPress?: (item: TData) => () => void;
-    };
-  }
->) {
-  return (
-    <FlashList
-      estimatedItemSize={70}
-      data={data}
-      renderItem={({ item, index }) => {
-        const first = index === 0;
-        const last = index === data!.length - 1;
-        return (
-          <ListItem
-            title={getTitle(item)}
-            description={getDescription ? getDescription(item) : undefined}
-            onPress={onPress ? onPress(item) : undefined}
-            {...{ first, last }}
-            className={!last ? "mb-[3px]" : undefined}
-          />
-        );
-      }}
-      {...props}
-    />
+}: {
+  data?: readonly TData[];
+  renderOptions: {
+    getTitle: (item: TData) => string;
+    getDescription?: (item: TData) => string;
+    onPress?: (item: TData) => () => void;
+  };
+}) {
+  return useMemo(
+    () => ({
+      estimatedItemSize: 70,
+      data,
+      renderItem: ({ item, index }: { item: TData; index: number }) => (
+        <ListItem
+          title={getTitle(item)}
+          description={getDescription ? getDescription(item) : undefined}
+          onPress={onPress ? onPress(item) : undefined}
+          first={index === 0}
+          last={index === (data?.length ?? 0) - 1}
+          className={index > 0 ? "mt-[3px]" : undefined}
+        />
+      ),
+    }),
+    [data, getTitle, getDescription, onPress],
   );
 }
 //#endregion

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,7 +1,5 @@
 import type { FlashListProps } from "@shopify/flash-list";
 import { FlashList as SFlashList } from "@shopify/flash-list";
-import type { ParseKeys } from "i18next";
-import { useMemo } from "react";
 import type { FlatListProps, ScrollViewProps } from "react-native";
 import {
   FlatList as RNFlatList,
@@ -9,102 +7,46 @@ import {
 } from "react-native";
 import { FlatList as RNASFlatList } from "react-native-actions-sheet";
 import { FlashList as RNASFlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
-import type { DragListProps } from "react-native-draglist";
-import RNDragList from "react-native-draglist";
 import type { FlashDragListProps } from "react-native-draglist/dist/FlashList";
 import RNFlashDragList from "react-native-draglist/dist/FlashList";
 
-import { ContentPlaceholder } from "./Transition/Placeholder";
-
-//#region Preset Values
 /** Presets for scrollview-like components. */
-export const ScrollPresets = {
+export const ScrollablePresets = {
   overScrollMode: "never",
   showsHorizontalScrollIndicator: false,
   showsVerticalScrollIndicator: false,
 } satisfies ScrollViewProps;
 
-export type ListEmptyProps = { isPending?: boolean; emptyMsgKey?: ParseKeys };
-export type WithListEmptyProps<T> = T & ListEmptyProps;
-
-/** Presets for list-like components (ie: `Flatlist`, `FlashList`). */
-export function useListPresets(args?: ListEmptyProps) {
-  return useMemo(
-    () => ({
-      ...ScrollPresets,
-      ListEmptyComponent: (
-        <ContentPlaceholder
-          isPending={args?.isPending}
-          errMsgKey={args?.emptyMsgKey}
-        />
-      ),
-    }),
-    [args],
-  );
-}
-//#endregion
-
 //#region Native Components
-/** `<FlatList />` with some defaults applied. */
-export function FlatList<TData>(
-  props: WithListEmptyProps<FlatListProps<TData>>,
-) {
-  const { isPending, emptyMsgKey, ...rest } = props;
-  const listPresets = useListPresets({ isPending, emptyMsgKey });
-  return <RNFlatList {...listPresets} {...rest} />;
+export function FlatList<TData>(props: FlatListProps<TData>) {
+  return <RNFlatList {...ScrollablePresets} {...props} />;
 }
 
-/** `<ScrollView />` with some defaults applied. */
 export function ScrollView(props: ScrollViewProps) {
-  return <RNScrollView {...ScrollPresets} {...props} />;
+  return <RNScrollView {...ScrollablePresets} {...props} />;
 }
 //#endregion
 
-//#region FlashLists
+//#region Flash Lists
 /** `<FlashList />` with some defaults applied. */
-export function FlashList<TData>(
-  props: WithListEmptyProps<FlashListProps<TData>>,
-) {
-  const { isPending, emptyMsgKey, ...rest } = props;
-  const listPresets = useListPresets({ isPending, emptyMsgKey });
-  return <SFlashList {...listPresets} {...rest} />;
+export function FlashList<TData>(props: FlashListProps<TData>) {
+  return <SFlashList {...ScrollablePresets} {...props} />;
 }
 
 /** `<FlatList />` from `react-native-actions-sheet` with some defaults applied. */
-export function SheetsFlatList<TData>(
-  props: WithListEmptyProps<FlatListProps<TData>>,
-) {
-  const { isPending, emptyMsgKey, ...rest } = props;
-  const listPresets = useListPresets({ isPending, emptyMsgKey });
-  return <RNASFlatList {...listPresets} {...rest} />;
+export function SheetsFlatList<TData>(props: FlatListProps<TData>) {
+  return <RNASFlatList {...ScrollablePresets} {...props} />;
 }
 
 /** `<FlashList />` from `react-native-actions-sheet` with some defaults applied. */
-export function SheetsFlashList<TData>(
-  props: WithListEmptyProps<FlashListProps<TData>>,
-) {
-  const { isPending, emptyMsgKey, ...rest } = props;
-  const listPresets = useListPresets({ isPending, emptyMsgKey });
-  return <RNASFlashList {...listPresets} {...rest} />;
+export function SheetsFlashList<TData>(props: FlashListProps<TData>) {
+  return <RNASFlashList {...ScrollablePresets} {...props} />;
 }
 //#endregion
 
-//#region DragLists
-/** `<DragList />` with some defaults applied. */
-export function DragList<TData>(
-  props: WithListEmptyProps<DragListProps<TData>>,
-) {
-  const { isPending, emptyMsgKey, ...rest } = props;
-  const listPresets = useListPresets({ isPending, emptyMsgKey });
-  return <RNDragList {...listPresets} {...rest} />;
-}
-
-/** `<FlashDragList />` with some defaults applied. */
-export function FlashDragList<TData>(
-  props: WithListEmptyProps<FlashDragListProps<TData>>,
-) {
-  const { isPending, emptyMsgKey, ...rest } = props;
-  const listPresets = useListPresets({ isPending, emptyMsgKey });
-  return <RNFlashDragList {...listPresets} {...rest} />;
+//#region Flash Drag List
+/** `<FlashDragList />` with some defaults. */
+export function FlashDragList<TData>(props: FlashDragListProps<TData>) {
+  return <RNFlashDragList {...ScrollablePresets} {...props} />;
 }
 //#endregion

--- a/mobile/src/components/Transition/Placeholder.tsx
+++ b/mobile/src/components/Transition/Placeholder.tsx
@@ -1,6 +1,7 @@
 import type { ParseKeys } from "i18next";
 import { View } from "react-native";
 
+import { cn } from "~/lib/style";
 import { Loading } from "./Loading";
 import { TStyledText } from "../Typography/StyledText";
 
@@ -9,11 +10,16 @@ export function ContentPlaceholder(props: {
   isPending?: boolean;
   /** Key to error messaeg in translations. */
   errMsgKey?: ParseKeys;
+  className?: string;
 }) {
-  return props.isPending ? (
-    <Loading />
-  ) : (
-    <TStyledText textKey={props.errMsgKey ?? "err.msg.noContent"} center />
+  return (
+    <View className={cn("p-4", props.className)}>
+      {props.isPending ? (
+        <Loading />
+      ) : (
+        <TStyledText textKey={props.errMsgKey ?? "err.msg.noContent"} center />
+      )}
+    </View>
   );
 }
 

--- a/mobile/src/layouts/Issue.tsx
+++ b/mobile/src/layouts/Issue.tsx
@@ -8,7 +8,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { GITHUB } from "~/constants/Links";
-import { ScrollPresets } from "~/components/Defaults";
+import { ScrollablePresets } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
 import { AccentText } from "~/components/Typography/AccentText";
 import { TStyledText } from "~/components/Typography/StyledText";
@@ -32,7 +32,7 @@ export function IssueLayout(props: {
     <View className="flex-1">
       <Animated.ScrollView
         contentContainerClassName="grow gap-6 p-4"
-        {...ScrollPresets}
+        {...ScrollablePresets}
       >
         <AccentText style={{ paddingTop: top + 16 }} className="text-4xl">
           {t(`err.flow.${props.issueType}.title`)}

--- a/mobile/src/layouts/StickyActionScroll.tsx
+++ b/mobile/src/layouts/StickyActionScroll.tsx
@@ -16,6 +16,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 
+import { ScrollablePresets } from "~/components/Defaults";
 import { AccentText } from "~/components/Typography/AccentText";
 
 /**
@@ -93,8 +94,7 @@ export function StickyActionListLayout<TData>({
             {t(titleKey)}
           </LayoutHeader>
         }
-        overScrollMode="never"
-        showsVerticalScrollIndicator={false}
+        {...ScrollablePresets}
         {...flashListProps}
         contentContainerStyle={{
           padding: 16,

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -8,11 +8,10 @@ import { playFromMediaList } from "../services/Playback";
 import type { PlayListSource } from "../types";
 
 import { cn } from "~/lib/style";
-import type { Maybe, Prettify } from "~/utils/types";
-import type { WithListEmptyProps } from "~/components/Defaults";
-import { useListPresets } from "~/components/Defaults";
+import type { Prettify } from "~/utils/types";
 import type { PressProps } from "~/components/Form/Button";
 import { IconButton } from "~/components/Form/Button";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
 //#region Track
@@ -60,32 +59,33 @@ export function Track({ id, trackSource, className, ...props }: Track.Props) {
 }
 //#endregion
 
-//#region Track List
-type TrackListProps = WithListEmptyProps<{
-  data: Maybe<readonly Track.Content[]>;
+//#region useTrackListPreset
+/** Presets used to render a list of `<Track />`. */
+export function useTrackListPreset(props: {
+  data?: readonly Track.Content[];
   trackSource: PlayListSource;
-}>;
-
-/** Presets used in the FlashList containing a list of `<Track />`. */
-export function useTrackListPreset(props: TrackListProps) {
-  const listPresets = useListPresets({
-    isPending: props.isPending,
-    emptyMsgKey: props.emptyMsgKey,
-  });
+  isPending?: boolean;
+}) {
   return useMemo(
     () => ({
-      ...listPresets,
       estimatedItemSize: 56, // 48px Height + 8px Margin Top
       data: props.data,
       keyExtractor: ({ id }) => id,
       renderItem: ({ item, index }) => (
         <Track
-          {...{ ...item, trackSource: props.trackSource }}
+          {...item}
+          trackSource={props.trackSource}
           className={index > 0 ? "mt-2" : undefined}
         />
       ),
+      ListEmptyComponent: (
+        <ContentPlaceholder
+          isPending={props.isPending}
+          errMsgKey="err.msg.noTracks"
+        />
+      ),
     }),
-    [props, listPresets],
+    [props],
   ) satisfies FlashListProps<Track.Content>;
 }
 //#endregion

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -19,7 +19,8 @@ import { cn } from "~/lib/style";
 import { FlashList, SheetsFlashList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { TextInput, useInputRef } from "~/components/Form/Input";
-import { TEm, TStyledText } from "~/components/Typography/StyledText";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
+import { TEm } from "~/components/Typography/StyledText";
 import { SearchResult } from "./SearchResult";
 import { useSearch } from "../hooks/useSearch";
 import type {
@@ -85,37 +86,37 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
         <ListComponent
           estimatedItemSize={56} // 48px Height + 8px Margin Top
           data={data}
-          keyExtractor={(_, index) => `${index}`}
-          renderItem={({ item, index }) => {
-            if (typeof item === "string") {
-              return (
-                <TEm
-                  textKey={`term.${item}`}
-                  className={index > 0 ? "mt-4" : undefined}
-                />
-              );
-            }
-            const { entry, ...rest } = item;
-
-            return (
+          // Note: We use `index` instead of the `id` or `name` field on the
+          // `entry` due to there being potentially shared values (ie: between
+          // artist & playlist names).
+          keyExtractor={(item, index) =>
+            typeof item === "string" ? item : `${index}`
+          }
+          renderItem={({ item, index }) =>
+            typeof item === "string" ? (
+              <TEm
+                textKey={`term.${item}`}
+                className={index > 0 ? "mt-4" : undefined}
+              />
+            ) : (
               <SearchResult
                 as="ripple"
                 /* @ts-expect-error - `type` should be limited to our scope. */
-                onPress={() => props.callbacks[rest.type](entry)}
+                onPress={() => props.callbacks[item.type](item.entry)}
                 wrapperClassName={cn("mt-2", {
-                  "rounded-full": rest.type === "artist",
+                  "rounded-full": item.type === "artist",
                 })}
                 className="pr-4"
-                {...rest}
+                {...item}
               />
-            );
-          }}
+            )
+          }
           ListEmptyComponent={
             query.length > 0 ? (
-              <TStyledText textKey="err.msg.noResults" center />
+              <ContentPlaceholder errMsgKey="err.msg.noResults" />
             ) : undefined
           }
-          contentContainerClassName="pb-4 pt-6"
+          contentContainerClassName="pt-6 pb-4"
         />
 
         <LinearGradient

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -41,7 +41,7 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
   const [query, setQuery] = useState("");
   const results = useSearch(props.searchScope, query);
 
-  // Format results to be used in `<FlashList />`.
+  // Format results to be used in list.
   const data = useMemo(
     () => (results ? formatResults(results) : undefined),
     [results],
@@ -134,9 +134,9 @@ export function SearchEngine<TScope extends SearchCategories>(props: {
 const withArtistName = ["album", "track"];
 
 /**
- * Flatten results to be used in a `<FlashList />` that functions like a
- * `<SectionList />`. Ensure the "sections" are in alphabetical order and
- * remove any groups with no items before formatting.
+ * Flatten results to be used in a list that functions like a `<SectionList />`.
+ * Ensure the "sections" are in alphabetical order and remove any groups with
+ * no items before formatting.
  */
 function formatResults(results: Partial<SearchResults>) {
   return Object.entries(results)

--- a/mobile/src/queries/artist.ts
+++ b/mobile/src/queries/artist.ts
@@ -28,8 +28,8 @@ export function useArtistForScreen(artistName: string) {
 
 /**
  * Group artists by their first character (or in a group of special
- * characters), like an index in a book for a `<FlashList />` that
- * functions like a `<SectionList />`.
+ * characters), like an index in a book for a list that functions like
+ * a `<SectionList />`.
  */
 export function useArtistsForIndex() {
   return useQuery({
@@ -47,8 +47,7 @@ export function useArtistsForIndex() {
         } else groupedArtists[key] = [artist];
       });
 
-      // Convert object to array to be used in a `<FlashList />` that acts
-      // like a `<SectionList />`.
+      // Convert object to array to be used in a list that acts like a `<SectionList />`.
       return Object.entries(groupedArtists)
         .sort((a, b) => a[0].localeCompare(b[0])) // Moves the `#` group to the front
         .map(([character, artists]) => [character, ...artists])

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -28,6 +28,7 @@ import { IconButton } from "~/components/Form/Button";
 import { TextInput } from "~/components/Form/Input";
 import type { SwipeableRef } from "~/components/Swipeable";
 import { Swipeable } from "~/components/Swipeable";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { StyledText, TStyledText } from "~/components/Typography/StyledText";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
@@ -117,8 +118,8 @@ function PageContent() {
         renderItem={(args) => <RenderItem {...args} />}
         onReordered={moveTrack}
         ListHeaderComponent={ListHeaderComponent}
+        ListEmptyComponent={<ContentPlaceholder errMsgKey="err.msg.noTracks" />}
         contentContainerClassName="py-4" // Applies to the internal `<FlashList />`.
-        emptyMsgKey="err.msg.noTracks"
       />
     </View>
   );

--- a/mobile/src/screens/Sheets/ScanFilterList/index.tsx
+++ b/mobile/src/screens/Sheets/ScanFilterList/index.tsx
@@ -22,6 +22,7 @@ import { IconButton } from "~/components/Form/Button";
 import { TextInput } from "~/components/Form/Input";
 import { Sheet } from "~/components/Sheet";
 import { Swipeable } from "~/components/Swipeable";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { StyledText } from "~/components/Typography/StyledText";
 
 //#region Sheet
@@ -81,8 +82,10 @@ export default function ScanFilterListSheet(props: {
             </Marquee>
           </Swipeable>
         )}
+        ListEmptyComponent={
+          <ContentPlaceholder errMsgKey="err.msg.noFilters" />
+        }
         contentContainerClassName="pb-4"
-        emptyMsgKey="err.msg.noFilters"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackToPlaylist.tsx
+++ b/mobile/src/screens/Sheets/TrackToPlaylist.tsx
@@ -13,6 +13,7 @@ import { Marquee } from "~/components/Containment/Marquee";
 import { SheetsFlashList } from "~/components/Defaults";
 import { Checkbox } from "~/components/Form/Selection";
 import { Sheet } from "~/components/Sheet";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { StyledText } from "~/components/Typography/StyledText";
 
 /** Sheet allowing us to select which playlists the track belongs to. */
@@ -57,8 +58,10 @@ export default function TrackToPlaylistSheet(props: {
             </Checkbox>
           );
         }}
+        ListEmptyComponent={
+          <ContentPlaceholder errMsgKey="err.msg.noPlaylists" />
+        }
         contentContainerClassName="pb-4"
-        emptyMsgKey="err.msg.noPlaylists"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/TrackUpcoming/index.tsx
+++ b/mobile/src/screens/Sheets/TrackUpcoming/index.tsx
@@ -13,6 +13,7 @@ import { FlashList, SheetsFlashList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { Sheet } from "~/components/Sheet";
 import { Swipeable } from "~/components/Swipeable";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
 /**
@@ -67,6 +68,9 @@ export default function TrackUpcomingSheet() {
           ) : null
         }
         ListHeaderComponent={<QueueList />}
+        ListEmptyComponent={
+          <ContentPlaceholder isPending={trackList.length === 0} />
+        }
         contentContainerClassName="pb-4"
       />
     </Sheet>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR applies the changes in how we render data in lists (using "preset hooks" instead of full-blown components), cherry-picked from #221.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Ensure that the app visually looks and feel the same as if we haven't made these changes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
