### PR TITLE
feat: Search & programmatic navigation to folder

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -111,7 +111,8 @@
     "patchedDependencies": {
       "react-native-gesture-handler": "patches/react-native-gesture-handler.patch",
       "@react-native-assets/slider": "patches/@react-native-assets__slider.patch",
-      "@backpackapp-io/react-native-toast": "patches/@backpackapp-io__react-native-toast.patch"
+      "@backpackapp-io/react-native-toast": "patches/@backpackapp-io__react-native-toast.patch",
+      "expo-router": "patches/expo-router.patch"
     }
   }
 }

--- a/mobile/patches/expo-router.patch
+++ b/mobile/patches/expo-router.patch
@@ -1,0 +1,14 @@
+diff --git a/build/hooks.js b/build/hooks.js
+index 565bb0187e6fc858b2cc4fefb7f6c5e1ffe73a21..2f095c7a07876c51240ed44a6b9e799712c65a24 100644
+--- a/build/hooks.js
++++ b/build/hooks.js
+@@ -96,6 +96,9 @@ function useLocalSearchParams() {
+                 }),
+             ];
+         }
++        else if (typeof value === 'undefined' || value === null) {
++            return [key, value];
++        }
+         else {
+             try {
+                 return [key, decodeURIComponent(value)];

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -14,6 +14,9 @@ patchedDependencies:
   '@react-native-assets/slider':
     hash: r2mjdjwkbzsvohkwkhe7tpugg4
     path: patches/@react-native-assets__slider.patch
+  expo-router:
+    hash: 57vunnovuvb4cthgesct5jkexy
+    path: patches/expo-router.patch
   react-native-gesture-handler:
     hash: rjhgnwrqf5shhovxtmq2tgj2qm
     path: patches/react-native-gesture-handler.patch
@@ -99,7 +102,7 @@ importers:
         version: 17.0.6(expo@52.0.46(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@3.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1)))(graphql@15.8.0)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1))(react@18.3.1))(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1))
       expo-router:
         specifier: ~3.5.24
-        version: 3.5.24(sdbw2itehpgjii3b5dbhtw2mkm)
+        version: 3.5.24(patch_hash=57vunnovuvb4cthgesct5jkexy)(sdbw2itehpgjii3b5dbhtw2mkm)
       expo-sqlite:
         specifier: ~15.1.4
         version: 15.1.4(expo@52.0.46(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@3.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1)))(graphql@15.8.0)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1))(react@18.3.1))(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1))(react@18.3.1)
@@ -10904,7 +10907,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-router@3.5.24(sdbw2itehpgjii3b5dbhtw2mkm):
+  expo-router@3.5.24(patch_hash=57vunnovuvb4cthgesct5jkexy)(sdbw2itehpgjii3b5dbhtw2mkm):
     dependencies:
       '@expo/metro-runtime': 3.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@18.3.22)(react@18.3.1))
       '@expo/server': 0.4.4(typescript@5.8.3)

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -1,4 +1,5 @@
 import { useIsFocused } from "@react-navigation/native";
+import { router, useLocalSearchParams } from "expo-router";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { BackHandler, Pressable, useWindowDimensions } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
@@ -19,6 +20,7 @@ import { useFolderContent } from "~/queries/folder";
 import { StickyActionListLayout } from "~/layouts/StickyActionScroll";
 
 import { cn } from "~/lib/style";
+import { addTrailingSlash } from "~/utils/string";
 import { useFlashListRef } from "~/components/Defaults";
 import { ContentPlaceholder } from "~/components/Transition/Placeholder";
 import { StyledText } from "~/components/Typography/StyledText";
