### PR TITLE
refactor: Make saving embedded artwork more reusable

### DIFF
--- a/mobile/src/modules/media/helpers/revalidate.ts
+++ b/mobile/src/modules/media/helpers/revalidate.ts
@@ -16,12 +16,12 @@ export async function revalidateActiveTrack(args: {
   if (args.type === "track" && activeTrack.id !== args.id) return;
 
   try {
-    const rntpTrack = await TrackPlayer.getActiveTrack();
-    if (!rntpTrack) return;
-
     const updatedTrackData = await getTrack(activeTrack.id);
     musicStore.setState({ activeTrack: updatedTrackData });
+
     // Update media notification with updated metadata.
+    const rntpTrack = await TrackPlayer.getActiveTrack();
+    if (!rntpTrack) return;
     await TrackPlayer.updateMetadataForTrack(0, {
       ...formatTrackforPlayer(updatedTrackData),
       // @ts-expect-error - Should allow for custom properties.

--- a/mobile/src/screens/ModifyTrack/context.tsx
+++ b/mobile/src/screens/ModifyTrack/context.tsx
@@ -1,5 +1,4 @@
 import { toast } from "@backpackapp-io/react-native-toast";
-import { getArtwork } from "@missingcore/react-native-metadata-retriever";
 import { router } from "expo-router";
 import { createContext, use, useRef } from "react";
 import type { StoreApi } from "zustand";
@@ -13,13 +12,15 @@ import { upsertAlbum } from "~/api/album";
 import { createArtist } from "~/api/artist";
 import { updateTrack } from "~/api/track";
 import { revalidateActiveTrack } from "~/modules/media/helpers/revalidate";
-import { cleanupImages } from "~/modules/scanning/helpers/artwork";
+import {
+  cleanupImages,
+  getArtworkUri,
+} from "~/modules/scanning/helpers/artwork";
 import {
   IGNORE_RECHECK,
   removeUnusedCategories,
 } from "~/modules/scanning/helpers/audio";
 
-import { saveImage } from "~/lib/file-system";
 import { ToastOptions } from "~/lib/toast";
 import { clearAllQueries } from "~/lib/react-query";
 import { wait } from "~/utils/promise";
@@ -160,7 +161,7 @@ export function TrackMetadataStoreProvider({
                 .map((name) => createArtist({ name })),
             );
 
-            const artworkUri = await getArtworkUri(uri);
+            const { uri: artworkUri } = await getArtworkUri(uri);
 
             // Add new album to the database.
             let albumId: string | null = null;
@@ -221,16 +222,5 @@ function asNaturalNumber(numStr: string) {
 /** Returns `null` if empty string. */
 function asNonEmptyString(str: string) {
   return str.trim() || null;
-}
-
-/** Save the artwork embedded on the track and return the uri to it. */
-async function getArtworkUri(uri: string) {
-  try {
-    const base64Artwork = await getArtwork(uri);
-    if (!base64Artwork) return null;
-    return await saveImage(base64Artwork);
-  } catch {
-    return null;
-  }
 }
 //#endregion


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

- Create reusable function for saving the embedded track artwork, which can be used during the onboarding process and when we're editing track metadata.
- Fix issue where we edit the track metadata before the RNTP service has been "activated" due to `TrackPlayer.getActiveTrack()` throwing an error. This would result in `activeTrack` not getting updated as.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR refactors artwork processing and track metadata updating to improve reliability and reusability. It adds validation for active tracks before metadata updates and creates a dedicated function for artwork handling. These changes enhance error handling and improve code maintainability across modules.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>