### PR TITLE
refactor: List optimizations

### DIFF
--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -91,8 +91,7 @@ export default function CurrentAlbumScreen() {
               />
             )
           }
-          className="mx-4"
-          contentContainerClassName="pt-4"
+          contentContainerClassName="px-4 pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
         />
       </CurrentListLayout>

--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -9,6 +9,7 @@ import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
 import { mutateGuard } from "~/lib/react-query";
+import { isNumber } from "~/utils/validation";
 import { FlashList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { PagePlaceholder } from "~/components/Transition/Placeholder";
@@ -74,11 +75,10 @@ export default function CurrentAlbumScreen() {
         <FlashList
           estimatedItemSize={56} // 48px Height + 8px Margin Top
           data={formattedData}
-          keyExtractor={(item) =>
-            typeof item === "number" ? `${item}` : item.id
-          }
+          keyExtractor={(item) => (isNumber(item) ? `${item}` : item.id)}
+          getItemType={(item) => (isNumber(item) ? "label" : "row")}
           renderItem={({ item, index }) =>
-            typeof item === "number" ? (
+            isNumber(item) ? (
               <Em dim className={index > 0 ? "mt-4" : undefined}>
                 {t("term.disc", { count: item })}
               </Em>

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -7,7 +7,6 @@ import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { useGetColumn } from "~/hooks/useGetColumn";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
-import { cn } from "~/lib/style";
 import { isYearDefined } from "~/utils/number";
 import { FlashList } from "~/components/Defaults";
 import { PagePlaceholder } from "~/components/Transition/Placeholder";
@@ -41,11 +40,11 @@ export default function CurrentArtistScreen() {
           <Track
             {...item}
             trackSource={trackSource}
-            className={cn("mx-4", { "mt-2": index > 0 })}
+            className={index > 0 ? "mt-2" : undefined}
           />
         )}
         ListHeaderComponent={<ArtistAlbums albums={data.albums} />}
-        contentContainerClassName="pt-4"
+        contentContainerClassName="px-4 pt-4"
         contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
       />
     </CurrentListLayout>
@@ -65,7 +64,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
 
   return (
     <>
-      <TEm dim textKey="term.albums" className="mx-4 mb-2" />
+      <TEm dim textKey="term.albums" className="mb-2" />
       <FlashList
         estimatedItemSize={width + 12} // Column width + gap from padding left
         horizontal
@@ -82,9 +81,10 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
             className={index > 0 ? "ml-3" : undefined}
           />
         )}
+        className="-mx-4"
         contentContainerClassName="px-4"
       />
-      <TEm dim textKey="term.tracks" className="m-4 mb-2" />
+      <TEm dim textKey="term.tracks" className="mb-2 mt-4" />
     </>
   );
 }

--- a/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
+++ b/mobile/src/app/(main)/(current)/playlist/Favorite Tracks.tsx
@@ -29,8 +29,7 @@ export default function FavoriteTracksScreen() {
       mediaSource={trackSource}
     >
       <FlashList
-        className="mx-4"
-        contentContainerClassName="pt-4"
+        contentContainerClassName="px-4 pt-4"
         contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
         {...presets}
       />

--- a/mobile/src/app/(main)/(home)/artist.tsx
+++ b/mobile/src/app/(main)/(home)/artist.tsx
@@ -3,6 +3,7 @@ import { router } from "expo-router";
 import { useArtistsForIndex } from "~/queries/artist";
 import { StickyActionListLayout } from "~/layouts/StickyActionScroll";
 
+import { isString } from "~/utils/validation";
 import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { Em } from "~/components/Typography/StyledText";
 import { SearchResult } from "~/modules/search/components/SearchResult";
@@ -15,9 +16,10 @@ export default function ArtistScreen() {
       titleKey="term.artists"
       estimatedItemSize={56} // 48px Height + 8px Margin Top
       data={data}
-      keyExtractor={(item) => (typeof item === "string" ? item : item.name)}
+      keyExtractor={(item) => (isString(item) ? item : item.name)}
+      getItemType={(item) => (isString(item) ? "label" : "row")}
       renderItem={({ item, index }) =>
-        typeof item === "string" ? (
+        isString(item) ? (
           <Em className={index > 0 ? "mt-4" : undefined}>{item}</Em>
         ) : (
           <SearchResult

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -15,15 +15,11 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-import type { FileNode } from "~/db/schema";
-
 import { useFolderContent } from "~/queries/folder";
-import {
-  StickyActionListLayout,
-  useStickyActionListLayoutRef,
-} from "~/layouts/StickyActionScroll";
+import { StickyActionListLayout } from "~/layouts/StickyActionScroll";
 
 import { cn } from "~/lib/style";
+import { useFlashListRef } from "~/components/Defaults";
 import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { StyledText } from "~/components/Typography/StyledText";
 import { Track } from "~/modules/media/components/Track";
@@ -32,12 +28,10 @@ import { SearchResult } from "~/modules/search/components/SearchResult";
 /** Animated scrollview supporting gestures. */
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 
-type FolderData = FileNode | Track.Content;
-
 /** Screen for `/folder` route. */
 export default function FolderScreen() {
   const isFocused = useIsFocused();
-  const listRef = useStickyActionListLayoutRef<FolderData>();
+  const listRef = useFlashListRef();
   const [dirSegments, _setDirSegments] = useState<string[]>([]);
 
   const fullPath = dirSegments.join("/");

--- a/mobile/src/app/(main)/(home)/index.tsx
+++ b/mobile/src/app/(main)/(home)/index.tsx
@@ -1,6 +1,5 @@
-import { FlashList as SFlashList } from "@shopify/flash-list";
 import { router } from "expo-router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ScrollView } from "react-native-gesture-handler";
 
 import {
@@ -14,7 +13,7 @@ import { StandardScrollLayout } from "~/layouts/StandardScroll";
 
 import { cn } from "~/lib/style";
 import { abbreviateNum } from "~/utils/number";
-import { FlashList, ScrollablePresets } from "~/components/Defaults";
+import { FlashList, useFlashListRef } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
 import { AccentText } from "~/components/Typography/AccentText";
 import { TEm, TStyledText } from "~/components/Typography/StyledText";
@@ -50,7 +49,7 @@ function RecentlyPlayed() {
 
   const [initNoData, setInitNoData] = useState(false);
   const [itemHeight, setItemHeight] = useState(0);
-  const listRef = useRef<SFlashList<MediaCard.Content>>(null);
+  const listRef = useFlashListRef();
 
   useEffect(() => {
     // Fix incorrect `<FlashList />` height due to it only being calculated
@@ -65,14 +64,14 @@ function RecentlyPlayed() {
       });
       setInitNoData(false);
     }
-  }, [initNoData, itemHeight]);
+  }, [listRef, initNoData, itemHeight]);
 
   if (!shouldShow) return null;
 
   return (
     <>
       <TEm textKey="feat.playedRecent.title" className="-mb-4" />
-      <SFlashList
+      <FlashList
         ref={listRef}
         estimatedItemSize={width + 12} // Column width + gap from padding left
         horizontal
@@ -93,7 +92,6 @@ function RecentlyPlayed() {
           />
         }
         renderScrollComponent={ScrollView}
-        {...ScrollablePresets}
         className="-mx-4"
         contentContainerClassName="px-4"
       />

--- a/mobile/src/app/setting/appearance/home-tabs-order.tsx
+++ b/mobile/src/app/setting/appearance/home-tabs-order.tsx
@@ -33,8 +33,7 @@ export default function HomeTabsOrderScreen() {
       renderItem={(args) => <RenderItem {...args} />}
       onReordered={onMove}
       ListHeaderComponent={ListHeaderComponent}
-      contentContainerClassName="py-4"
-      className="mx-4"
+      contentContainerClassName="p-4"
     />
   );
 }

--- a/mobile/src/app/setting/insights/save-errors.tsx
+++ b/mobile/src/app/setting/insights/save-errors.tsx
@@ -19,7 +19,6 @@ export default function SaveErrorsScreen() {
     <FlashList
       keyExtractor={({ id }) => id}
       ListEmptyComponent={<ContentPlaceholder errMsgKey="err.msg.noErrors" />}
-      className="mx-4"
       contentContainerClassName="p-4"
       {...presets}
     />

--- a/mobile/src/app/setting/third-party/index.tsx
+++ b/mobile/src/app/setting/third-party/index.tsx
@@ -21,7 +21,6 @@ export default function ThirdPartyScreen() {
   return (
     <FlashList
       keyExtractor={([id]) => id}
-      className="mx-4"
       contentContainerClassName="p-4"
       {...presets}
     />

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,5 +1,6 @@
 import type { FlashListProps } from "@shopify/flash-list";
 import { FlashList as SFlashList } from "@shopify/flash-list";
+import { forwardRef, useRef } from "react";
 import type { FlatListProps, ScrollViewProps } from "react-native";
 import {
   FlatList as RNFlatList,
@@ -18,9 +19,15 @@ export const ScrollablePresets = {
 } satisfies ScrollViewProps;
 
 //#region Native Components
-export function FlatList<TData>(props: FlatListProps<TData>) {
-  return <RNFlatList {...ScrollablePresets} {...props} />;
+export function useFlatListRef() {
+  return useRef<RNFlatList>(null);
 }
+
+export const FlatList = forwardRef(function FlatList(props, ref) {
+  return <RNFlatList ref={ref} {...ScrollablePresets} {...props} />;
+}) as <TData>(
+  props: FlatListProps<TData> & { ref?: React.ForwardedRef<RNFlatList> },
+) => React.JSX.Element;
 
 export function ScrollView(props: ScrollViewProps) {
   return <RNScrollView {...ScrollablePresets} {...props} />;

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,5 +1,5 @@
 import type { FlashListProps } from "@shopify/flash-list";
-import { FlashList as SFlashList } from "@shopify/flash-list";
+import { FlashList as RawFlashList } from "@shopify/flash-list";
 import { forwardRef, useRef } from "react";
 import type { FlatListProps, ScrollViewProps } from "react-native";
 import {
@@ -9,7 +9,8 @@ import {
 import { FlatList as RNASFlatList } from "react-native-actions-sheet";
 import { FlashList as RNASFlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
 import type { FlashDragListProps } from "react-native-draglist/dist/FlashList";
-import RNFlashDragList from "react-native-draglist/dist/FlashList";
+import RawFlashDragList from "react-native-draglist/dist/FlashList";
+import Animated from "react-native-reanimated";
 
 /** Presets for scrollview-like components. */
 export const ScrollablePresets = {
@@ -25,8 +26,8 @@ export function useFlatListRef() {
 
 export const FlatList = forwardRef(function FlatList(props, ref) {
   return <RNFlatList ref={ref} {...ScrollablePresets} {...props} />;
-}) as <TData>(
-  props: FlatListProps<TData> & { ref?: React.ForwardedRef<RNFlatList> },
+}) as <T>(
+  props: FlatListProps<T> & { ref?: React.ForwardedRef<RNFlatList> },
 ) => React.JSX.Element;
 
 export function ScrollView(props: ScrollViewProps) {
@@ -34,26 +35,44 @@ export function ScrollView(props: ScrollViewProps) {
 }
 //#endregion
 
-//#region Flash Lists
-/** `<FlashList />` with some defaults applied. */
-export function FlashList<TData>(props: FlashListProps<TData>) {
-  return <SFlashList {...ScrollablePresets} {...props} />;
-}
+//#region Flash List
+type FlashListSignature = <T>(
+  props: FlashListProps<T> & { ref?: React.ForwardedRef<RawFlashList<T>> },
+) => React.JSX.Element;
 
+const RawAnimatedFlashList = Animated.createAnimatedComponent(RawFlashList);
+
+export const FlashList = forwardRef(function FlashList(props, ref) {
+  return <RawFlashList ref={ref} {...ScrollablePresets} {...props} />;
+}) as FlashListSignature;
+
+export const AnimatedFlashList = forwardRef(
+  function AnimatedFlashList(props, ref) {
+    // @ts-expect-error - Ref should be compatible.
+    return <RawAnimatedFlashList ref={ref} {...ScrollablePresets} {...props} />;
+  },
+) as FlashListSignature;
+
+export function useFlashListRef() {
+  return useRef<RawFlashList<any>>(null);
+}
+//#endregion
+
+//#region Sheet Lists
 /** `<FlatList />` from `react-native-actions-sheet` with some defaults applied. */
-export function SheetsFlatList<TData>(props: FlatListProps<TData>) {
+export function SheetsFlatList<T>(props: FlatListProps<T>) {
   return <RNASFlatList {...ScrollablePresets} {...props} />;
 }
 
 /** `<FlashList />` from `react-native-actions-sheet` with some defaults applied. */
-export function SheetsFlashList<TData>(props: FlashListProps<TData>) {
+export function SheetsFlashList<T>(props: FlashListProps<T>) {
   return <RNASFlashList {...ScrollablePresets} {...props} />;
 }
 //#endregion
 
 //#region Flash Drag List
 /** `<FlashDragList />` with some defaults. */
-export function FlashDragList<TData>(props: FlashDragListProps<TData>) {
-  return <RNFlashDragList {...ScrollablePresets} {...props} />;
+export function FlashDragList<T>(props: FlashDragListProps<T>) {
+  return <RawFlashDragList {...ScrollablePresets} {...props} />;
 }
 //#endregion

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,5 +1,6 @@
 import type { FlashListProps } from "@shopify/flash-list";
 import { FlashList as RawFlashList } from "@shopify/flash-list";
+import { cssInterop } from "nativewind";
 import { forwardRef, useRef } from "react";
 import type { FlatListProps, ScrollViewProps } from "react-native";
 import {
@@ -38,11 +39,14 @@ export function ScrollView(props: ScrollViewProps) {
 type FlashListSignature = <T>(
   props: FlashListProps<T> & { ref?: React.ForwardedRef<RawFlashList<T>> },
 ) => React.JSX.Element;
+const WrappedFlashList = cssInterop(RawFlashList, {
+  contentContainerClassName: "contentContainerStyle",
+}) as FlashListSignature;
 
-const RawAnimatedFlashList = Animated.createAnimatedComponent(RawFlashList);
+const RawAnimatedFlashList = Animated.createAnimatedComponent(WrappedFlashList);
 
 export const FlashList = forwardRef(function FlashList(props, ref) {
-  return <RawFlashList ref={ref} {...ScrollablePresets} {...props} />;
+  return <WrappedFlashList ref={ref} {...ScrollablePresets} {...props} />;
 }) as FlashListSignature;
 
 export const AnimatedFlashList = forwardRef(
@@ -65,8 +69,12 @@ export function SheetsFlashList<T>(props: FlashListProps<T>) {
 //#endregion
 
 //#region Flash Drag List
+const WrappedFlashDragList = cssInterop(RawFlashDragList, {
+  contentContainerClassName: "contentContainerStyle",
+}) as typeof RawFlashDragList;
+
 /** `<FlashDragList />` with some defaults. */
 export function FlashDragList<T>(props: FlashDragListProps<T>) {
-  return <RawFlashDragList {...ScrollablePresets} {...props} />;
+  return <WrappedFlashDragList {...ScrollablePresets} {...props} />;
 }
 //#endregion

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -6,7 +6,6 @@ import {
   FlatList as RNFlatList,
   ScrollView as RNScrollView,
 } from "react-native";
-import { FlatList as RNASFlatList } from "react-native-actions-sheet";
 import { FlashList as RNASFlashList } from "react-native-actions-sheet/dist/src/views/FlashList";
 import type { FlashDragListProps } from "react-native-draglist/dist/FlashList";
 import RawFlashDragList from "react-native-draglist/dist/FlashList";
@@ -59,11 +58,6 @@ export function useFlashListRef() {
 //#endregion
 
 //#region Sheet Lists
-/** `<FlatList />` from `react-native-actions-sheet` with some defaults applied. */
-export function SheetsFlatList<T>(props: FlatListProps<T>) {
-  return <RNASFlatList {...ScrollablePresets} {...props} />;
-}
-
 /** `<FlashList />` from `react-native-actions-sheet` with some defaults applied. */
 export function SheetsFlashList<T>(props: FlashListProps<T>) {
   return <RNASFlashList {...ScrollablePresets} {...props} />;

--- a/mobile/src/layouts/StickyActionScroll.tsx
+++ b/mobile/src/layouts/StickyActionScroll.tsx
@@ -1,7 +1,6 @@
-import type { FlashListProps } from "@shopify/flash-list";
-import { FlashList } from "@shopify/flash-list";
+import type { FlashList, FlashListProps } from "@shopify/flash-list";
 import type { ParseKeys } from "i18next";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { LayoutChangeEvent, TextProps } from "react-native";
 import { useWindowDimensions } from "react-native";
@@ -16,11 +15,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 
-import { ScrollablePresets } from "~/components/Defaults";
+import { AnimatedFlashList } from "~/components/Defaults";
 import { AccentText } from "~/components/Typography/AccentText";
 
 /**
- * FlashList layout with optional action component that gets stickied
+ * Flash List layout with optional action component that gets stickied
  * after scrolling.
  */
 export function StickyActionListLayout<TData>({
@@ -28,7 +27,7 @@ export function StickyActionListLayout<TData>({
   StickyAction,
   estimatedActionSize = 0,
   listRef,
-  ...flashListProps
+  ...props
 }: FlashListProps<TData> & {
   /** Key to title in translations. */
   titleKey: ParseKeys;
@@ -37,7 +36,7 @@ export function StickyActionListLayout<TData>({
   /** Height of the StickyAction. */
   estimatedActionSize?: number;
   /** Pass a ref to the animated FlashList. */
-  listRef?: React.RefObject<Animated.FlatList<TData>>;
+  listRef?: React.RefObject<FlashList<any>>;
 }) {
   const { t } = useTranslation();
   const { top } = useSafeAreaInsets();
@@ -46,12 +45,6 @@ export function StickyActionListLayout<TData>({
 
   const initActionPos = useSharedValue(0);
   const scrollAmount = useSharedValue(0);
-
-  // Declare inside the component to ensure type-safety.
-  const AnimatedFlashList = useMemo(
-    () => Animated.createAnimatedComponent<FlashListProps<TData>>(FlashList),
-    [],
-  );
 
   /** Calculate the initial starting position of `StickyAction`. */
   const calcInitStartPos = useCallback(
@@ -81,7 +74,6 @@ export function StickyActionListLayout<TData>({
   return (
     <>
       <AnimatedFlashList
-        // @ts-expect-error An Animated.FlatList shares the general methods we want to access.
         ref={listRef}
         onScroll={scrollHandler}
         ListHeaderComponent={
@@ -94,8 +86,7 @@ export function StickyActionListLayout<TData>({
             {t(titleKey)}
           </LayoutHeader>
         }
-        {...ScrollablePresets}
-        {...flashListProps}
+        {...props}
         contentContainerStyle={{
           padding: 16,
           paddingBottom: bottomInset.withNav + 16,
@@ -115,14 +106,6 @@ export function StickyActionListLayout<TData>({
     </>
   );
 }
-
-//#region Hooks
-/** Custom hook for getting a ref to a `<StickyActionListLayout />`. */
-export function useStickyActionListLayoutRef<TData>() {
-  const ref = useRef<Animated.FlatList<TData>>(null);
-  return ref;
-}
-//#endregion
 
 function LayoutHeader({
   style,

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -16,6 +16,7 @@ import { Search } from "~/icons/Search";
 import { useTheme } from "~/hooks/useTheme";
 
 import { cn } from "~/lib/style";
+import { isString } from "~/utils/validation";
 import { FlashList, SheetsFlashList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { TextInput, useInputRef } from "~/components/Form/Input";
@@ -102,11 +103,10 @@ function SearchResultsList<TScope extends SearchCategories>(
         // Note: We use `index` instead of the `id` or `name` field on the
         // `entry` due to there being potentially shared values (ie: between
         // artist & playlist names).
-        keyExtractor={(item, index) =>
-          typeof item === "string" ? item : `${index}`
-        }
+        keyExtractor={(item, index) => (isString(item) ? item : `${index}`)}
+        getItemType={(item) => (isString(item) ? "label" : "row")}
         renderItem={({ item, index }) =>
-          typeof item === "string" ? (
+          isString(item) ? (
             <TEm
               textKey={`term.${item}`}
               className={index > 0 ? "mt-4" : undefined}

--- a/mobile/src/screens/NowPlaying/Sheets.tsx
+++ b/mobile/src/screens/NowPlaying/Sheets.tsx
@@ -140,7 +140,7 @@ function TrackUpcomingSheet(props: {
               title={item.name}
               description={item.artistName ?? "—"}
               imageSource={getTrackCover(item)}
-              className={cn("px-4", {
+              className={cn({
                 "opacity-25": index >= disableIndex,
                 "mt-1": index > 0,
               })}
@@ -151,7 +151,8 @@ function TrackUpcomingSheet(props: {
         ListEmptyComponent={
           <ContentPlaceholder isPending={trackList.length === 0} />
         }
-        contentContainerClassName="pb-4"
+        ListHeaderComponentStyle={{ marginHorizontal: -16 }}
+        contentContainerClassName="px-4 pb-4"
       />
     </Sheet>
   );

--- a/mobile/src/screens/Sheets/Settings/Root.tsx
+++ b/mobile/src/screens/Sheets/Settings/Root.tsx
@@ -80,8 +80,8 @@ function LanguageSheet(props: { sheetRef: React.RefObject<ActionSheetRef> }) {
   return (
     <Sheet ref={props.sheetRef} titleKey="feat.language.title" snapTop>
       <SheetsFlashList
-        estimatedItemSize={58} // 54px Height + 4px Margin Top
         accessibilityRole="radiogroup"
+        estimatedItemSize={58} // 54px Height + 4px Margin Top
         data={LANGUAGES}
         keyExtractor={({ code }) => code}
         extraData={languageCode}

--- a/mobile/src/screens/Sheets/Settings/Root.tsx
+++ b/mobile/src/screens/Sheets/Settings/Root.tsx
@@ -78,12 +78,7 @@ function BackupSheet(props: { sheetRef: React.RefObject<ActionSheetRef> }) {
 function LanguageSheet(props: { sheetRef: React.RefObject<ActionSheetRef> }) {
   const languageCode = useUserPreferencesStore((state) => state.language);
   return (
-    <Sheet
-      ref={props.sheetRef}
-      titleKey="feat.language.title"
-      contentContainerClassName="pb-0"
-      snapTop
-    >
+    <Sheet ref={props.sheetRef} titleKey="feat.language.title" snapTop>
       <SheetsFlashList
         estimatedItemSize={58} // 54px Height + 4px Margin Top
         accessibilityRole="radiogroup"

--- a/mobile/src/screens/Sheets/Settings/Root.tsx
+++ b/mobile/src/screens/Sheets/Settings/Root.tsx
@@ -9,7 +9,7 @@ import { LANGUAGES } from "~/modules/i18n/constants";
 import { useExportBackup, useImportBackup } from "./helpers/BackupData";
 
 import { mutateGuard } from "~/lib/react-query";
-import { SheetsFlatList } from "~/components/Defaults";
+import { SheetsFlashList } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
 import { Radio } from "~/components/Form/Selection";
 import { Sheet } from "~/components/Sheet";
@@ -82,20 +82,24 @@ function LanguageSheet(props: { sheetRef: React.RefObject<ActionSheetRef> }) {
       ref={props.sheetRef}
       titleKey="feat.language.title"
       contentContainerClassName="pb-0"
+      snapTop
     >
-      <SheetsFlatList
+      <SheetsFlashList
+        estimatedItemSize={58} // 54px Height + 4px Margin Top
         accessibilityRole="radiogroup"
         data={LANGUAGES}
         keyExtractor={({ code }) => code}
-        renderItem={({ item }) => (
+        extraData={languageCode}
+        renderItem={({ item, index }) => (
           <Radio
             selected={languageCode === item.code}
             onSelect={() => setLanguage(item.code)}
+            wrapperClassName={index > 0 ? "mt-1" : undefined}
           >
             <StyledText>{item.name}</StyledText>
           </Radio>
         )}
-        contentContainerClassName="gap-1 pb-4"
+        contentContainerClassName="pb-4"
       />
     </Sheet>
   );

--- a/mobile/src/utils/validation.ts
+++ b/mobile/src/utils/validation.ts
@@ -1,0 +1,7 @@
+export function isNumber(item: any): item is number {
+  return typeof item === "number";
+}
+
+export function isString(item: any): item is string {
+  return typeof item === "string";
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR applies some optimizations to the existing lists since we narrowed down the performance issue w/ navigation to "Current Album/Artist" screens with lots of tracks to Legend List.

- Fixed horizontal padding not working when passed in `contentContainerClassName` (due to FlashList internally extracting `contentContainerStyle` and applying it to a internal component - explictly remapping the prop fixes the issue).
- Utilize `getItemType` to tell FlashList to use separate recycling pool when we render different types of components in the list.
- All list components used should be from `Defaults.tsx`.
  - Replaced use of `SheetsFlatList` with `SheetsFlashList` (we need to use the `snapTop` prop as otherwise, the FlashList won't have a defined height).
  - Created new `AnimatedFlashList` component.
  - Exported `FlatList`, `FlashList`, and `AnimatedFlashList` now supports refs.

> [!NOTE]  
> Weird "bug" that occurred is the negative margin trick didn't work for the "Queue List" portion of the "Upcoming Sheet" when it worked everywhere else (Recent List, "Album List" on Artist screen).
> - We could mimic this behavior by applying the negative margin via `ListHeaderComponentStyle` on the parent list.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