@@ -32,6 +34,7 @@ const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 export default function FolderScreen() {
   const isFocused = useIsFocused();
   const listRef = useFlashListRef();
+  const { path } = useLocalSearchParams<{ path?: string }>();
   const [dirSegments, _setDirSegments] = useState<string[]>([]);
 
   const fullPath = dirSegments.join("/");
@@ -54,6 +57,16 @@ export default function FolderScreen() {
       [listRef],
     );
 
+  // Enable the ability to navigate to a specific folder programmatically.
+  useEffect(() => {
+    if (!isFocused || !path) return;
+    // Exclude the `/` at the end of the path.
+    setDirSegments(addTrailingSlash(path).split("/").slice(0, -1));
+    // Clear search params after reading from it.
+    router.setParams({ path: undefined });
+  }, [isFocused, path, setDirSegments]);
+
+  // Enables our "fake tabs" be affected by the navigation back gesture.
   useEffect(() => {
     // Prevent event from working when this screen isn't focused.
     if (!isFocused) return;

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -191,7 +191,7 @@ function Breadcrumbs({
                 // `pathSegments.length` instead of `pathSegments.length - 1`
                 // due to us prepending an extra entry to denote the "Root".
                 disabled={idx === dirSegments.length}
-                className="min-h-12 justify-center active:opacity-75"
+                className="min-h-12 min-w-6 items-center justify-center active:opacity-75"
               >
                 <StyledText
                   className={cn("text-xs", {

--- a/mobile/src/app/search.tsx
+++ b/mobile/src/app/search.tsx
@@ -21,13 +21,15 @@ export default function SearchScreen() {
 }
 
 /** List of media we want to appear in the search. */
-const searchScope = ["album", "artist", "playlist", "track"] as const;
+const searchScope = ["album", "artist", "folder", "playlist", "track"] as const;
 
 /** Actions that we want to run when we click on a search item. */
 const searchCallbacks: SearchCallbacks = {
   /* Visit the media's page. */
   album: ({ id }) => router.push(`/album/${id}`),
   artist: ({ name }) => router.push(`/artist/${encodeURIComponent(name)}`),
+  folder: ({ path }) =>
+    console.log("Navigating to `/folder` screen for:", path),
   playlist: ({ name }) => router.push(`/playlist/${encodeURIComponent(name)}`),
   /* Play the specified track. */
   track: ({ id }) =>

--- a/mobile/src/app/search.tsx
+++ b/mobile/src/app/search.tsx
@@ -28,8 +28,6 @@ const searchCallbacks: SearchCallbacks = {
   /* Visit the media's page. */
   album: ({ id }) => router.push(`/album/${id}`),
   artist: ({ name }) => router.push(`/artist/${encodeURIComponent(name)}`),
-  folder: ({ path }) =>
-    console.log("Navigating to `/folder` screen for:", path),
   playlist: ({ name }) => router.push(`/playlist/${encodeURIComponent(name)}`),
   /* Play the specified track. */
   track: ({ id }) =>
@@ -37,4 +35,16 @@ const searchCallbacks: SearchCallbacks = {
       trackId: id,
       source: { type: "playlist", id: ReservedPlaylists.tracks },
     }),
+  /*
+    Navigate to the folder route, meaning a "back" action won't bring us
+    back to this screen.
+    
+    Although using `push()` works, things become a bit janky as:
+      1. The navigation bar won't work the way we expect.
+      2. If we use this pushed screen, at a certain point when using the
+      "back" gesture, we'll end up back to this screen, which might be a
+      bit unexpected.
+  */
+  folder: ({ path }) =>
+    router.navigate(`/folder?path=${encodeURIComponent(path)}`),
 };

--- a/mobile/src/db/slimTypes.ts
+++ b/mobile/src/db/slimTypes.ts
@@ -1,4 +1,4 @@
-import type { Album, Artist, Playlist, Track } from "~/db/schema";
+import type { Album, Artist, FileNode, Playlist, Track } from "~/db/schema";
 
 /** What the `artwork` field typically holds. */
 export type Artwork = string | null;
@@ -15,6 +15,9 @@ export type SlimAlbumWithTracks = SlimAlbum & { tracks: SlimTrack[] };
 
 /** Minimum data typically used from `Artist`. */
 export type SlimArtist = Pick<Artist, "name" | "artwork">;
+
+/** Minimum data typically used from `Folder`. */
+export type SlimFolder = FileNode & { tracks: SlimTrack[] };
 
 /** Minimum data typically used from `Playlist`. */
 export type SlimPlaylist = Pick<Playlist, "name" | "artwork">;

--- a/mobile/src/db/slimTypes.ts
+++ b/mobile/src/db/slimTypes.ts
@@ -17,7 +17,7 @@ export type SlimAlbumWithTracks = SlimAlbum & { tracks: SlimTrack[] };
 export type SlimArtist = Pick<Artist, "name" | "artwork">;
 
 /** Minimum data typically used from `Folder`. */
-export type SlimFolder = FileNode & { tracks: SlimTrack[] };
+export type SlimFolder = FileNode & { tracks: SlimTrackWithAlbum[] };
 
 /** Minimum data typically used from `Playlist`. */
 export type SlimPlaylist = Pick<Playlist, "name" | "artwork">;

--- a/mobile/src/modules/media/services/RecentList.ts
+++ b/mobile/src/modules/media/services/RecentList.ts
@@ -6,6 +6,7 @@ import { formatForMediaCard } from "~/db/utils";
 import i18next from "~/modules/i18n";
 import { getAlbum } from "~/api/album";
 import { getArtist } from "~/api/artist";
+import { getFolderTracks } from "~/api/folder";
 import { getPlaylist, getSpecialPlaylist } from "~/api/playlist";
 
 import { createPersistedSubscribedStore } from "~/lib/zustand";
@@ -83,8 +84,14 @@ recentListStore.subscribe(
           });
           entry = formatForMediaCard({ type: "artist", data, t: i18next.t });
         } else if (type === "folder") {
-          // TODO: Eventually support folders in the recent list.
-          entry = undefined;
+          const numTracks = (await getFolderTracks(id)).length;
+          entry = {
+            type: "folder",
+            source: null,
+            href: `/folder?path=${encodeURIComponent(id)}`,
+            title: id.split("/").at(-2) ?? id,
+            description: i18next.t("plural.track", { count: numTracks }),
+          };
         } else {
           let data = null;
           if (ReservedNames.has(id)) {

--- a/mobile/src/modules/media/types.ts
+++ b/mobile/src/modules/media/types.ts
@@ -1,9 +1,5 @@
 /** Types of "media" we can play audio from. */
 export type MediaType = "album" | "artist" | "folder" | "playlist" | "track";
 
-// FIXME: We currently also ignore "folder" to preserve the old behavior.
-/** Media containing a list of playable content. */
-export type MediaList = Exclude<MediaType, "folder" | "track">;
-
 /** Identifies a list of tracks that will be played. */
 export type PlayListSource = { type: Exclude<MediaType, "track">; id: string };

--- a/mobile/src/modules/scanning/constants.ts
+++ b/mobile/src/modules/scanning/constants.ts
@@ -1,4 +1,4 @@
-const MigrationOptions = ["kv-store"] as const;
+const MigrationOptions = ["kv-store", "fileNodes-adjustment"] as const;
 
 export type MigrationOption = (typeof MigrationOptions)[number];
 
@@ -17,5 +17,5 @@ export const MigrationHistory: Record<
   number,
   { version: string; changes: MigrationOption[] }
 > = {
-  0: { version: "v2.3.0", changes: ["kv-store"] },
+  0: { version: "v2.3.0", changes: ["kv-store", "fileNodes-adjustment"] },
 };

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -1,17 +1,13 @@
-import { StorageVolumesDirectoryPaths } from "@missingcore/react-native-metadata-retriever";
-
 import { db } from "~/db";
 import type { FileNode } from "~/db/schema";
 import { fileNodes } from "~/db/schema";
 
 import { addTrailingSlash } from "~/utils/string";
 
-/** Remove the `/` at the start. */
-const volumePaths = StorageVolumesDirectoryPaths.map((path) => path.slice(1));
-
 /**
  * Generate the list of `FileNode` entries to a given uri. The uri should
- * start with `file:///`.
+ * start with `file:///` and not end with a `/` (the string after the last
+ * `/` should be the filename.).
  */
 export async function savePathComponents(uri: string) {
   // Removes the `file:///` at the start and the filename at the end of the uri.
@@ -23,25 +19,15 @@ export async function savePathComponents(uri: string) {
   });
   if (exists) return;
 
-  // Figure out which storage volume this file belongs to.
-  const _usedVolume = volumePaths.filter((p) => filePath.startsWith(p))[0];
-  // Don't throw error, but exit if the uri doesn't belong to any of the
-  // storage volumes detected by `@missingcore/react-native-metadata-retriever`.
-  if (!_usedVolume) return;
-  const usedVolume = addTrailingSlash(_usedVolume);
-
   // List of `FileNode` entries that make up the uri.
-  const foundNodes: FileNode[] = [
-    { name: usedVolume.slice(0, -1), path: usedVolume, parentPath: null },
-  ];
-
-  // Find remaining `FileNode` entries.
-  const segments = filePath.slice(usedVolume.length).split("/");
-  segments.forEach((name, idx) => {
-    const parentPath = addTrailingSlash(
-      `${usedVolume}${segments.slice(0, idx).join("/")}`,
-    );
-    foundNodes.push({ name, path: `${parentPath}${name}/`, parentPath });
+  const foundNodes: FileNode[] = [];
+  filePath.split("/").forEach((name, idx) => {
+    if (idx === 0) {
+      foundNodes.push({ name, path: `${name}/`, parentPath: null });
+    } else {
+      const parentPath = foundNodes[idx - 1]!.path;
+      foundNodes.push({ name, path: `${parentPath}${name}/`, parentPath });
+    }
   });
 
   // Insert found nodes into database.

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -237,16 +237,23 @@ function formatResults(results: Partial<SearchResults>, tab: SearchTab) {
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([key, data]) => [
       ...(tab === "all" ? [key as SearchCategories[number]] : []),
-      ...data.map((item) => ({
-        type: key as SearchCategories[number],
-        // @ts-expect-error - Values are of correct types.
-        imageSource: getArtwork({ type: key, data: item }),
-        title: item.name,
-        // prettier-ignore
+      ...data.map((item) => {
+        let description: string | undefined;
         // @ts-expect-error - `artistName` should be present in these cases.
-        description: withArtistName.includes(key) ? (item.artistName ?? "—") : undefined,
-        entry: item,
-      })),
+        if (withArtistName.includes(key)) description = item.artistName ?? "—";
+        // @ts-expect-error - `path` should be present in these cases.
+        else if (item.path) description = item.path;
+
+        return {
+          type: key as SearchCategories[number],
+          imageSource:
+            // @ts-expect-error - Values are of correct types.
+            key !== "folder" ? getArtwork({ type: key, data: item }) : null,
+          title: item.name,
+          description,
+          entry: item,
+        };
+      }),
     ])
     .flat();
 }

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -1,6 +1,7 @@
 import type {
   SlimAlbumWithTracks,
   SlimArtist,
+  SlimFolder,
   SlimPlaylistWithTracks,
   SlimTrackWithAlbum,
 } from "~/db/slimTypes";
@@ -8,13 +9,13 @@ import type {
 import type { MediaType } from "~/modules/media/types";
 
 /** Categories of media that can be returned by search. */
-export type SearchCategories = ReadonlyArray<Exclude<MediaType, "folder">>;
+export type SearchCategories = readonly MediaType[];
 
 /** Functions that can be triggered on the categories of media. */
 export type SearchCallbacks = {
   album: (album: SlimAlbumWithTracks) => void | Promise<void>;
   artist: (artist: SlimArtist) => void | Promise<void>;
-  // folder: (folder: unknown) => void | Promise<void>;
+  folder: (folder: SlimFolder) => void | Promise<void>;
   playlist: (playlist: SlimPlaylistWithTracks) => void | Promise<void>;
   track: (track: SlimTrackWithAlbum) => void | Promise<void>;
 };
@@ -23,7 +24,7 @@ export type SearchCallbacks = {
 export type SearchResults = {
   album: SlimAlbumWithTracks[];
   artist: SlimArtist[];
-  // folder: unknown[];
+  folder: SlimFolder[];
   playlist: SlimPlaylistWithTracks[];
   track: SlimTrackWithAlbum[];
 };

--- a/mobile/src/screens/ModifyPlaylist/Sheets.tsx
+++ b/mobile/src/screens/ModifyPlaylist/Sheets.tsx
@@ -7,7 +7,7 @@ import { SearchEngine } from "~/modules/search/components/SearchEngine";
 import type { SearchCallbacks } from "~/modules/search/types";
 
 /** List of media we want to appear in the search. */
-const searchScope = ["album", "track"] as const;
+const searchScope = ["album", "folder", "track"] as const;
 
 /** Enables us to add music to a playlist. */
 export const AddMusicSheet = deferInitialRender(function AddMusicSheet(props: {

--- a/mobile/src/screens/ModifyPlaylist/context.tsx
+++ b/mobile/src/screens/ModifyPlaylist/context.tsx
@@ -49,7 +49,7 @@ type PlaylistStore = InitStoreProps & {
   setShowConfirmation: (status: boolean) => void;
 
   /** Callbacks to add searched tracks to the `tracks` state. */
-  SearchCallbacks: Pick<SearchCallbacks, "album" | "track">;
+  SearchCallbacks: Pick<SearchCallbacks, "album" | "folder" | "track">;
 
   /** Validates our inputs before passing those values to `onSubmit`. */
   INTERNAL_onSubmit: () => Promise<void>;
@@ -133,6 +133,10 @@ export function PlaylistStoreProvider({
               i18next.t("template.entryAdded", { name: album.name }),
               ToastOptions,
             );
+          },
+          folder: ({ name, tracks }) => {
+            set((prev) => ({ tracks: mergeTracks(prev.tracks, tracks) }));
+            toast(i18next.t("template.entryAdded", { name }), ToastOptions);
           },
           track: (track) => {
             set((prev) => ({

--- a/mobile/src/screens/NowPlaying/TopAppBar.tsx
+++ b/mobile/src/screens/NowPlaying/TopAppBar.tsx
@@ -38,11 +38,12 @@ function AppBarContent() {
   const usedDesign = useUserPreferencesStore((state) => state.nowPlayingDesign);
 
   const listHref = useMemo(() => {
-    if (!playingSource || playingSource.type === "folder") return undefined;
+    if (!playingSource) return undefined;
     const { type, id } = playingSource;
     if (type === "playlist" && id === ReservedPlaylists.tracks) return "/track";
-    return `/${type}/${encodeURIComponent(id)}` satisfies Href;
-  }, [playingSource]);
+    else if (type === "folder") return `/folder?path=${encodeURIComponent(id)}`;
+    return `/${type}/${encodeURIComponent(id)}`;
+  }, [playingSource]) as Href;
 
   if (usedDesign === "vinylOld") return null;
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

- Add support for searching for folders.
- Add support for adding contents of folders to playlists.
- Add support for programmatically navigating to a specific folder (via Search, Recently Played, and Now Playing).
- Patch `expo-router`'s `useLocalSearchParams()` not allowing the ability to clear a search parameter.
- Changed how the Folder screen work - we no longer have the `storage/emulated/0` shortcut, instead we have folders for each component (`storage`, `emulated`, and `0`).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
