### PR TITLE
feat: Hiding Tracks

### DIFF
--- a/mobile/src/api/playlist.ts
+++ b/mobile/src/api/playlist.ts
@@ -32,7 +32,12 @@ const _getPlaylist: QueryOneWithTracksFn<Playlist> =
           columns: {},
           with: {
             track: {
-              columns: { ...getColumns(options?.trackColumns), hiddenAt: true },
+              // Note: If columns are provided, ensure `hiddenAt` is included.
+              columns: getColumns(
+                options?.trackColumns
+                  ? [...options.trackColumns, "hiddenAt"]
+                  : undefined,
+              ),
               ...withAlbum({ defaultWithAlbum: true, ...options }),
             },
           },
@@ -41,7 +46,6 @@ const _getPlaylist: QueryOneWithTracksFn<Playlist> =
       },
     });
     if (!playlist) throw new Error(i18next.t("err.msg.noPlaylists"));
-    // @ts-expect-error - Data is compatible.
     return fixPlaylistJunction(playlist);
   };
 
@@ -63,7 +67,12 @@ const _getPlaylists: QueryManyWithTracksFn<Playlist> =
           columns: {},
           with: {
             track: {
-              columns: { ...getColumns(options?.trackColumns), hiddenAt: true },
+              // Note: If columns are provided, ensure `hiddenAt` is included.
+              columns: getColumns(
+                options?.trackColumns
+                  ? [...options.trackColumns, "hiddenAt"]
+                  : undefined,
+              ),
               ...withAlbum({ defaultWithAlbum: true, ...options }),
             },
           },
@@ -72,7 +81,6 @@ const _getPlaylists: QueryManyWithTracksFn<Playlist> =
       },
       orderBy: (fields) => iAsc(fields.name),
     });
-    // @ts-expect-error - Data is compatible.
     return allPlaylists.map((data) => fixPlaylistJunction(data));
   };
 

