### PR TITLE
fix: Duplicate Albums From Different Release Years

### DIFF
--- a/mobile/src/api/artist.ts
+++ b/mobile/src/api/artist.ts
@@ -34,15 +34,15 @@ export async function getArtistAlbums(id: string) {
     where: (fields, { eq }) => eq(fields.artistName, id),
     with: { tracks: { columns: { year: true } } },
   });
-  const albumWithYear = allAlbums.map((album) => {
-    return { ...album, year: getYearRange(album.tracks) };
+  const albumWithYear = allAlbums.map(({ tracks, ...album }) => {
+    return { ...album, year: getYearRange(tracks) };
   });
   // FIXME: Once Hermes supports `toSorted`, use it instead.
   albumWithYear.sort(
     (a, b) =>
       b.year.maxYear - a.year.maxYear || b.year.minYear - a.year.minYear,
   );
-  return albumWithYear.map(({ tracks: _, year, ...album }) => {
+  return albumWithYear.map(({ year, ...album }) => {
     return { ...album, releaseYear: year.range };
   });
 }

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -7,12 +7,13 @@ import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { useGetColumn } from "~/hooks/useGetColumn";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
-import { isYearDefined } from "~/utils/number";
 import { FlashList } from "~/components/Defaults";
 import { PagePlaceholder } from "~/components/Transition/Placeholder";
 import { TEm } from "~/components/Typography/StyledText";
 import { MediaCard } from "~/modules/media/components/MediaCard";
 import { Track } from "~/modules/media/components/Track";
+
+type ArtistAlbum = Omit<Album, "releaseYear"> & { releaseYear: string | null };
 
 /** Screen for `/artist/[id]` route. */
 export default function CurrentArtistScreen() {
@@ -55,7 +56,7 @@ export default function CurrentArtistScreen() {
  * Display a list of the artist's albums. Renders a heading for the track
  * list only if the artist has albums.
  */
-function ArtistAlbums({ albums }: { albums: Album[] | null }) {
+function ArtistAlbums({ albums }: { albums: ArtistAlbum[] | null }) {
   const { width } = useGetColumn({
     cols: 1,
     gap: 0,
@@ -80,7 +81,7 @@ function ArtistAlbums({ albums }: { albums: Album[] | null }) {
             source={item.artwork}
             href={`/album/${item.id}`}
             title={item.name}
-            description={`${isYearDefined(item.releaseYear) ? item.releaseYear : "————"}`}
+            description={item.releaseYear || "————"}
             className={index > 0 ? "ml-3" : undefined}
           />
         )}

--- a/mobile/src/db/drizzle/0010_brief_exodus.sql
+++ b/mobile/src/db/drizzle/0010_brief_exodus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tracks` ADD `year` integer;

--- a/mobile/src/db/drizzle/meta/0010_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,514 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7ccc081d-97c8-447c-8522-95bfa8cb6bca",
+  "prevId": "9cd3b104-a2c9-486d-aa17-4330bebfd4e4",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(coalesce(\"alt_artwork\", \"embedded_artwork\"))",
+            "type": "virtual"
+          }
+        },
+        "embedded_artwork": {
+          "name": "embedded_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {
+        "albums_name_artist_name_release_year_unique": {
+          "name": "albums_name_artist_name_release_year_unique",
+          "columns": [
+            "name",
+            "artist_name",
+            "release_year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(coalesce(\"alt_artwork\", \"embedded_artwork\"))",
+            "type": "virtual"
+          }
+        },
+        "embedded_artwork": {
+          "name": "embedded_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "parent_folder": {
+          "name": "parent_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(rtrim(\"uri\", replace(\"uri\", '/', '')))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1751075864737,
       "tag": "0009_ambitious_puppet_master",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1751415385922,
+      "tag": "0010_brief_exodus",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -11,6 +11,7 @@ import m0006 from "./0006_wild_gabe_jones.sql";
 import m0007 from "./0007_cooing_the_stranger.sql";
 import m0008 from "./0008_little_toad.sql";
 import m0009 from "./0009_ambitious_puppet_master.sql";
+import m0010 from "./0010_brief_exodus.sql";
 
 export default {
   journal,
@@ -25,5 +26,6 @@ export default {
     m0007,
     m0008,
     m0009,
+    m0010,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -33,17 +33,21 @@ export const albums = sqliteTable(
     artistName: text("artist_name")
       .notNull()
       .references(() => artists.name),
-    /*
-      FIXME: This is technically `.notNull()`, but the migration will fail
-      for users who have "duplicate" album where `releaseYear = null`.
-    */
-    releaseYear: integer("release_year").default(-1),
     artwork: text().generatedAlwaysAs(
       (): SQL => sql`coalesce(${albums.altArtwork}, ${albums.embeddedArtwork})`,
     ),
     embeddedArtwork: text(),
     altArtwork: text(),
     isFavorite: integer({ mode: "boolean" }).notNull().default(false),
+
+    /*
+      FIXME: This is technically `.notNull()`, but the migration will fail
+      for users who have "duplicate" album where `releaseYear = null`.
+    */
+    /**
+     * @deprecated Remove along with its use in the Unique key in a future release.
+     */
+    releaseYear: integer("release_year").default(-1),
   },
   (t) => [unique().on(t.name, t.artistName, t.releaseYear)],
 );
@@ -64,6 +68,7 @@ export const tracks = sqliteTable("tracks", {
   // Album relations
   disc: integer(),
   track: integer(),
+  year: integer(),
   // Other metadata
   duration: integer().notNull(), // Track duration in seconds
   format: text(), // Currently the mimetype of the file

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -18,7 +18,7 @@ import type {
 
 import i18next from "~/modules/i18n";
 
-import { formatSeconds, isYearDefined } from "~/utils/number";
+import { formatSeconds } from "~/utils/number";
 import { omitKeys } from "~/utils/object";
 import type { AtLeast, Prettify } from "~/utils/types";
 import { ReservedNames, ReservedPlaylists } from "~/modules/media/constants";
@@ -52,6 +52,20 @@ export function mergeTracks<TData extends { id: string }>(
 ) {
   const trackIds = new Set(arr2.map(({ id }) => id));
   return arr1.filter(({ id }) => !trackIds.has(id)).concat(arr2);
+}
+
+/** Get the year range from the `year` field on tracks. */
+export function getYearRange<TData extends { year: number | null }>(
+  entries: TData[],
+) {
+  const years = entries
+    .filter(({ year }) => year !== null)
+    .map(({ year }) => year) as number[];
+  if (years.length === 0) return { minYear: null, maxYear: null, range: null };
+  const minYear = Math.min(...years);
+  const maxYear = Math.max(...years);
+  const range = minYear === maxYear ? `${maxYear}` : `${minYear} - ${maxYear}`;
+  return { minYear, maxYear, range };
 }
 //#endregion
 
@@ -134,8 +148,9 @@ export function formatForCurrentScreen({ type, data, t }: ScreenFormatter) {
       data.tracks.reduce((total, curr) => total + curr.duration, 0),
     ),
   ];
-  if (type === "album" && isYearDefined(data.releaseYear)) {
-    metadata.unshift(String(data.releaseYear));
+  if (type === "album") {
+    const { range } = getYearRange(data.tracks);
+    if (range !== null) metadata.unshift(range);
   }
 
   const albumInfo = type === "album" ? omitKeys(data, ["tracks"]) : null;

--- a/mobile/src/db/utils.ts
+++ b/mobile/src/db/utils.ts
@@ -61,7 +61,7 @@ export function getYearRange<TData extends { year: number | null }>(
   const years = entries
     .filter(({ year }) => year !== null)
     .map(({ year }) => year) as number[];
-  if (years.length === 0) return { minYear: null, maxYear: null, range: null };
+  if (years.length === 0) return { minYear: -1, maxYear: -1, range: null };
   const minYear = Math.min(...years);
   const maxYear = Math.max(...years);
   const range = minYear === maxYear ? `${maxYear}` : `${minYear} - ${maxYear}`;

--- a/mobile/src/modules/scanning/constants.ts
+++ b/mobile/src/modules/scanning/constants.ts
@@ -1,4 +1,7 @@
-export type MigrationOption = "kv-store" | "fileNodes-adjustment";
+export type MigrationOption =
+  | "kv-store"
+  | "fileNodes-adjustment"
+  | "duplicate-album-fix";
 
 /**
  * History of data migrations due to "breaking" changes.
@@ -16,4 +19,5 @@ export const MigrationHistory: Record<
   { version: string; changes: MigrationOption[] }
 > = {
   0: { version: "v2.3.0", changes: ["kv-store", "fileNodes-adjustment"] },
+  1: { version: "v2.4.0", changes: ["duplicate-album-fix"] },
 };

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -223,14 +223,12 @@ async function getTrackEntry({
       .map((name) => createArtist({ name: name!.trim() })),
   );
 
-  // Add new album to the database. The unique key on `Album` covers the rare
-  // case where an artist releases multiple albums with the same name.
+  // Add new album to the database.
   let albumId: string | null = null;
   if (!!t.albumTitle?.trim() && !!t.albumArtist?.trim()) {
     const newAlbum = await upsertAlbum({
       name: t.albumTitle.trim(),
       artistName: t.albumArtist.trim(),
-      releaseYear: t.year ?? -1,
     });
     if (newAlbum) albumId = newAlbum.id;
   }
@@ -242,6 +240,7 @@ async function getTrackEntry({
     albumId,
     track: t.trackNumber,
     disc: t.discNumber,
+    year: t.year,
     format: t.sampleMimeType,
     bitrate,
     sampleRate,

--- a/mobile/src/screens/ModifyTrack/context.tsx
+++ b/mobile/src/screens/ModifyTrack/context.tsx
@@ -109,7 +109,7 @@ export function TrackMetadataStoreProvider({
       artistName: initialData.artistName ?? "",
       album: initialData.album?.name ?? "",
       albumArtist: initialData.album?.artistName ?? "",
-      year: initialData.album?.releaseYear?.toString() ?? "",
+      year: initialData.year?.toString() ?? "",
       disc: initialData.disc?.toString() ?? "",
       track: initialData.track?.toString() ?? "",
     };
@@ -144,13 +144,13 @@ export function TrackMetadataStoreProvider({
               artistName: asNonEmptyString(artistName),
               track: asNaturalNumber(track),
               disc: asNaturalNumber(disc),
+              year: asNaturalNumber(year),
               embeddedArtwork: null as string | null,
               modificationTime: IGNORE_RECHECK,
             };
             const updatedAlbum = {
               name: asNonEmptyString(album),
               artistName: asNonEmptyString(albumArtist),
-              year: asNaturalNumber(year) ?? -1,
             };
 
             // Add new artists to the database.
@@ -162,14 +162,12 @@ export function TrackMetadataStoreProvider({
 
             const artworkUri = await getArtworkUri(uri);
 
-            // Add new album to the database. The unique key on `Album` covers the rare
-            // case where an artist releases multiple albums with the same name.
+            // Add new album to the database.
             let albumId: string | null = null;
             if (updatedAlbum.name && updatedAlbum.artistName) {
               const newAlbum = await upsertAlbum({
                 name: updatedAlbum.name,
                 artistName: updatedAlbum.artistName,
-                releaseYear: updatedAlbum.year,
                 embeddedArtwork: artworkUri,
               });
               if (newAlbum) albumId = newAlbum.id;

--- a/mobile/src/utils/number.ts
+++ b/mobile/src/utils/number.ts
@@ -68,8 +68,3 @@ function pushTimeSegment(
     arr.length === 0 ? `${length}` : `${length}`.padStart(2, `0`);
   arr.push(lengthStr + (suffix ?? ""));
 }
-
-/** Determines if a year is defined. */
-export function isYearDefined(year: number | null) {
-  return year !== null && year !== -1;
-}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This is a more "permanent" fix to the problem of duplicate albums caused by having different release years (see #220). This "deprecates" the use of `releaseYear` as part of what makes an `Album` entry unique.

- We have a new `year` field in the `Track` schema.
- Created a migration that copies over the `releaseYear` to the `year` field, then merges all the albums with the same name & artist.
  - We set `releaseYear = -1` as we can't necessarily remove this field yet (alongside the unique constraint as otherwise, the app would crash for users with duplicate albums).
- Fixed how we display the album release year on the album screen and in the list of albums in the artist screen.

> [!NOTE]
> We plan on deprecating the `releaseYear` Album field alongside its use as part of the unique constraint in a future release.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- [x] Have the year be inserted into the Track's `year` field instead of the Album's `releaseYear` field (onboarding & metadata editing).
- [x] Have the album display the year range it covers based on the `year` field on the Tracks.
- [x] Have an artist's albums be correctly sorted accounting for the "range" of years and album can have.
- [x] Have migration correctly merge duplicate albums with different years.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses duplicate album issues by deprecating the 'releaseYear' field and introducing a new 'year' field derived from track data. The changes include database schema updates, migration logic enhancements, and UI/API improvements to ensure albums are sorted and displayed correctly based on computed year ranges. These modifications improve data consistency across the application.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 4
-->
</div>