### PR TITLE
chore: Use latest metadata retriever API

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -29,7 +29,7 @@
     "@lukemorales/query-key-factory": "^1.3.4",
     "@miblanchard/react-native-slider": "^2.6.0",
     "@missingcore/react-native-actual-path": "^0.1.0",
-    "@missingcore/react-native-metadata-retriever": "^1.1.0",
+    "@missingcore/react-native-metadata-retriever": "2.0.0-beta.2",
     "@paralleldrive/cuid2": "^2.2.2",
     "@react-native-assets/slider": "^11.0.11",
     "@react-native-async-storage/async-storage": "2.1.2",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@missingcore/react-native-metadata-retriever':
-        specifier: ^1.1.0
-        version: 1.1.0(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.0-beta.2
+        version: 2.0.0-beta.2(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
@@ -1345,8 +1345,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@missingcore/react-native-metadata-retriever@1.1.0':
-    resolution: {integrity: sha512-VAWSmqpkD45Z+pmxeyTL0BTS97JMO7kkQ/f2KOJsY855WPw6pAMyxdydCPaAhvPZEkNC1herf0cvJQNE+4MgYw==}
+  '@missingcore/react-native-metadata-retriever@2.0.0-beta.2':
+    resolution: {integrity: sha512-r/f7fTSjCNIoagI2IFPlcHm5frwEHe0bf7dPQhKujhC0gFLTXgxPPyYH+7RBVBfzz/CUBlZVgouVfvDDpvPEUQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -7188,7 +7188,7 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0)
 
-  '@missingcore/react-native-metadata-retriever@1.1.0(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@missingcore/react-native-metadata-retriever@2.0.0-beta.2(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
       react-native: 0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0)

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -1,4 +1,8 @@
-import { getArtwork } from "@missingcore/react-native-metadata-retriever";
+import {
+  SaveFormat,
+  saveArtwork,
+} from "@missingcore/react-native-metadata-retriever";
+import { createId } from "@paralleldrive/cuid2";
 import { eq, inArray, isNotNull, or } from "drizzle-orm";
 import { Directory } from "expo-file-system/next";
 
@@ -10,7 +14,7 @@ import { getAlbums, updateAlbum } from "~/api/album";
 import { getTracks, updateTrack } from "~/api/track";
 import { onboardingStore } from "../services/Onboarding";
 
-import { ImageDirectory, deleteImage, saveImage } from "~/lib/file-system";
+import { ImageDirectory, deleteImage } from "~/lib/file-system";
 import { Stopwatch } from "~/utils/debug";
 import { BATCH_PRESETS, batch } from "~/utils/promise";
 
@@ -131,9 +135,12 @@ async function saveSinglesArtwork(
  */
 export async function getArtworkUri(uri: string) {
   try {
-    const base64Artwork = await getArtwork(uri);
-    if (!base64Artwork) return { error: false, uri: null };
-    const artworkUri = await saveImage(base64Artwork);
+    const artworkUri = await saveArtwork(uri, {
+      compress: 0.85,
+      format: SaveFormat.WEBP,
+      saveUri: `${ImageDirectory}/${createId()}.webp`,
+    });
+    if (!artworkUri) return { error: false, uri: null };
     return { error: false, uri: artworkUri };
   } catch {
     // In case we fail to save an image due to having an invalid base64 string.

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -140,7 +140,6 @@ export async function getArtworkUri(uri: string) {
       format: SaveFormat.WEBP,
       saveUri: `${ImageDirectory}/${createId()}.webp`,
     });
-    if (!artworkUri) return { error: false, uri: null };
     return { error: false, uri: artworkUri };
   } catch {
     console.log(`[Error] Failed to save image for "${uri}".`);

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -143,8 +143,7 @@ export async function getArtworkUri(uri: string) {
     if (!artworkUri) return { error: false, uri: null };
     return { error: false, uri: artworkUri };
   } catch {
-    // In case we fail to save an image due to having an invalid base64 string.
-    console.log(`[Error] Failed to get or save image for "${uri}".`);
+    console.log(`[Error] Failed to save image for "${uri}".`);
     return { error: true, uri: null };
   }
 }

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -1,6 +1,6 @@
 import {
   MetadataPresets,
-  getBulkMetadata,
+  getMetadata,
 } from "@missingcore/react-native-metadata-retriever";
 import { inArray, lt } from "drizzle-orm";
 import { File } from "expo-file-system/next";
@@ -8,6 +8,7 @@ import type { Asset as MediaLibraryAsset } from "expo-media-library";
 import { getAssetsAsync } from "expo-media-library";
 
 import { db } from "~/db";
+import type { InvalidTrack } from "~/db/schema";
 import {
   albums,
   artists,
@@ -27,7 +28,7 @@ import { onboardingStore } from "../services/Onboarding";
 import { getExcludedColumns, withColumns } from "~/lib/drizzle";
 import { Stopwatch } from "~/utils/debug";
 import { chunkArray } from "~/utils/object";
-import { BATCH_PRESETS } from "~/utils/promise";
+import { BATCH_PRESETS, isFulfilled, isRejected } from "~/utils/promise";
 import {
   addTrailingSlash,
   getSafeUri,
@@ -67,7 +68,9 @@ export async function findAndSaveAudio() {
   // as we would have saved at least some tracks).
   const trackBatches = chunkArray(unstagedTracks, 50);
   for (const tBatch of trackBatches) {
-    const { results, errors } = await bulkRetrieveMetadata(tBatch);
+    const res = await Promise.allSettled(tBatch.map(safeRetrieveMetadata));
+    const results = res.filter(isFulfilled).map((r) => r.value);
+    const errors: InvalidTrack[] = res.filter(isRejected).map((r) => r.reason);
     onboardingStore.setState((prev) => ({
       staged: prev.staged + results.length,
       saveErrors: prev.saveErrors + errors.length,
@@ -288,63 +291,56 @@ const wantedMetadata = [
 ] as const;
 
 /**
- * Returns an array of `TrackMetadata` & `InvalidTrack`.
+ * Get the metadata associated with a track.
  *
  * **Note:** We return `album`, which is non-standard and should be used
  * to create an Album and then swapped out with the created `albumId`.
  */
-async function bulkRetrieveMetadata(assets: MediaLibraryAsset[]) {
-  const assetURIMap = Object.fromEntries(assets.map((a) => [a.uri, a]));
-  const { results, errors } = await getBulkMetadata(
-    assets.map(({ uri }) => uri),
-    wantedMetadata,
-  );
+async function getTrackMetadata(asset: MediaLibraryAsset) {
+  const { id, uri, duration, modificationTime, filename } = asset;
+  const { bitrate, sampleRate, ...t } = await getMetadata(uri, wantedMetadata);
+  const file = new File(getSafeUri(uri));
 
-  const formattedResults = results.map(({ uri, data }) => {
-    const { id, duration, modificationTime, filename } = assetURIMap[uri]!;
-    const { bitrate, sampleRate, ...t } = data;
+  let newAlbum: { name: string; artistName: string } | undefined;
+  if (!!t.albumTitle?.trim() && !!t.albumArtist?.trim()) {
+    newAlbum = { name: t.albumTitle.trim(), artistName: t.albumArtist.trim() };
+  }
 
-    const file = new File(getSafeUri(uri));
+  return {
+    id,
+    name: t.title?.trim() || removeFileExtension(filename),
+    artistName: t.artist?.trim() || null,
+    album: newAlbum,
+    track: t.trackNumber,
+    disc: t.discNumber,
+    year: t.year,
+    format: t.sampleMimeType,
+    bitrate,
+    sampleRate,
+    duration,
+    uri,
+    modificationTime,
+    fetchedArt: false,
+    size: file.exists ? (file.size ?? 0) : 0,
+  };
+}
 
-    let newAlbum: { name: string; artistName: string } | undefined;
-    if (!!t.albumTitle?.trim() && !!t.albumArtist?.trim()) {
-      newAlbum = {
-        name: t.albumTitle.trim(),
-        artistName: t.albumArtist.trim(),
-      };
-    }
-
-    return {
-      id,
-      name: t.title?.trim() || removeFileExtension(filename),
-      artistName: t.artist?.trim() || null,
-      album: newAlbum,
-      track: t.trackNumber,
-      disc: t.discNumber,
-      year: t.year,
-      format: t.sampleMimeType,
-      bitrate,
-      sampleRate,
-      duration,
-      uri,
-      modificationTime,
-      fetchedArt: false,
-      size: file.exists ? (file.size ?? 0) : 0,
-    };
-  });
-
-  const formattedErrors = errors.map(({ uri, data }) => {
-    const { id, modificationTime } = assetURIMap[uri]!;
+/** Returns `TrackMetadata` or `InvalidTrack`. */
+async function safeRetrieveMetadata(asset: MediaLibraryAsset) {
+  const { id, uri, modificationTime } = asset;
+  try {
+    const trackEntry = await getTrackMetadata(asset);
+    return Promise.resolve(trackEntry);
+  } catch (err) {
+    const isError = err instanceof Error;
     const errorInfo = {
-      errorName: data.name || "UnknownError",
-      errorMessage: data.message || "Rejected for unknown reasons.",
+      errorName: isError ? err.name : "UnknownError",
+      errorMessage: isError ? err.message : "Rejected for unknown reasons.",
     };
     // We may end up here if the track at the given uri doesn't exist anymore.
     console.log(`[Track ${id}] ${errorInfo.errorMessage}`);
-    return { id, uri, modificationTime, ...errorInfo };
-  });
-
-  return { results: formattedResults, errors: formattedErrors };
+    return Promise.reject({ id, uri, modificationTime, ...errorInfo });
+  }
 }
 
 const UpsertInvalidTrackFields = getExcludedColumns([

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -49,7 +49,7 @@
   },
   "@missingcore/react-native-metadata-retriever": {
     "name": "@missingcore/react-native-metadata-retriever",
-    "version": "1.1.0",
+    "version": "2.0.0-beta.2",
     "copyright": "Copyright (c) 2024 MissingCore <missingcoredev@outlook.com>",
     "source": "https://github.com/MissingCore/react-native-metadata-retriever",
     "license": "MIT",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR updates our code to use the latest features from our `@missingcore/react-native-metadata-retriever` package that we currently have in beta.
- The reusable `getArtworkUri` function now uses the new `saveArtwork` function instead of `getArtwork` + `saveImage`.
- Using `getBulkMetadata` instead of `getMetadata` actually increases the onboarding time, so we're sticking with the old method.
  - The problem seems to be trying to get the file size of 50 tracks synchronously at the same time.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
