### PR TITLE
refactor: Reduce time for saving new tracks by ~30-40%

### DIFF
--- a/mobile/src/api/artist.ts
+++ b/mobile/src/api/artist.ts
@@ -69,9 +69,11 @@ export const getArtists = _getArtists();
 //#endregion
 
 //#region POST Methods
-/** Create a new artist entry. */
-export async function createArtist(entry: typeof artists.$inferInsert) {
-  return db.insert(artists).values(entry).onConflictDoNothing();
+/** Create new artist entries. */
+export async function createArtists(
+  entries: Array<typeof artists.$inferInsert>,
+) {
+  return db.insert(artists).values(entries).onConflictDoNothing();
 }
 //#endregion
 

--- a/mobile/src/api/track.ts
+++ b/mobile/src/api/track.ts
@@ -120,6 +120,14 @@ export async function addToPlaylist(
       });
   });
 }
+
+/** Create new track entries, or update existing ones. */
+export function upsertTracks(entries: Array<typeof tracks.$inferInsert>) {
+  return db.insert(tracks).values(entries).onConflictDoUpdate({
+    target: tracks.id,
+    set: UpsertFields,
+  });
+}
 //#endregion
 
 //#region DELETE Methods
@@ -183,14 +191,6 @@ export async function removeInvalidTrackRelations() {
         .where(inArray(tracksToPlaylists.trackId, invalidTracks));
     }
   } catch {}
-}
-
-/** Create new track entries, or update existing ones. */
-export function upsertTracks(entries: Array<typeof tracks.$inferInsert>) {
-  return db.insert(tracks).values(entries).onConflictDoUpdate({
-    target: tracks.id,
-    set: UpsertFields,
-  });
 }
 //#endregion
 

--- a/mobile/src/lib/drizzle.ts
+++ b/mobile/src/lib/drizzle.ts
@@ -1,5 +1,6 @@
 import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
+import { toSnakeCase } from "drizzle-orm/casing";
 
 /*
   References:
@@ -27,4 +28,11 @@ export const iDesc = (column: SQLiteColumn) =>
 export function withColumns<T extends string>(columns: T[]) {
   const columnsObj = Object.fromEntries(columns.map((col) => [col, true]));
   return columnsObj as Record<T, true>;
+}
+
+/** Returns an object mapping columns to its `excluded.` notation. */
+export function getExcludedColumns<T extends string>(columns: T[]) {
+  return Object.fromEntries(
+    columns.map((k) => [k, sql.raw(`excluded.${toSnakeCase(k)}`)]),
+  );
 }

--- a/mobile/src/lib/drizzle.ts
+++ b/mobile/src/lib/drizzle.ts
@@ -19,3 +19,12 @@ export const iAsc = (column: SQLiteColumn) =>
  */
 export const iDesc = (column: SQLiteColumn) =>
   sql`${column} COLLATE NOCASE DESC, ${column} DESC`;
+
+/**
+ * Return an object for the `columns` field in Drizzle's Query
+ * Builder that returns the specified columns.
+ */
+export function withColumns<T extends string>(columns: T[]) {
+  const columnsObj = Object.fromEntries(columns.map((col) => [col, true]));
+  return columnsObj as Record<T, true>;
+}

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -18,11 +18,9 @@ import {
   tracks,
 } from "~/db/schema";
 
-import { upsertAlbum } from "~/api/album";
-import { createArtist } from "~/api/artist";
 import { RECENT_RANGE_MS } from "~/api/recent";
 import { getSaveErrors } from "~/api/setting";
-import { createTrack, deleteTrack, getTracks, updateTrack } from "~/api/track";
+import { deleteTrack, getTracks } from "~/api/track";
 import { userPreferencesStore } from "~/services/UserPreferences";
 import { Queue, musicStore } from "~/modules/media/services/Music";
 import { onboardingStore } from "../services/Onboarding";
@@ -231,6 +229,12 @@ export async function findAndSaveAudio() {
         target: tracks.id,
         set: setTrackUpsert,
       });
+      await db.delete(invalidTracks).where(
+        inArray(
+          invalidTracks.id,
+          tBatch.map(({ id }) => id),
+        ),
+      );
     }
   }
 

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -234,6 +234,16 @@ export async function findAndSaveAudio() {
     }
   }
 
