### PR TITLE
refactor: Improve performance of `savePathComponents()`

### DIFF
--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -145,7 +145,7 @@ export async function findAndSaveAudio() {
         const trackEntry = await getTrackEntry(mediaAsset);
 
         // Make sure we have the "folder" structure to this file.
-        await savePathComponents(uri);
+        await savePathComponents([uri]);
 
         if (modifiedTracks.has(id) && !isRetry) {
           // Update existing track.

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -9,8 +9,8 @@ import { fileNodes } from "~/db/schema";
  */
 export async function savePathComponents(uris: string[]) {
   // Removes the `file:///` at the start and the filename at the end of the uri.
-  const filePaths = uris.map((uri) =>
-    uri.slice(8).split("/").slice(0, -1).join("/"),
+  const filePaths = new Set(
+    uris.map((uri) => uri.slice(8).split("/").slice(0, -1).join("/")),
   );
 
   // List of `FileNode` entries that make up the uri.

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -2,32 +2,28 @@ import { db } from "~/db";
 import type { FileNode } from "~/db/schema";
 import { fileNodes } from "~/db/schema";
 
-import { addTrailingSlash } from "~/utils/string";
-
 /**
- * Generate the list of `FileNode` entries to a given uri. The uri should
+ * Generate the list of `FileNode` entries to for each uri. The uri should
  * start with `file:///` and not end with a `/` (the string after the last
  * `/` should be the filename.).
  */
-export async function savePathComponents(uri: string) {
+export async function savePathComponents(uris: string[]) {
   // Removes the `file:///` at the start and the filename at the end of the uri.
-  const filePath = uri.slice(8).split("/").slice(0, -1).join("/");
-
-  // Check if the file path is in the database already,
-  const exists = await db.query.fileNodes.findFirst({
-    where: (fields, { eq }) => eq(fields.path, addTrailingSlash(filePath)),
-  });
-  if (exists) return;
+  const filePaths = uris.map((uri) =>
+    uri.slice(8).split("/").slice(0, -1).join("/"),
+  );
 
   // List of `FileNode` entries that make up the uri.
   const foundNodes: FileNode[] = [];
-  filePath.split("/").forEach((name, idx) => {
-    if (idx === 0) {
-      foundNodes.push({ name, path: `${name}/`, parentPath: null });
-    } else {
-      const parentPath = foundNodes[idx - 1]!.path;
-      foundNodes.push({ name, path: `${parentPath}${name}/`, parentPath });
-    }
+  filePaths.forEach((filePath) => {
+    filePath.split("/").forEach((name, idx) => {
+      if (idx === 0) {
+        foundNodes.push({ name, path: `${name}/`, parentPath: null });
+      } else {
+        const parentPath = foundNodes[idx - 1]!.path;
+        foundNodes.push({ name, path: `${parentPath}${name}/`, parentPath });
+      }
+    });
   });
 
   // Insert found nodes into database.

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -18,7 +18,8 @@ export async function savePathComponents(uris: string[]) {
   const nodeMap: Record<string, Set<string>> = {};
   const rootNodes = new Set<string>();
   filePaths.forEach((filePath, _idx) => {
-    filePath.split("/").forEach((name, idx) => {
+    const filePathParts = filePath.split("/");
+    filePathParts.forEach((name, idx) => {
       if (idx === 0) {
         const path = `${name}/`;
         // Prevent over-inserting root-node paths.
@@ -27,7 +28,7 @@ export async function savePathComponents(uris: string[]) {
           foundNodes.push({ name, path, parentPath: null });
         }
       } else {
-        const parentPath = foundNodes[idx - 1]!.path;
+        const parentPath = `${filePathParts.slice(0, idx).join("/")}/`;
         const path = `${parentPath}${name}/`;
         // Prevent over-inserting paths (to prevent `RangeError: Maximum call
         // stack size exceeded (native stack depth)` with Drizzle ORM).

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -17,7 +17,7 @@ export async function savePathComponents(uris: string[]) {
   const foundNodes: FileNode[] = [];
   const nodeMap: Record<string, Set<string>> = {};
   const rootNodes = new Set<string>();
-  filePaths.forEach((filePath, _idx) => {
+  filePaths.forEach((filePath) => {
     const filePathParts = filePath.split("/");
     filePathParts.forEach((name, idx) => {
       if (idx === 0) {

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -33,8 +33,7 @@ export async function savePathComponents(uris: string[]) {
         // Prevent over-inserting paths (to prevent `RangeError: Maximum call
         // stack size exceeded (native stack depth)` with Drizzle ORM).
         const parentPreSaved = Object.hasOwn(nodeMap, parentPath);
-        const exists = parentPreSaved ? nodeMap[parentPath]!.has(path) : false;
-        if (!exists) {
+        if (!nodeMap[parentPath]?.has(path)) {
           if (parentPreSaved) nodeMap[parentPath]!.add(path);
           else nodeMap[parentPath] = new Set([path]);
           foundNodes.push({ name, path, parentPath });

--- a/mobile/src/modules/scanning/helpers/folder.ts
+++ b/mobile/src/modules/scanning/helpers/folder.ts
@@ -16,10 +16,16 @@ export async function savePathComponents(uris: string[]) {
   // List of `FileNode` entries that make up the uri.
   const foundNodes: FileNode[] = [];
   const nodeMap: Record<string, Set<string>> = {};
-  filePaths.forEach((filePath) => {
+  const rootNodes = new Set<string>();
+  filePaths.forEach((filePath, _idx) => {
     filePath.split("/").forEach((name, idx) => {
       if (idx === 0) {
-        foundNodes.push({ name, path: `${name}/`, parentPath: null });
+        const path = `${name}/`;
+        // Prevent over-inserting root-node paths.
+        if (!rootNodes.has(path)) {
+          rootNodes.add(path);
+          foundNodes.push({ name, path, parentPath: null });
+        }
       } else {
         const parentPath = foundNodes[idx - 1]!.path;
         const path = `${parentPath}${name}/`;

--- a/mobile/src/modules/scanning/helpers/migrations.ts
+++ b/mobile/src/modules/scanning/helpers/migrations.ts
@@ -78,11 +78,9 @@ const MigrationFunctionMap: Record<MigrationOption, () => Promise<void>> = {
         oldRootNodes.map((node) => node.path),
       ),
     );
-    await Promise.allSettled(
-      // The "placeholder" portion won't get saved.
-      oldRootNodes.map((node) =>
-        savePathComponents("file:///" + node.path + "placeholder"),
-      ),
+    // The "placeholder" portion won't get saved.
+    await savePathComponents(
+      oldRootNodes.map((node) => "file:///" + node.path + "placeholder"),
     );
   },
 

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -10,7 +10,7 @@ import { Resynchronize } from "~/modules/media/services/Resynchronize";
 
 import { clearAllQueries } from "~/lib/react-query";
 import { ToastOptions } from "~/lib/toast";
-import { batch, wait } from "~/utils/promise";
+import { wait } from "~/utils/promise";
 import { findAndSaveArtwork, cleanupImages } from "./artwork";
 import { cleanupDatabase, findAndSaveAudio } from "./audio";
 import { savePathComponents } from "./folder";
@@ -34,10 +34,7 @@ export async function rescanForTracks(deepScan = false) {
     const allTracks = await db.query.tracks.findMany({
       columns: { uri: true },
     });
-    await batch({
-      data: allTracks,
-      callback: ({ uri }) => savePathComponents(uri),
-    });
+    await savePathComponents(allTracks.map(({ uri }) => uri));
 
     // Make sure we retry invalid tracks.
     // eslint-disable-next-line drizzle/enforce-delete-with-where


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR rewrites `savePathComponents()` to allow passing an array of URIs, which drastically reduced the time it takes to regenerate the folder structure for the files we track.
- We no longer pre-check to see if the URI was already saved and instead, just save everything as this would probably add a bit of delay as we then need to read the DB for these values.

For 4987 tracks, regenerating the folder structure via the rescan feature:
- The old method took `23.0450s`.
- The refactored method took `0.1423s`.

This does give us hope for improving the performance of onboarding by using bulk insertion.

> [!NOTE]
> One thing we need to keep in mind is that we don't want to bulk insert too many entries as otherwise, Drizzle will throw an `RangeError: Maximum call stack size exceeded (native stack depth)` error.
>
> This was from trying to insert over 40000 entries at once.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
