### PR TITLE
fix: Sheet gesture not working with scrollable child with `nestedScrollEnabled`

### DIFF
--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,8 +1,12 @@
 import type { FlashListProps as RawFlashListProps } from "@shopify/flash-list";
 import { FlashList as RawFlashList } from "@shopify/flash-list";
 import { cssInterop } from "nativewind";
-import { useRef } from "react";
-import type { FlatListProps, ScrollViewProps } from "react-native";
+import { useMemo, useRef, useState } from "react";
+import type {
+  FlatListProps,
+  LayoutChangeEvent,
+  ScrollViewProps,
+} from "react-native";
 import {
   FlatList as RNFlatList,
   ScrollView as RNScrollView,
@@ -17,6 +21,29 @@ export const ScrollablePresets = {
   showsHorizontalScrollIndicator: false,
   showsVerticalScrollIndicator: false,
 } satisfies ScrollViewProps;
+
+/**
+ * Returns whether a scrollable container is scrollable (ie: if its content
+ * height is greater than the container size).
+ */
+export function useIsScrollable() {
+  const layoutHeight = useRef(0);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  const handlers = useMemo(
+    () => ({
+      onLayout: (e: LayoutChangeEvent) => {
+        layoutHeight.current = e.nativeEvent.layout.height;
+      },
+      onContentSizeChange: (_w: number, h: number) => {
+        setIsScrollable(h !== layoutHeight.current);
+      },
+    }),
+    [],
+  );
+
+  return useMemo(() => ({ handlers, isScrollable }), [handlers, isScrollable]);
+}
 
 //#region Native Components
 export function useFlatListRef() {

--- a/mobile/src/components/Sheet.tsx
+++ b/mobile/src/components/Sheet.tsx
@@ -51,13 +51,21 @@ export function Sheet({
 }: SheetProps & { ref?: TrueSheetRef }) {
   const { t } = useTranslation();
   const { canvasAlt } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { height: screenHeight } = useWindowDimensions();
   const [enableToast, setEnableToast] = useState(false);
   const [disableToastAnim, setDisableToastAnim] = useState(true);
   const [sheetHeight, setSheetHeight] = useState(0);
   const [headerHeight, setHeaderHeight] = useState(0);
   const disableAnimTimerRef = useRef<number>(null);
 
-  const maxSheetHeight = useMaxSheetHeight();
+  // In Android API 35+, the "height" now includes the system decoration
+  // areas and display cutout (status & navigation bar heights).
+  //  - https://github.com/facebook/react-native/issues/47080#issuecomment-2421914957
+  const trueScreenHeight = useMemo(() => {
+    if (!platformApiLevel || platformApiLevel < 35) return screenHeight;
+    return screenHeight - insets.top - insets.bottom;
+  }, [insets.bottom, insets.top, screenHeight]);
 
   return (
     <TrueSheet
@@ -66,7 +74,8 @@ export function Sheet({
       sizes={[snapTop ? "large" : "auto"]}
       backgroundColor={canvasAlt}
       cornerRadius={BorderRadius.lg}
-      maxHeight={maxSheetHeight}
+      // Sheet max height will be just before the `<TopAppBar />`.
+      maxHeight={trueScreenHeight - 56}
       grabber={false}
       onPresent={(e) => {
         if (onPresent) onPresent(e);
@@ -100,7 +109,7 @@ export function Sheet({
           // TrueSheet doesn't know the actual scrollable area, so we
           // need to exclude the height taken up by the "SheetHeader"
           // from the container that can hold a scrollable.
-          [{ maxHeight: maxSheetHeight - headerHeight }],
+          [{ maxHeight: trueScreenHeight - 56 - headerHeight }],
           contentContainerStyle,
         ]}
         className={cn(
@@ -144,21 +153,4 @@ function SheetHeader(props: {
       ) : null}
     </View>
   );
-}
-
-/** Returns the max height of the sheet. */
-function useMaxSheetHeight() {
-  const insets = useSafeAreaInsets();
-  const { height: screenHeight } = useWindowDimensions();
-
-  // In Android API 35+, the "height" now includes the system decoration
-  // areas and display cutout (status & navigation bar heights).
-  //  - https://github.com/facebook/react-native/issues/47080#issuecomment-2421914957
-  const trueScreenHeight = useMemo(() => {
-    if (!platformApiLevel || platformApiLevel < 35) return screenHeight;
-    return screenHeight - insets.top - insets.bottom;
-  }, [insets.bottom, insets.top, screenHeight]);
-
-  // Sheet max height will be just before the `<TopAppBar />`.
-  return useMemo(() => trueScreenHeight - 56, [trueScreenHeight]);
 }

--- a/mobile/src/screens/Sheets/Settings/Root.tsx
+++ b/mobile/src/screens/Sheets/Settings/Root.tsx
@@ -9,7 +9,7 @@ import { useExportBackup, useImportBackup } from "./helpers/BackupData";
 
 import { deferInitialRender } from "~/lib/react";
 import { mutateGuard } from "~/lib/react-query";
-import { FlatList } from "~/components/Defaults";
+import { FlatList, useIsScrollable } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
 import { Radio } from "~/components/Form/Selection";
 import type { TrueSheetRef } from "~/components/Sheet";
@@ -78,6 +78,8 @@ function BackupSheet(props: { sheetRef: TrueSheetRef }) {
 /** Enables the ability to change the language used. */
 function LanguageSheet(props: { sheetRef: TrueSheetRef }) {
   const languageCode = useUserPreferencesStore((state) => state.language);
+  const { handlers, isScrollable } = useIsScrollable();
+
   return (
     <Sheet
       ref={props.sheetRef}
@@ -96,7 +98,8 @@ function LanguageSheet(props: { sheetRef: TrueSheetRef }) {
             <StyledText>{item.name}</StyledText>
           </Radio>
         )}
-        nestedScrollEnabled
+        {...handlers}
+        nestedScrollEnabled={isScrollable}
         contentContainerClassName="gap-1 pb-4"
       />
     </Sheet>

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -38,7 +38,7 @@ import {
   formatSeconds,
 } from "~/utils/number";
 import { Marquee } from "~/components/Containment/Marquee";
-import { FlashList, ScrollView } from "~/components/Defaults";
+import { FlashList, ScrollView, useIsScrollable } from "~/components/Defaults";
 import { Divider } from "~/components/Divider";
 import { Button } from "~/components/Form/Button";
 import { Checkbox } from "~/components/Form/Selection";
@@ -57,6 +57,7 @@ import { MediaImage } from "~/modules/media/components/MediaImage";
 export function TrackSheet() {
   const data = useSessionStore((state) => state.displayedTrack);
   const trackArtworkSheetRef = useSheetRef();
+  const { handlers, isScrollable } = useIsScrollable();
 
   const editArtwork = useCallback(() => {
     trackArtworkSheetRef.current?.present();
@@ -71,7 +72,11 @@ export function TrackSheet() {
         sizes={["auto", "large"]}
       >
         {data !== null ? (
-          <ScrollView nestedScrollEnabled contentContainerClassName="gap-4">
+          <ScrollView
+            {...handlers}
+            nestedScrollEnabled={isScrollable}
+            contentContainerClassName="gap-4"
+          >
             <TrackIntro key={data._checked} data={data} />
             <PrimaryTrackContent data={data} editArtwork={editArtwork} />
             <TrackLinks data={data} />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

There's a "rare" situation where gestures directly on the sheet (to expand or dismiss) doesn't work. This was narrowed down to having a scrollable container inside the sheet with the `nestedScrollEnabled` prop, where the sheet doesn't take up the whole screen. Disabling `nestedScrollEnabled` (when it's not even needed) fixed the issue.

This was solved by creating a `useIsScrollable` hook in the `Defaults.tsx` file (where we export all the scrollable components) that return event handlers and a boolean on whether the scrollable can be scrolled.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a rare issue with sheet gestures in nested scrollable containers by implementing the useIsScrollable hook. The hook intelligently determines when a container is scrollable and applies appropriate event handlers, ensuring the nestedScrollEnabled prop is only active when needed, thereby improving sheet interaction reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>