--- a/mobile/src/api/setting.ts
+++ b/mobile/src/api/setting.ts
@@ -16,6 +16,12 @@ export async function getDatabaseSummary() {
     images: imgDir.exists ? imgDir.list().length : 0,
     playlists: await db.$count(playlists),
     tracks: await db.$count(tracks),
+    hiddenTracks: (
+      await db.query.tracks.findMany({
+        where: (fields, { isNotNull }) => isNotNull(fields.hiddenAt),
+        columns: { id: true },
+      })
+    ).length,
     saveErrors: await db.$count(invalidTracks),
     totalDuration:
       Number(

--- a/mobile/src/api/track.ts
+++ b/mobile/src/api/track.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 
 import { db } from "~/db";
 import type { Album, Track } from "~/db/schema";
@@ -60,9 +60,13 @@ export async function getTracks<
   columns?: TCols[];
   albumColumns?: [ACols, ...ACols[]];
   withAlbum?: WithAlbum_User;
+  withHidden?: boolean;
 }) {
   const allTracks = await db.query.tracks.findMany({
-    where: and(...(options?.where ?? [])),
+    where: and(
+      ...(options?.where ??
+        (!options?.withHidden ? [isNull(tracks.hiddenAt)] : [])),
+    ),
     columns: getColumns(options?.columns),
     ...withAlbum({ defaultWithAlbum: true, ...options }),
     orderBy: (fields) => iAsc(fields.name),

--- a/mobile/src/api/utils.ts
+++ b/mobile/src/api/utils.ts
@@ -1,6 +1,8 @@
-import type { asc, desc, sql } from "drizzle-orm";
+import type { SQL, asc, desc, sql } from "drizzle-orm";
+import { isNull } from "drizzle-orm";
 
 import type { Track } from "~/db/schema";
+import { tracks } from "~/db/schema";
 
 /** Get columns we want to select in the database schema. */
 export function getColumns(keys?: string[]) {
@@ -34,12 +36,15 @@ export function withTracks(
   return (trackOptions.withTracks !== false
     ? {
         tracks: {
+          where: isNull(tracks.hiddenAt),
           columns: getColumns(trackOptions?.trackColumns),
           orderBy: trackOptions.orderBy,
           ...withAlbum(albumOptions),
         },
       }
-    : {}) as unknown as { tracks: { with: { album: true } } };
+    : {}) as unknown as {
+    tracks: { where: SQL<unknown>; with: { album: true } };
+  };
 }
 
 type WithAlbumOptions = {

--- a/mobile/src/app/(main)/(current)/album/[id].tsx
+++ b/mobile/src/app/(main)/(current)/album/[id].tsx
@@ -12,7 +12,10 @@ import { mutateGuard } from "~/lib/react-query";
 import { isNumber } from "~/utils/validation";
 import { FlashList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
-import { PagePlaceholder } from "~/components/Transition/Placeholder";
+import {
+  ContentPlaceholder,
+  PagePlaceholder,
+} from "~/components/Transition/Placeholder";
 import { Em, StyledText } from "~/components/Typography/StyledText";
 import { Track } from "~/modules/media/components/Track";
 
@@ -89,6 +92,13 @@ export default function CurrentAlbumScreen() {
                 className={index > 0 ? "mt-2" : undefined}
               />
             )
+          }
+          ListEmptyComponent={
+            <ContentPlaceholder
+              errMsg={t("feat.hiddenTracks.extra.hasHiddenTracks", {
+                name: t("term.album"),
+              })}
+            />
           }
           contentContainerClassName="px-4 pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -1,4 +1,5 @@
 import { useLocalSearchParams } from "expo-router";
+import { useTranslation } from "react-i18next";
 
 import type { Album } from "~/db/schema";
 
@@ -8,7 +9,10 @@ import { useGetColumn } from "~/hooks/useGetColumn";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
 import { FlashList } from "~/components/Defaults";
-import { PagePlaceholder } from "~/components/Transition/Placeholder";
+import {
+  ContentPlaceholder,
+  PagePlaceholder,
+} from "~/components/Transition/Placeholder";
 import { TEm } from "~/components/Typography/StyledText";
 import { MediaCard } from "~/modules/media/components/MediaCard";
 import { Track } from "~/modules/media/components/Track";
@@ -17,6 +21,7 @@ type ArtistAlbum = Omit<Album, "releaseYear"> & { releaseYear: string | null };
 
 /** Screen for `/artist/[id]` route. */
 export default function CurrentArtistScreen() {
+  const { t } = useTranslation();
   const { bottomInset } = useBottomActionsContext();
   const { id: artistName } = useLocalSearchParams<{ id: string }>();
   const { isPending, error, data } = useArtistForScreen(artistName);
@@ -45,6 +50,13 @@ export default function CurrentArtistScreen() {
           />
         )}
         ListHeaderComponent={<ArtistAlbums albums={data.albums} />}
+        ListEmptyComponent={
+          <ContentPlaceholder
+            errMsg={t("feat.hiddenTracks.extra.hasHiddenTracks", {
+              name: t("term.artist"),
+            })}
+          />
+        }
         contentContainerClassName="px-4 pt-4"
         contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}
       />

--- a/mobile/src/app/setting/_layout.tsx
+++ b/mobile/src/app/setting/_layout.tsx
@@ -25,6 +25,10 @@ export default function SettingsLayout() {
         options={{ title: t("feat.insights.title") }}
       />
       <Stack.Screen
+        name="insights/hidden"
+        options={{ title: t("feat.hiddenTracks.title") }}
+      />
+      <Stack.Screen
         name="insights/save-errors"
         options={{ title: t("feat.saveErrors.title") }}
       />

--- a/mobile/src/app/setting/insights/hidden.tsx
+++ b/mobile/src/app/setting/insights/hidden.tsx
@@ -5,7 +5,6 @@ import { useHiddenTracks } from "~/queries/setting";
 import { useHideTrack } from "~/queries/track";
 
 import { mutateGuard } from "~/lib/react-query";
-import { cn } from "~/lib/style";
 import { FlashList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { ContentPlaceholder } from "~/components/Transition/Placeholder";
@@ -41,13 +40,13 @@ export default function HiddenTracksScreen() {
               disabled={hideTrack.isPending}
             />
           }
-          className={cn("bg-canvas", { "mt-2": index > 0 })}
+          className={index > 0 ? "mt-2" : undefined}
         />
       )}
       ListEmptyComponent={
         <ContentPlaceholder
           isPending={isPending}
-          errMsgKey="err.msg.noContent"
+          errMsgKey="feat.hiddenTracks.extra.notFound"
         />
       }
       contentContainerClassName="p-4"

--- a/mobile/src/app/setting/insights/hidden.tsx
+++ b/mobile/src/app/setting/insights/hidden.tsx
@@ -22,6 +22,7 @@ export default function HiddenTracksScreen() {
       estimatedItemSize={56} // 48px Height + 8px Margin Top
       data={data}
       keyExtractor={({ id }) => id}
+      extraData={hideTrack.isPending}
       renderItem={({ item, index }) => (
         <SearchResult
           type="track"

--- a/mobile/src/app/setting/insights/hidden.tsx
+++ b/mobile/src/app/setting/insights/hidden.tsx
@@ -1,0 +1,4 @@
+/** Screen for `/setting/insights/hidden` route. */
+export default function HiddenTracksScreen() {
+  return null;
+}

--- a/mobile/src/app/setting/insights/hidden.tsx
+++ b/mobile/src/app/setting/insights/hidden.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import { VisibilityOff } from "~/icons/VisibilityOff";
 import { useHiddenTracks } from "~/queries/setting";
-import { useToggleHideTrack } from "~/queries/track";
+import { useHideTrack } from "~/queries/track";
 
 import { mutateGuard } from "~/lib/react-query";
 import { cn } from "~/lib/style";
@@ -15,7 +15,7 @@ import { SearchResult } from "~/modules/search/components/SearchResult";
 export default function HiddenTracksScreen() {
   const { t } = useTranslation();
   const { isPending, data } = useHiddenTracks();
-  const toggleHideTrack = useToggleHideTrack();
+  const hideTrack = useHideTrack();
 
   return (
     <FlashList
@@ -35,9 +35,9 @@ export default function HiddenTracksScreen() {
               Icon={VisibilityOff}
               accessibilityLabel={t("template.entryShow", { name: item.name })}
               onPress={() =>
-                mutateGuard(toggleHideTrack, { trackId: item.id, hide: false })
+                mutateGuard(hideTrack, { trackId: item.id, isHidden: false })
               }
-              disabled={toggleHideTrack.isPending}
+              disabled={hideTrack.isPending}
             />
           }
           className={cn("bg-canvas", { "mt-2": index > 0 })}

--- a/mobile/src/app/setting/insights/hidden.tsx
+++ b/mobile/src/app/setting/insights/hidden.tsx
@@ -1,4 +1,55 @@
+import { useTranslation } from "react-i18next";
+
+import { VisibilityOff } from "~/icons/VisibilityOff";
+import { useHiddenTracks } from "~/queries/setting";
+import { useToggleHideTrack } from "~/queries/track";
+
+import { mutateGuard } from "~/lib/react-query";
+import { cn } from "~/lib/style";
+import { FlashList } from "~/components/Defaults";
+import { IconButton } from "~/components/Form/Button";
+import { ContentPlaceholder } from "~/components/Transition/Placeholder";
+import { SearchResult } from "~/modules/search/components/SearchResult";
+
 /** Screen for `/setting/insights/hidden` route. */
 export default function HiddenTracksScreen() {
-  return null;
+  const { t } = useTranslation();
+  const { isPending, data } = useHiddenTracks();
+  const toggleHideTrack = useToggleHideTrack();
+
+  return (
+    <FlashList
+      estimatedItemSize={56} // 48px Height + 8px Margin Top
+      data={data}
+      keyExtractor={({ id }) => id}
+      renderItem={({ item, index }) => (
+        <SearchResult
+          type="track"
+          title={item.name}
+          description={t("feat.hiddenTracks.extra.hiddenAt", {
+            date: new Date(item.hiddenAt!).toDateString(),
+          })}
+          imageSource={item.artwork}
+          RightElement={
+            <IconButton
+              Icon={VisibilityOff}
+              accessibilityLabel={t("template.entryShow", { name: item.name })}
+              onPress={() =>
+                mutateGuard(toggleHideTrack, { trackId: item.id, hide: false })
+              }
+              disabled={toggleHideTrack.isPending}
+            />
+          }
+          className={cn("bg-canvas", { "mt-2": index > 0 })}
+        />
+      )}
+      ListEmptyComponent={
+        <ContentPlaceholder
+          isPending={isPending}
+          errMsgKey="err.msg.noContent"
+        />
+      }
+      contentContainerClassName="p-4"
+    />
+  );
 }

--- a/mobile/src/app/setting/insights/index.tsx
+++ b/mobile/src/app/setting/insights/index.tsx
@@ -54,7 +54,7 @@ function StorageWidget() {
   );
 
   return (
-    <Card className="gap-2 rounded-b-sm">
+    <Card className="gap-4 rounded-b-sm">
       <ProgressBar
         entries={[
           { color: Colors.red, value: data?.images ?? 0 },
@@ -64,7 +64,7 @@ function StorageWidget() {
         ]}
         total={data?.total ?? 0}
       />
-      <Legend className="py-2">
+      <Legend>
         <LegendItem
           nameKey="feat.insights.extra.images"
           value={getValue("images")}
@@ -108,8 +108,8 @@ function DBSummaryWidget() {
   );
 
   return (
-    <Card className="gap-2 rounded-t-sm">
-      <Legend className="pb-2">
+    <Card className="gap-4 rounded-t-sm">
+      <Legend>
         <LegendItem nameKey="term.albums" value={getValue("albums")} />
         <LegendItem nameKey="term.artists" value={getValue("artists")} />
         <LegendItem
@@ -118,6 +118,12 @@ function DBSummaryWidget() {
         />
         <LegendItem nameKey="term.playlists" value={getValue("playlists")} />
         <LegendItem nameKey="term.tracks" value={getValue("tracks")} />
+      </Legend>
+      <Legend>
+        <LegendItem
+          nameKey="feat.hiddenTracks.title"
+          value={getValue("hiddenTracks")}
+        />
         <LegendItem
           nameKey="feat.saveErrors.title"
           value={getValue("saveErrors")}

--- a/mobile/src/app/setting/insights/index.tsx
+++ b/mobile/src/app/setting/insights/index.tsx
@@ -24,13 +24,20 @@ export default function InsightsScreen() {
         <DBSummaryWidget />
       </List>
 
-      <ListItem
-        titleKey="feat.saveErrors.title"
-        description={t("feat.saveErrors.brief")}
-        onPress={() => router.navigate("/setting/insights/save-errors")}
-        first
-        last
-      />
+      <List>
+        <ListItem
+          titleKey="feat.hiddenTracks.title"
+          description={t("feat.hiddenTracks.brief")}
+          onPress={() => router.navigate("/setting/insights/hidden")}
+          first
+        />
+        <ListItem
+          titleKey="feat.saveErrors.title"
+          description={t("feat.saveErrors.brief")}
+          onPress={() => router.navigate("/setting/insights/save-errors")}
+          last
+        />
+      </List>
     </StandardScrollLayout>
   );
 }

--- a/mobile/src/components/Transition/Placeholder.tsx
+++ b/mobile/src/components/Transition/Placeholder.tsx
@@ -3,19 +3,28 @@ import { View } from "react-native";
 
 import { cn } from "~/lib/style";
 import { Loading } from "./Loading";
-import { TStyledText } from "../Typography/StyledText";
+import { StyledText, TStyledText } from "../Typography/StyledText";
 
-/** Placeholder to render inside a list. */
-export function ContentPlaceholder(props: {
-  isPending?: boolean;
+type ErrorMsgProps = {
   /** Key to error messaeg in translations. */
   errMsgKey?: ParseKeys;
-  className?: string;
-}) {
+  /** Displays this over the string specified by `errMsgKey`. */
+  errMsg?: string;
+};
+
+/** Placeholder to render inside a list. */
+export function ContentPlaceholder(
+  props: ErrorMsgProps & {
+    isPending?: boolean;
+    className?: string;
+  },
+) {
   return (
     <View className={cn("p-4", props.className)}>
       {props.isPending ? (
         <Loading />
+      ) : props.errMsg ? (
+        <StyledText center>{props.errMsg}</StyledText>
       ) : (
         <TStyledText textKey={props.errMsgKey ?? "err.msg.noContent"} center />
       )}
@@ -24,11 +33,7 @@ export function ContentPlaceholder(props: {
 }
 
 /** Placeholder to render while waiting for data from React Query. */
-export function PagePlaceholder(props: {
-  isPending: boolean;
-  /** Key to error messaeg in translations. */
-  errMsgKey?: ParseKeys;
-}) {
+export function PagePlaceholder(props: ErrorMsgProps & { isPending: boolean }) {
   return (
     <View className="w-full flex-1 p-4">
       <ContentPlaceholder {...props} />

--- a/mobile/src/db/drizzle/0010_fresh_risque.sql
+++ b/mobile/src/db/drizzle/0010_fresh_risque.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tracks` ADD `hidden_at` integer;

--- a/mobile/src/db/drizzle/meta/0010_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,528 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "96bc34ee-a6df-443f-82aa-9fff1e1f61ef",
+  "prevId": "9cd3b104-a2c9-486d-aa17-4330bebfd4e4",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(coalesce(\"alt_artwork\", \"embedded_artwork\"))",
+            "type": "virtual"
+          }
+        },
+        "embedded_artwork": {
+          "name": "embedded_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {
+        "albums_name_artist_name_release_year_unique": {
+          "name": "albums_name_artist_name_release_year_unique",
+          "columns": [
+            "name",
+            "artist_name",
+            "release_year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "albums_artist_name_artists_name_fk": {
+          "name": "albums_artist_name_artists_name_fk",
+          "tableFrom": "albums",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(coalesce(\"alt_artwork\", \"embedded_artwork\"))",
+            "type": "virtual"
+          }
+        },
+        "embedded_artwork": {
+          "name": "embedded_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "edited_metadata": {
+          "name": "edited_metadata",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_folder": {
+          "name": "parent_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(rtrim(\"uri\", replace(\"uri\", '/', '')))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_artist_name_artists_name_fk": {
+          "name": "tracks_artist_name_artists_name_fk",
+          "tableFrom": "tracks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1751075864737,
       "tag": "0009_ambitious_puppet_master",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1752446464645,
+      "tag": "0010_fresh_risque",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -11,6 +11,7 @@ import m0006 from "./0006_wild_gabe_jones.sql";
 import m0007 from "./0007_cooing_the_stranger.sql";
 import m0008 from "./0008_little_toad.sql";
 import m0009 from "./0009_ambitious_puppet_master.sql";
+import m0010 from "./0010_fresh_risque.sql";
 
 export default {
   journal,
@@ -25,5 +26,6 @@ export default {
     m0007,
     m0008,
     m0009,
+    m0010,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -86,8 +86,10 @@ export const tracks = sqliteTable("tracks", {
   // Data checking fields.
   isFavorite: integer({ mode: "boolean" }).notNull().default(false),
   fetchedArt: integer({ mode: "boolean" }).notNull().default(false),
-  // Use Epoch time instead of boolean to track when we edited the metadata.
+  // Use Epoch time instead of boolean to track when we did the action.
   editedMetadata: integer(),
+  hiddenAt: integer(),
+
   parentFolder: text().generatedAlwaysAs(
     // Ref: https://stackoverflow.com/a/38330814
     (): SQL => sql`rtrim(${tracks.uri}, replace(${tracks.uri}, '/', ''))`,

--- a/mobile/src/lib/react-query.ts
+++ b/mobile/src/lib/react-query.ts
@@ -1,9 +1,10 @@
+import { useIsFocused } from "@react-navigation/native";
 import type {
   DefaultOptions,
   UseMutationResult,
   UseQueryResult,
 } from "@tanstack/react-query";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, useQuery } from "@tanstack/react-query";
 
 import { queries as q } from "~/queries/keyStore";
 
@@ -58,3 +59,10 @@ export function clearAllQueries(client: QueryClient = queryClient) {
 export type ExtractQueryData<T extends () => UseQueryResult<any>> = NonNullable<
   ReturnType<T>["data"]
 >;
+
+/** `useQuery`, but it only refetches when the screen is in focus. */
+// @ts-expect-error - Type conflict.
+export const useFocusedQuery: typeof useQuery = (options) => {
+  const isFocused = useIsFocused();
+  return useQuery({ subscribed: isFocused, ...options });
+};

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -191,7 +191,8 @@
       "brief": "Tracks not shown in the app.",
       "extra": {
         "hiddenAt": "Hidden on {{- date}}.",
-        "hasHiddenTracks": "{{- name}} has hidden tracks."
+        "hasHiddenTracks": "{{- name}} has hidden tracks.",
+        "notFound": "No hidden tracks found."
       }
     },
     "saveErrors": {

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -190,7 +190,8 @@
       "title": "Hidden Tracks",
       "brief": "Tracks not shown in the app.",
       "extra": {
-        "hiddenAt": "Hidden on {{- date}}."
+        "hiddenAt": "Hidden on {{- date}}.",
+        "hasHiddenTracks": "{{- name}} has hidden tracks."
       }
     },
     "saveErrors": {

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -190,7 +190,7 @@
       "title": "Hidden Tracks",
       "brief": "Tracks not shown in the app.",
       "extra": {
-        "hiddenAt": "Hidden at {{date}}."
+        "hiddenAt": "Hidden on {{- date}}."
       }
     },
     "saveErrors": {
@@ -259,7 +259,7 @@
       "description": "Stop playing audio after the specified amount of minutes.",
       "extra": {
         "start": "Start",
-        "stopTime": "Audio will stop playing at {{time}}."
+        "stopTime": "Audio will stop playing at {{- time}}."
       }
     },
     "translate": {

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -186,6 +186,13 @@
         "totalDuration": "Total Duration"
       }
     },
+    "hiddenTracks": {
+      "title": "Hidden Tracks",
+      "brief": "Tracks not shown in the app.",
+      "extra": {
+        "hiddenAt": "Hidden at {{date}}."
+      }
+    },
     "saveErrors": {
       "title": "Save Errors",
       "brief": "See the reason why some tracks weren't saved."

--- a/mobile/src/modules/media/services/Music.ts
+++ b/mobile/src/modules/media/services/Music.ts
@@ -271,9 +271,10 @@ export class Queue {
   /** Remove list of track ids in the current queue. */
   static async removeIds(ids: string[]) {
     const idSet = new Set(ids);
-    musicStore.setState((prev) => ({
-      queueList: prev.queueList.filter((tId) => !idSet.has(tId)),
-    }));
+    const prevQueueList = musicStore.getState().queueList;
+    const updatedQueueList = prevQueueList.filter((tId) => !idSet.has(tId));
+    if (prevQueueList.length === updatedQueueList.length) return;
+    musicStore.setState({ queueList: updatedQueueList });
     await RNTPManager.reloadNextTrack();
   }
 }

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -39,6 +39,7 @@ export async function findAndSaveArtwork() {
     columns: ["id", "name", "albumId", "uri"],
     withAlbum: false,
     where: [eq(tracks.fetchedArt, false)],
+    withHidden: true,
   });
   // Sort tracks to optimize SQL queries.
   const singles: PartialTrack[] = [];

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -33,7 +33,11 @@ export async function rescanForTracks(deepScan = false) {
     // Re-create the "folder" structure for tracks we've already saved.
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(fileNodes);
-    const allTracks = await getTracks({ columns: ["uri"], withAlbum: false });
+    const allTracks = await getTracks({
+      columns: ["uri"],
+      withAlbum: false,
+      withHidden: true,
+    });
     await batch({
       data: allTracks,
       callback: ({ uri }) => savePathComponents(uri),

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -51,7 +51,13 @@ export async function rescanForTracks(deepScan = false) {
     await db
       .update(tracks)
       .set({ fetchedArt: false })
-      .where(and(eq(tracks.fetchedArt, true), isNull(tracks.artwork)));
+      .where(
+        and(
+          eq(tracks.fetchedArt, true),
+          isNull(tracks.artwork),
+          isNull(tracks.hiddenAt),
+        ),
+      );
 
     // Update all tracks whose metadata hasn't been manually changed by
     // the user, even if its `modificationTime` hasn't changed.
@@ -62,7 +68,7 @@ export async function rescanForTracks(deepScan = false) {
       await db
         .update(tracks)
         .set({ modificationTime: -1 })
-        .where(isNull(tracks.editedMetadata));
+        .where(and(isNull(tracks.editedMetadata), isNull(tracks.hiddenAt)));
     }
 
     // Rescan library for any new tracks and delete any old ones.

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -6,7 +6,6 @@ import { db } from "~/db";
 import { fileNodes, invalidTracks, tracks } from "~/db/schema";
 
 import i18next from "~/modules/i18n";
-import { getTracks } from "~/api/track";
 import { RecentList } from "~/modules/media/services/RecentList";
 import { Resynchronize } from "~/modules/media/services/Resynchronize";
 
@@ -33,10 +32,8 @@ export async function rescanForTracks(deepScan = false) {
     // Re-create the "folder" structure for tracks we've already saved.
     // eslint-disable-next-line drizzle/enforce-delete-with-where
     await db.delete(fileNodes);
-    const allTracks = await getTracks({
-      columns: ["uri"],
-      withAlbum: false,
-      withHidden: true,
+    const allTracks = await db.query.tracks.findMany({
+      columns: { uri: true },
     });
     await batch({
       data: allTracks,
@@ -51,13 +48,7 @@ export async function rescanForTracks(deepScan = false) {
     await db
       .update(tracks)
       .set({ fetchedArt: false })
-      .where(
-        and(
-          eq(tracks.fetchedArt, true),
-          isNull(tracks.artwork),
-          isNull(tracks.hiddenAt),
-        ),
-      );
+      .where(and(eq(tracks.fetchedArt, true), isNull(tracks.artwork)));
 
     // Update all tracks whose metadata hasn't been manually changed by
     // the user, even if its `modificationTime` hasn't changed.
@@ -68,7 +59,7 @@ export async function rescanForTracks(deepScan = false) {
       await db
         .update(tracks)
         .set({ modificationTime: -1 })
-        .where(and(isNull(tracks.editedMetadata), isNull(tracks.hiddenAt)));
+        .where(isNull(tracks.editedMetadata));
     }
 
     // Rescan library for any new tracks and delete any old ones.

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -78,18 +78,26 @@ async function getAllMedia() {
   });
 
   return {
-    album: await getAlbums({
-      columns: ["id", "name", "artistName", "artwork"],
-      trackColumns: ["id", "name", "artistName", "artwork"],
-    }),
-    artist: await getArtists({
-      columns: ["name", "artwork"],
-      withTracks: false,
-    }),
-    folder: (allFolders as SlimFolder[]).map((f) => {
-      f.tracks = groupedTracks[`file:///${addTrailingSlash(f.path)}`] ?? [];
-      return f;
-    }),
+    album: (
+      await getAlbums({
+        columns: ["id", "name", "artistName", "artwork"],
+        trackColumns: ["id", "name", "artistName", "artwork"],
+      })
+    ).filter(({ tracks }) => tracks.length > 0),
+    artist: (
+      await getArtists({
+        columns: ["name", "artwork"],
+        trackColumns: ["id"],
+      })
+    )
+      .filter(({ tracks }) => tracks.length > 0)
+      .map(({ tracks: _, ...rest }) => rest),
+    folder: (allFolders as SlimFolder[])
+      .map((f) => {
+        f.tracks = groupedTracks[`file:///${addTrailingSlash(f.path)}`] ?? [];
+        return f;
+      })
+      .filter(({ tracks }) => tracks.length > 0),
     playlist: await getPlaylists({
       columns: ["name", "artwork"],
       trackColumns: ["artwork"],

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import { db } from "~/db";
@@ -9,6 +8,7 @@ import { getArtists } from "~/api/artist";
 import { getPlaylists } from "~/api/playlist";
 import { getTracks } from "~/api/track";
 
+import { useFocusedQuery } from "~/lib/react-query";
 import { addTrailingSlash } from "~/utils/string";
 import type { Prettify } from "~/utils/types";
 import type { SearchCategories, SearchResults } from "../types";
@@ -108,6 +108,6 @@ function useAllMedia() {
   // query. For other places (ie: modifying playlists), we can manually add
   // that in.
   //  - FIXME: If we add the "Hide Track" feature, things might need to change.
-  return useQuery({ queryKey, queryFn: getAllMedia });
+  return useFocusedQuery({ queryKey, queryFn: getAllMedia });
 }
 //#endregion

--- a/mobile/src/queries/artist.ts
+++ b/mobile/src/queries/artist.ts
@@ -8,6 +8,8 @@ import { updateArtist } from "~/api/artist";
 import { Resynchronize } from "~/modules/media/services/Resynchronize";
 import { queries as q } from "./keyStore";
 
+import { useFocusedQuery } from "~/lib/react-query";
+
 //#region Queries
 /** Get specified artist. */
 export function useArtist(artistName: string) {
@@ -17,7 +19,7 @@ export function useArtist(artistName: string) {
 /** Format artist information for artist's `(current)` screen. */
 export function useArtistForScreen(artistName: string) {
   const { t } = useTranslation();
-  return useQuery({
+  return useFocusedQuery({
     ...q.artists.detail(artistName),
     select: ({ albums, ...artist }) => ({
       ...formatForCurrentScreen({ type: "artist", data: artist, t }),

--- a/mobile/src/queries/folder.ts
+++ b/mobile/src/queries/folder.ts
@@ -1,13 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
-
 import { formatForTrack } from "~/db/utils";
 
 import { queries as q } from "./keyStore";
 
+import { useFocusedQuery } from "~/lib/react-query";
+
 //#region Queries
 /** Return the subdirectories and tracks in this current directory. */
 export function useFolderContent(folderPath?: string) {
-  return useQuery({
+  return useFocusedQuery({
     ...q.folders.detail(folderPath),
     select: ({ subDirectories, tracks }) => ({
       subDirectories,

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -23,15 +23,11 @@ export const queries = createQueryKeyStore({
   albums: {
     all: {
       queryKey: null,
-      queryFn: async () => {
-        const allAlbums = await getAlbums({
+      queryFn: () =>
+        getAlbums({
           columns: ["id", "name", "artistName", "artwork"],
-          trackColumns: ["id"],
-        });
-        return allAlbums
-          .filter(({ tracks }) => tracks.length > 0)
-          .map(({ tracks: _, ...rest }) => rest);
-      },
+          withTracks: false,
+        }),
     },
     detail: (albumId: string) => ({
       queryKey: [albumId],
@@ -42,15 +38,11 @@ export const queries = createQueryKeyStore({
   artists: {
     all: {
       queryKey: null,
-      queryFn: async () => {
-        const allArtists = await getArtists({
+      queryFn: () =>
+        getArtists({
           columns: ["name", "artwork"],
-          trackColumns: ["id"],
-        });
-        return allArtists
-          .filter(({ tracks }) => tracks.length > 0)
-          .map(({ tracks: _, ...rest }) => rest);
-      },
+          withTracks: false,
+        }),
     },
     detail: (artistName: string) => ({
       queryKey: [artistName],
@@ -166,7 +158,7 @@ async function getFavoriteLists() {
     getAlbums({
       where: [eq(albums.isFavorite, true)],
       columns: ["id", "name", "artistName", "artwork"],
-      trackColumns: ["id"],
+      withTracks: false,
     }),
     getPlaylists({
       where: [eq(playlists.isFavorite, true)],
@@ -175,10 +167,5 @@ async function getFavoriteLists() {
       albumColumns: ["artwork"],
     }),
   ]);
-  return {
-    albums: favAlbums
-      .filter(({ tracks }) => tracks.length > 0)
-      .map(({ tracks: _, ...rest }) => rest),
-    playlists: favPlaylists,
-  };
+  return { albums: favAlbums, playlists: favPlaylists };
 }

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -1,7 +1,7 @@
 import { createQueryKeyStore } from "@lukemorales/query-key-factory";
-import { eq } from "drizzle-orm";
+import { eq, isNotNull } from "drizzle-orm";
 
-import { albums, playlists } from "~/db/schema";
+import { albums, playlists, tracks } from "~/db/schema";
 
 import { getAlbum, getAlbums } from "~/api/album";
 import { getArtist, getArtistAlbums, getArtists } from "~/api/artist";
@@ -121,6 +121,15 @@ export const queries = createQueryKeyStore({
     releaseNote: {
       queryKey: null,
       queryFn: () => getLatestRelease(),
+    },
+    hiddenTracks: {
+      queryKey: null,
+      queryFn: () =>
+        getTracks({
+          where: [isNotNull(tracks.hiddenAt)],
+          columns: ["id", "name", "artwork", "hiddenAt"],
+          albumColumns: ["artwork"],
+        }),
     },
     saveErrors: {
       queryKey: null,

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -23,11 +23,15 @@ export const queries = createQueryKeyStore({
   albums: {
     all: {
       queryKey: null,
-      queryFn: () =>
-        getAlbums({
+      queryFn: async () => {
+        const allAlbums = await getAlbums({
           columns: ["id", "name", "artistName", "artwork"],
-          withTracks: false,
-        }),
+          trackColumns: ["id"],
+        });
+        return allAlbums
+          .filter(({ tracks }) => tracks.length > 0)
+          .map(({ tracks: _, ...rest }) => rest);
+      },
     },
     detail: (albumId: string) => ({
       queryKey: [albumId],
@@ -158,7 +162,7 @@ async function getFavoriteLists() {
     getAlbums({
       where: [eq(albums.isFavorite, true)],
       columns: ["id", "name", "artistName", "artwork"],
-      withTracks: false,
+      trackColumns: ["id"],
     }),
     getPlaylists({
       where: [eq(playlists.isFavorite, true)],
@@ -167,5 +171,10 @@ async function getFavoriteLists() {
       albumColumns: ["artwork"],
     }),
   ]);
-  return { albums: favAlbums, playlists: favPlaylists };
+  return {
+    albums: favAlbums
+      .filter(({ tracks }) => tracks.length > 0)
+      .map(({ tracks: _, ...rest }) => rest),
+    playlists: favPlaylists,
+  };
 }

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -129,6 +129,7 @@ export const queries = createQueryKeyStore({
           where: [isNotNull(tracks.hiddenAt)],
           columns: ["id", "name", "artwork", "hiddenAt"],
           albumColumns: ["artwork"],
+          withHidden: true,
         }),
     },
     saveErrors: {

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -42,11 +42,15 @@ export const queries = createQueryKeyStore({
   artists: {
     all: {
       queryKey: null,
-      queryFn: () =>
-        getArtists({
+      queryFn: async () => {
+        const allArtists = await getArtists({
           columns: ["name", "artwork"],
-          withTracks: false,
-        }),
+          trackColumns: ["id"],
+        });
+        return allArtists
+          .filter(({ tracks }) => tracks.length > 0)
+          .map(({ tracks: _, ...rest }) => rest);
+      },
     },
     detail: (artistName: string) => ({
       queryKey: [artistName],

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -19,6 +19,7 @@ import {
 import { Resynchronize } from "~/modules/media/services/Resynchronize";
 import { queries as q } from "./keyStore";
 
+import { useFocusedQuery } from "~/lib/react-query";
 import { wait } from "~/utils/promise";
 
 //#region Queries
@@ -33,7 +34,7 @@ export function usePlaylist(playlistName: string) {
 /** Format playlist information for playlist's `(current)` screen. */
 export function usePlaylistForScreen(playlistName: string) {
   const { t } = useTranslation();
-  return useQuery({
+  return useFocusedQuery({
     ...q.playlists.detail(playlistName),
     select: (data) => ({
       ...formatForCurrentScreen({ type: "playlist", data, t }),

--- a/mobile/src/queries/setting.ts
+++ b/mobile/src/queries/setting.ts
@@ -17,6 +17,25 @@ export function useLatestRelease() {
   });
 }
 
+/** Return tracks that we've hidden. */
+export function useHiddenTracks() {
+  return useQuery({
+    ...q.settings.hiddenTracks,
+    select: (data) => {
+      // FIXME: Once Hermes supports `toSorted`, use it instead.
+      data.sort((a, b) => {
+        // Both `hiddenAt` should technically be not `null`.
+        if (a.hiddenAt === b.hiddenAt) return 0;
+        if (a.hiddenAt === null) return 1;
+        if (b.hiddenAt === null) return -1;
+        return b.hiddenAt - a.hiddenAt;
+      });
+      return data;
+    },
+    staleTime: 0,
+  });
+}
+
 /** Return the tracks that resulted in an error while saving. */
 export function useSaveErrors() {
   return useQuery({ ...q.settings.saveErrors, staleTime: 0 });

--- a/mobile/src/queries/setting.ts
+++ b/mobile/src/queries/setting.ts
@@ -23,13 +23,8 @@ export function useHiddenTracks() {
     ...q.settings.hiddenTracks,
     select: (data) => {
       // FIXME: Once Hermes supports `toSorted`, use it instead.
-      data.sort((a, b) => {
-        // Both `hiddenAt` should technically be not `null`.
-        if (a.hiddenAt === b.hiddenAt) return 0;
-        if (a.hiddenAt === null) return 1;
-        if (b.hiddenAt === null) return -1;
-        return b.hiddenAt - a.hiddenAt;
-      });
+      // Both `hiddenAt` should technically be not `null`.
+      data.sort((a, b) => b.hiddenAt! - a.hiddenAt!);
       return data;
     },
     staleTime: 0,

--- a/mobile/src/queries/track.ts
+++ b/mobile/src/queries/track.ts
@@ -86,20 +86,21 @@ export function useFavoriteTrack(trackId: string) {
 /** Set the hidden status of a track. */
 export function useHideTrack() {
   return useMutation({
-    mutationFn: (args: { trackId: string; isHidden: boolean }) =>
-      updateTrack(args.trackId, {
+    mutationFn: async (args: { trackId: string; isHidden: boolean }) => {
+      await wait(1);
+      await updateTrack(args.trackId, {
         hiddenAt: args.isHidden ? Date.now() : null,
-      }),
+      });
+    },
     onSuccess: async (_, { trackId }) => {
       // There's a lot of places where this track may appear.
       clearAllQueries();
-
       const { currentList, playingSource } = musicStore.getState();
       // Need to resynchronize the Music store if we're playing this track.
       if (currentList.includes(trackId)) {
         await Resynchronize.onTracks(playingSource!);
       }
-      await Queue.removeIds([trackId]);
+      Queue.removeIds([trackId]);
       RecentList.refresh();
     },
   });

--- a/mobile/src/queries/track.ts
+++ b/mobile/src/queries/track.ts
@@ -15,7 +15,7 @@ import { Resynchronize } from "~/modules/media/services/Resynchronize";
 import { useSortTracks } from "~/modules/media/services/SortPreferences";
 import { queries as q } from "./keyStore";
 
-import { clearAllQueries } from "~/lib/react-query";
+import { clearAllQueries, useFocusedQuery } from "~/lib/react-query";
 import { wait } from "~/utils/promise";
 import { ReservedPlaylists } from "~/modules/media/constants";
 
@@ -33,7 +33,7 @@ export function useTrackPlaylists(trackId: string) {
 /** Return list of `Track.Content` from tracks. */
 export function useTracksForTrackCard() {
   const sortTracksFn = useSortTracks();
-  return useQuery({
+  return useFocusedQuery({
     ...q.tracks.all,
     select: (data) =>
       sortTracksFn(data).map((track) => formatForTrack("track", track)),

--- a/mobile/src/screens/NowPlaying/helpers/UpcomingStore.ts
+++ b/mobile/src/screens/NowPlaying/helpers/UpcomingStore.ts
@@ -79,6 +79,7 @@ async function getTracksFromIds(trackIds: string[]) {
     where: [inArray(tracks.id, trackIds)],
     columns: ["id", "name", "artistName", "artwork"],
     albumColumns: ["artwork"],
+    withHidden: true,
   });
   return trackIds.map((tId) => unorderedTracks.find(({ id }) => id === tId));
 }

--- a/mobile/src/screens/Sheets/Settings/helpers/BackupData.ts
+++ b/mobile/src/screens/Sheets/Settings/helpers/BackupData.ts
@@ -72,7 +72,7 @@ async function findExistingAlbumsFactory() {
 
 /** Creates a factory function that finds tracks associated to `RawTrack`. */
 async function findExistingTracksFactory() {
-  const allTracks = await getTracks();
+  const allTracks = await getTracks({ withHidden: true });
   return (entries: Array<z.infer<typeof RawTrack>>) => {
     return entries
       .map((entry) =>

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -16,11 +16,14 @@ import { List } from "~/icons/List";
 import { PlaylistAdd } from "~/icons/PlaylistAdd";
 import { QueueMusic } from "~/icons/QueueMusic";
 import { Schedule } from "~/icons/Schedule";
+import { Visibility } from "~/icons/Visibility";
+import { VisibilityOff } from "~/icons/VisibilityOff";
 import { usePlaylists } from "~/queries/playlist";
 import {
   useAddToPlaylist,
   useFavoriteTrack,
   useRemoveFromPlaylist,
+  useToggleHideTrack,
   useTrack,
   useTrackPlaylists,
 } from "~/queries/track";
@@ -180,6 +183,7 @@ function TrackIconActions(props: { id: string; editArtwork: VoidFunction }) {
   const { t } = useTranslation();
   const { data } = useTrack(props.id);
   const favoriteTrack = useFavoriteTrack(props.id);
+  const toggleHideTrack = useToggleHideTrack();
 
   const favStatus = data?.isFavorite ?? false;
   const isFav = favoriteTrack.isPending ? !favStatus : favStatus;
@@ -203,6 +207,19 @@ function TrackIconActions(props: { id: string; editArtwork: VoidFunction }) {
         Icon={Image}
         accessibilityLabel={t("feat.artwork.extra.change")}
         onPress={sheetAction(props.editArtwork)}
+      />
+      <IconButton
+        Icon={data?.hiddenAt ? VisibilityOff : Visibility}
+        accessibilityLabel={t(
+          `template.entry${data?.hiddenAt ? "Show" : "Hide"}`,
+          { name: data?.name },
+        )}
+        onPress={sheetAction(() =>
+          mutateGuard(toggleHideTrack, {
+            trackId: props.id,
+            hide: !data?.hiddenAt,
+          }),
+        )}
       />
     </Card>
   );

--- a/mobile/src/screens/Sheets/Track.tsx
+++ b/mobile/src/screens/Sheets/Track.tsx
@@ -23,7 +23,7 @@ import {
   useAddToPlaylist,
   useFavoriteTrack,
   useRemoveFromPlaylist,
-  useToggleHideTrack,
+  useHideTrack,
   useTrack,
   useTrackPlaylists,
 } from "~/queries/track";
@@ -183,7 +183,7 @@ function TrackIconActions(props: { id: string; editArtwork: VoidFunction }) {
   const { t } = useTranslation();
   const { data } = useTrack(props.id);
   const favoriteTrack = useFavoriteTrack(props.id);
-  const toggleHideTrack = useToggleHideTrack();
+  const hideTrack = useHideTrack();
 
   const favStatus = data?.isFavorite ?? false;
   const isFav = favoriteTrack.isPending ? !favStatus : favStatus;
@@ -215,9 +215,9 @@ function TrackIconActions(props: { id: string; editArtwork: VoidFunction }) {
           { name: data?.name },
         )}
         onPress={sheetAction(() =>
-          mutateGuard(toggleHideTrack, {
+          mutateGuard(hideTrack, {
             trackId: props.id,
-            hide: !data?.hiddenAt,
+            isHidden: !data?.hiddenAt,
           }),
         )}
       />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds the ability for users to hide tracks via the Track sheet. To unhide a track, go to the new "Hidden Tracks" page access through the "Insights" settings page. This slots in the place for a "deleting tracks" feature since we don't want to directly modify tracks with this app.

There's some caveats with the design decisions we made:
- If we hide the current playing track, the current playing track will then be treated as part of the "queue".
- When we unhide a track in the current playing list, it won't get automatically added. This is due to being unable to validate whether that unhidden track belongs to the current playing list without always having to check the current playing list when we unhide a track, which can be "expensive".
- Albums & artists with only hidden tracks will still show up in the "Albums" & "Artists" screen. Going to those screens will display the normal screen, except that there'll be a note telling the user that this album or artist only has hidden tracks.

### Other Changes

- New `useFocusedQuery` hook which is `useQuery`, but only refetches when the screen is focused ([ref](https://tanstack.com/query/v5/docs/framework/react/react-native#disable-queries-on-out-of-focus-screens)).
- Optimized `Queue.removeIds` to not reload the next track if it doesn't need to.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- [x] Ensure when we hide a track, the track gets removed from all screens.
- [x] Ensure when we unhide a track, the track reappears.
- [x] Ensure queries that require both hidden & nonhidden tracks still work.
  - We don't want to recreate a `Track` entry for hidden track when while on the "Loading" screen when we launch the app.
  - We don't want to cleanup the DB of album & artists with only hidden tracks.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