+  if (erroredTracks.length > 0) {
+    await db.delete(tracks).where(
+      inArray(
+        tracks.id,
+        erroredTracks.map(({ id }) => id),
+      ),
+    );
+    await db.insert(invalidTracks).values(erroredTracks);
+  }
+
   const { staged, saveErrors } = onboardingStore.getState();
   console.log(
     `Found/updated ${staged} tracks & encountered ${saveErrors} errors in ${stopwatch.lapTime()}.`,

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -209,6 +209,8 @@ export async function findAndSaveAudio() {
     else albumIdMap[artistName] = { [name]: id };
   });
 
+  await savePathComponents(rawTrackEntries.map(({ uri }) => uri));
+
   const { staged, saveErrors } = onboardingStore.getState();
   console.log(
     `Found/updated ${staged} tracks & encountered ${saveErrors} errors in ${stopwatch.lapTime()}.`,

--- a/mobile/src/screens/ModifyTrack/context.tsx
+++ b/mobile/src/screens/ModifyTrack/context.tsx
@@ -8,8 +8,8 @@ import { createComputed } from "zustand-computed";
 import type { TrackWithAlbum } from "~/db/schema";
 
 import i18next from "~/modules/i18n";
-import { upsertAlbum } from "~/api/album";
-import { createArtist } from "~/api/artist";
+import { upsertAlbums } from "~/api/album";
+import { createArtists } from "~/api/artist";
 import { updateTrack } from "~/api/track";
 import { revalidateActiveTrack } from "~/modules/media/helpers/revalidate";
 import {
@@ -156,7 +156,7 @@ export function TrackMetadataStoreProvider({
             await Promise.allSettled(
               [updatedTrack.artistName, updatedAlbum.artistName]
                 .filter((name) => name !== null)
-                .map((name) => createArtist({ name })),
+                .map((name) => createArtists([{ name }])),
             );
 
             const { uri: artworkUri } = await getArtworkUri(uri);
@@ -164,11 +164,13 @@ export function TrackMetadataStoreProvider({
             // Add new album to the database.
             let albumId: string | null = null;
             if (updatedAlbum.name && updatedAlbum.artistName) {
-              const newAlbum = await upsertAlbum({
-                name: updatedAlbum.name,
-                artistName: updatedAlbum.artistName,
-                embeddedArtwork: artworkUri,
-              });
+              const [newAlbum] = await upsertAlbums([
+                {
+                  name: updatedAlbum.name,
+                  artistName: updatedAlbum.artistName,
+                  embeddedArtwork: artworkUri,
+                },
+              ]);
               if (newAlbum) albumId = newAlbum.id;
             }
             if (!albumId) updatedTrack.embeddedArtwork = artworkUri;

--- a/mobile/src/utils/object.ts
+++ b/mobile/src/utils/object.ts
@@ -1,3 +1,12 @@
+/** Split an array into "chunks". */
+export function chunkArray<T>(arr: T[], chunkSize: number) {
+  const chunkedArray: T[][] = [];
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    chunkedArray.push(arr.slice(i, i + chunkSize));
+  }
+  return chunkedArray;
+}
+
 /** Returns a copy of the array with the value at the specified index moved. */
 export function moveArray<T>(
   arr: T[],


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR rewrites `findAndSaveAudio()` to take advantage of bulk insertion to hopefully reduce the time it takes to save new tracks discovered on the device.

We bulk save tracks in batches of 50 as if we bulk save tracks in a single query, it'll cause problems as if the app gets closed midway while getting the metadata or during bulk-insertion, we have to re-scan and re-fetch the metadata for all tracks.

For saving 4987 tracks:
- The old method took `~4:28.32`.
- The refactored method took `~2:46.92`.

There is some variance between runs (we got anywhere between 2.5 & 3 minutes), but we should see a `30-40%` reduction in the scan & save time.

**Other Changes:**
- Revised creation functions for albums & artists to support bulk insertion.
- Replace `createTrack` with `upsertTracks` (which should simplify the saving logic when dealing with a new or updated track).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
