### PR TITLE
feat: Improved RTL Support

### DIFF
--- a/mobile/patches/@react-native-assets__slider.patch
+++ b/mobile/patches/@react-native-assets__slider.patch
@@ -11,11 +11,24 @@ index 242b83b5325bb5db4bd64a176a95176675c8ca73..bba3f83b575ba80d923cbc88d412ec34
          react_1.default.createElement(Track_1.default, { ...trackProps, color: maximumTrackTintColor, style: maxStyle, length: (1 - percentage) * 100, track: 'max' }),
          react_1.default.createElement(Marks_1.default, { type: 'slider', ...marksProps })));
  });
+diff --git a/dist/components/ResponderView.js b/dist/components/ResponderView.js
+index 9c9c8765f517c31f977dc11e4c54b9d069ee7a82..cb3e9f52215f2a2f3b1e17999dadad17f0edd8b1 100644
+--- a/dist/components/ResponderView.js
++++ b/dist/components/ResponderView.js
+@@ -120,7 +120,7 @@ const ResponderView = react_1.default.forwardRef((props, ref) => {
+     });
+     const containerStyle = react_1.default.useMemo(() => [styleSheet[vertical ? 'vertical' : 'horizontal'], style], [vertical, style]);
+     return (react_1.default.createElement(RN.View, { ...others, focusable: false, pointerEvents: 'box-only', ref: forwardRef, onLayout: onLayout, style: containerStyle, onStartShouldSetResponder: isEnabled, onMoveShouldSetResponder: isEnabled, onResponderGrant: onPress, onResponderRelease: onRelease, onResponderMove: onMove, onResponderTerminationRequest: keepResponder, onResponderTerminate: onRelease },
+-        react_1.default.createElement(SliderView_1.default, { vertical: vertical, inverted: inverted }, props.children)));
++        react_1.default.createElement(SliderView_1.default, { vertical: vertical }, props.children)));
+ });
+ ResponderView.displayName = 'ResponderView';
+ exports.default = react_1.default.memo(ResponderView);
 diff --git a/dist/components/Thumb.js b/dist/components/Thumb.js
-index 6cefc1eed8978efee4cdb0f5cba95dbf2d74413a..10a3746d79999914b711dd1dc128df140e287d74 100644
+index f6b20d6fff19456405d65e40976cdccef58d3d74..007eccc8682bc899cab9dae06f00b6f479647674 100644
 --- a/dist/components/Thumb.js
 +++ b/dist/components/Thumb.js
-@@ -66,7 +66,6 @@ function getThumbStyle(size, color) {
+@@ -80,7 +80,6 @@ function getThumbStyle(size, color) {
              backgroundColor: color,
              borderRadius: size / 2,
              overflow: 'hidden',
@@ -24,10 +37,10 @@ index 6cefc1eed8978efee4cdb0f5cba95dbf2d74413a..10a3746d79999914b711dd1dc128df14
          }
      }).thumb;
 diff --git a/dist/components/Track.js b/dist/components/Track.js
-index 6d33f31c3e00d8ab8b113c45755d06bbfefb9fb3..ccfc60f8615aa537d0c7cbfe8bd4468ed4cd49e0 100644
+index 41517e995d9403c0f435dc0fe98e058af6e36176..69b3beb69c8e301c3f8b48cd58ab358dbcac2580 100644
 --- a/dist/components/Track.js
 +++ b/dist/components/Track.js
-@@ -24,12 +24,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
+@@ -38,12 +38,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
  Object.defineProperty(exports, "__esModule", { value: true });
  const react_1 = __importDefault(require("react"));
  const RN = __importStar(require("react-native"));
@@ -43,7 +56,7 @@ index 6d33f31c3e00d8ab8b113c45755d06bbfefb9fb3..ccfc60f8615aa537d0c7cbfe8bd4468e
              backgroundColor: color,
              // This is for web
              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-@@ -41,7 +42,7 @@ function getTrackStyle(length, thickness, color, vertical) {
+@@ -55,7 +56,7 @@ function getTrackStyle(length, thickness, color, vertical) {
  }
  const Track = ({ style, thickness, length, vertical, color = 'grey', CustomTrack, track }) => {
      const trackViewStyle = react_1.default.useMemo(() => [

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: zgygxsuuqk33jr3gwbxpbkmczi
     path: patches/@backpackapp-io__react-native-toast.patch
   '@react-native-assets/slider':
-    hash: r2mjdjwkbzsvohkwkhe7tpugg4
+    hash: t2vslaq3o2r5rmxjymsu3p2x2m
     path: patches/@react-native-assets__slider.patch
   expo-file-system:
     hash: hgu53i2ax26gwnr5j43lvhx4h4
@@ -57,7 +57,7 @@ importers:
         version: 2.2.2
       '@react-native-assets/slider':
         specifier: ^11.0.11
-        version: 11.0.11(patch_hash=r2mjdjwkbzsvohkwkhe7tpugg4)(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+        version: 11.0.11(patch_hash=t2vslaq3o2r5rmxjymsu3p2x2m)(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))
@@ -7240,7 +7240,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.0.0(react@19.0.0)
       react: 19.0.0
 
-  '@react-native-assets/slider@11.0.11(patch_hash=r2mjdjwkbzsvohkwkhe7tpugg4)(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+  '@react-native-assets/slider@11.0.11(patch_hash=t2vslaq3o2r5rmxjymsu3p2x2m)(react-native@0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
       react-native: 0.79.6(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.0.0)

--- a/mobile/src/app/(main)/(current)/artist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/artist/[id].tsx
@@ -1,5 +1,6 @@
 import { useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
+import { I18nManager } from "react-native";
 
 import type { Album } from "~/db/schema";
 
@@ -8,6 +9,7 @@ import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { useGetColumn } from "~/hooks/useGetColumn";
 import { CurrentListLayout } from "~/layouts/CurrentList";
 
+import { OnRTL } from "~/lib/react";
 import { FlashList } from "~/components/Defaults";
 import {
   ContentPlaceholder,
@@ -94,11 +96,12 @@ function ArtistAlbums({ albums }: { albums: ArtistAlbum[] | null }) {
             href={`/album/${item.id}`}
             title={item.name}
             description={item.releaseYear || "————"}
-            className={index > 0 ? "ml-3" : undefined}
+            className={index > 0 ? OnRTL.decide("mr-3", "ml-3") : undefined}
           />
         )}
         className="-mx-4"
         contentContainerClassName="px-4"
+        disableAutoLayout={I18nManager.isRTL}
       />
       <TEm dim textKey="term.tracks" className="mb-2 mt-4" />
     </>

--- a/mobile/src/app/(main)/(current)/playlist/[id].tsx
+++ b/mobile/src/app/(main)/(current)/playlist/[id].tsx
@@ -18,6 +18,7 @@ import { CurrentListLayout } from "~/layouts/CurrentList";
 import { areRenderItemPropsEqual } from "~/lib/react-native-draglist";
 
 import { Colors } from "~/constants/Styles";
+import { OnRTL } from "~/lib/react";
 import { mutateGuard } from "~/lib/react-query";
 import { cn } from "~/lib/style";
 import { FlashDragList } from "~/components/Defaults";
@@ -143,7 +144,7 @@ const RenderItem = memo(
                   name: item.title,
                 })}
                 onPress={() => mutateGuard(removeTrack, trackSource.id)}
-                className="mr-4 bg-red p-3"
+                className={cn("bg-red p-3", OnRTL.decide("ml-4", "mr-4"))}
               >
                 <Remove color={Colors.neutral100} />
               </Button>

--- a/mobile/src/app/(main)/(current)/recently-played.tsx
+++ b/mobile/src/app/(main)/(current)/recently-played.tsx
@@ -1,6 +1,7 @@
 import { useIsFocused } from "@react-navigation/native";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { I18nManager } from "react-native";
 
 import { RECENT_DAY_RANGE } from "~/api/recent";
 import { queries as q } from "~/queries/keyStore";
@@ -11,6 +12,7 @@ import {
 import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { useGetColumn } from "~/hooks/useGetColumn";
 
+import { OnRTL } from "~/lib/react";
 import { queryClient } from "~/lib/react-query";
 import { FlashList } from "~/components/Defaults";
 import { PagePlaceholder } from "~/components/Transition/Placeholder";
@@ -98,11 +100,12 @@ function RecentlyPlayedLists(props: { data?: MediaCard.Content[] }) {
         <MediaCard
           {...item}
           size={width}
-          className={index > 0 ? "ml-3" : undefined}
+          className={index > 0 ? OnRTL.decide("mr-3", "ml-3") : undefined}
         />
       )}
       className="-mx-4"
       contentContainerClassName="px-4 pb-6"
+      disableAutoLayout={I18nManager.isRTL}
     />
   );
 }

--- a/mobile/src/app/(main)/(home)/folder.tsx
+++ b/mobile/src/app/(main)/(home)/folder.tsx
@@ -5,6 +5,7 @@ import { BackHandler, Pressable, useWindowDimensions } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import Animated, {
   FadeInLeft,
+  FadeOutLeft,
   FadeOutRight,
   scrollTo,
   useAnimatedRef,
@@ -19,6 +20,7 @@ import Animated, {
 import { useFolderContent } from "~/queries/folder";
 import { StickyActionListLayout } from "~/layouts/StickyActionScroll";
 
+import { OnRTL, OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { addTrailingSlash } from "~/utils/string";
 import { useFlashListRef } from "~/components/Defaults";
@@ -156,7 +158,12 @@ function Breadcrumbs({
   };
 
   useDerivedValue(() => {
-    scrollTo(breadcrumbsRef, newScrollPos.value, 0, true);
+    scrollTo(
+      breadcrumbsRef,
+      OnRTLWorklet.decide(0, newScrollPos.value),
+      0,
+      true,
+    );
   });
 
   const offsetStyle = useAnimatedStyle(() => ({
@@ -179,11 +186,17 @@ function Breadcrumbs({
         {[undefined, ...dirSegments].map((dirName, idx) => (
           <Fragment key={idx}>
             {idx > 0 ? (
-              <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
+              <Animated.View
+                entering={FadeInLeft}
+                exiting={OnRTL.decide(FadeOutLeft, FadeOutRight)}
+              >
                 <StyledText className="px-1 text-xs">/</StyledText>
               </Animated.View>
             ) : null}
-            <Animated.View entering={FadeInLeft} exiting={FadeOutRight}>
+            <Animated.View
+              entering={FadeInLeft}
+              exiting={OnRTL.decide(FadeOutLeft, FadeOutRight)}
+            >
               <Pressable
                 // Pop the segments we pushed onto the stack and update
                 // the path segments atom accordingly.

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -14,6 +14,7 @@ import { useBottomActionsContext } from "~/hooks/useBottomActionsContext";
 import { useHasNewUpdate } from "~/hooks/useHasNewUpdate";
 import { useTheme } from "~/hooks/useTheme";
 
+import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { FlatList, useFlatListRef } from "~/components/Defaults";
 import { Button, IconButton } from "~/components/Form/Button";
@@ -162,12 +163,14 @@ function NavigationList() {
         pointerEvents="none"
         colors={[`${surface}E6`, `${surface}00`]}
         {...ShadowProps}
-        className="absolute left-0 h-full w-4"
+        style={{ [OnRTL.decide("right", "left")]: 0 }}
+        className="absolute h-full w-4"
       />
       <LinearGradient
         pointerEvents="none"
         colors={[`${surface}00`, `${surface}E6`]}
         {...ShadowProps}
+        style={{ [OnRTL.decide("left", "right")]: 0 }}
         className="absolute right-0 h-full w-4"
       />
     </View>

--- a/mobile/src/app/(main)/_layout.tsx
+++ b/mobile/src/app/(main)/_layout.tsx
@@ -171,7 +171,7 @@ function NavigationList() {
         colors={[`${surface}00`, `${surface}E6`]}
         {...ShadowProps}
         style={{ [OnRTL.decide("left", "right")]: 0 }}
-        className="absolute right-0 h-full w-4"
+        className="absolute h-full w-4"
       />
     </View>
   );

--- a/mobile/src/app/setting/update.tsx
+++ b/mobile/src/app/setting/update.tsx
@@ -79,7 +79,7 @@ export default function AppUpdateScreen() {
             >
               <Text
                 style={{ fontFamily: "monospace" }}
-                className="text-xxs text-foreground/60"
+                className="text-left text-xxs text-foreground/60"
               >
                 {node.content}
               </Text>

--- a/mobile/src/components/Containment/Marquee.tsx
+++ b/mobile/src/components/Containment/Marquee.tsx
@@ -13,6 +13,7 @@ import { View } from "react-native";
 
 import { useTheme } from "~/hooks/useTheme";
 
+import { OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 
 /** Used to progressively display long content. */
@@ -88,20 +89,26 @@ export function Marquee({
   }, [containerWidth, contentWidth, offset]);
 
   const contentStyles = useAnimatedStyle(() => ({
-    transform: [{ translateX: -offset.value }],
+    transform: [{ translateX: OnRTLWorklet.flipSign(-offset.value) }],
   }));
 
   // Styles to determine when to render the scroll shadow.
   const isLeftVisible = useAnimatedStyle(() => ({
-    display: offset.value === 0 ? "none" : "flex",
+    display:
+      offset.value === OnRTLWorklet.decide(contentWidth - containerWidth, 0)
+        ? "none"
+        : "flex",
     top: topOffset,
+    [OnRTLWorklet.decide("right", "left")]: 0,
   }));
   const isRightVisible = useAnimatedStyle(() => ({
     display:
-      !isStatic && offset.value < contentWidth - containerWidth
+      !isStatic &&
+      offset.value !== OnRTLWorklet.decide(0, contentWidth - containerWidth)
         ? "flex"
         : "none",
     top: topOffset,
+    [OnRTLWorklet.decide("left", "right")]: 0,
   }));
 
   return (
@@ -130,14 +137,14 @@ export function Marquee({
       <Animated.View
         pointerEvents="none"
         style={isLeftVisible}
-        className={cn("absolute left-0 h-full", { hidden: isStatic })}
+        className={cn("absolute h-full", { hidden: isStatic })}
       >
         <LinearGradient colors={[endColor, startColor]} {...ShadowProps} />
       </Animated.View>
       <Animated.View
         pointerEvents="none"
         style={isRightVisible}
-        className={cn("absolute right-0 h-full", { hidden: isStatic })}
+        className={cn("absolute h-full", { hidden: isStatic })}
       >
         <LinearGradient colors={[startColor, endColor]} {...ShadowProps} />
       </Animated.View>

--- a/mobile/src/components/Form/Input.tsx
+++ b/mobile/src/components/Form/Input.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import type { TextInputProps } from "react-native";
+import { I18nManager } from "react-native";
 import { TextInput as RNTextInput } from "react-native-gesture-handler";
 
 import { useUserPreferencesStore } from "~/services/UserPreferences";
@@ -28,6 +29,7 @@ export function NumericInput({ className, style, ...props }: InputProps) {
         className,
       )}
       style={[{ fontFamily: getFont(accentFont) }, style]}
+      textAlign={I18nManager.isRTL ? "right" : undefined}
       {...props}
     />
   );
@@ -50,6 +52,7 @@ export function TextInput({ className, style, ...props }: InputProps) {
         className,
       )}
       style={[{ fontFamily: getFont(primaryFont) }, style]}
+      textAlign={I18nManager.isRTL ? "right" : undefined}
       {...props}
     />
   );

--- a/mobile/src/components/Form/Input.tsx
+++ b/mobile/src/components/Form/Input.tsx
@@ -1,10 +1,10 @@
 import { useRef } from "react";
 import type { TextInputProps } from "react-native";
-import { I18nManager } from "react-native";
 import { TextInput as RNTextInput } from "react-native-gesture-handler";
 
 import { useUserPreferencesStore } from "~/services/UserPreferences";
 
+import { OnRTL } from "~/lib/react";
 import { cn, getFont } from "~/lib/style";
 
 export function useInputRef() {
@@ -29,7 +29,7 @@ export function NumericInput({ className, style, ...props }: InputProps) {
         className,
       )}
       style={[{ fontFamily: getFont(accentFont) }, style]}
-      textAlign={I18nManager.isRTL ? "right" : undefined}
+      textAlign={OnRTL._use("right")}
       {...props}
     />
   );
@@ -52,7 +52,7 @@ export function TextInput({ className, style, ...props }: InputProps) {
         className,
       )}
       style={[{ fontFamily: getFont(primaryFont) }, style]}
-      textAlign={I18nManager.isRTL ? "right" : undefined}
+      textAlign={OnRTL._use("right")}
       {...props}
     />
   );

--- a/mobile/src/components/Form/Slider.tsx
+++ b/mobile/src/components/Form/Slider.tsx
@@ -63,7 +63,7 @@ export function NSlider(
         accessible
         accessibilityLabel={`${props.label}: ${formattedValue}`}
         pointerEvents="none"
-        className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 flex-row items-center gap-2"
+        className="absolute top-1/2 z-10 w-full -translate-y-1/2 flex-row items-center justify-center gap-2"
       >
         {props.icon}
         <StyledText className="min-w-12 text-sm" bold>

--- a/mobile/src/components/Form/Slider.tsx
+++ b/mobile/src/components/Form/Slider.tsx
@@ -1,7 +1,7 @@
 import { Slider as RNSlider } from "@miblanchard/react-native-slider";
 import SheetSlider from "@react-native-assets/slider";
 import { useState } from "react";
-import { Pressable, View } from "react-native";
+import { I18nManager, Pressable, View } from "react-native";
 
 import { useTheme } from "~/hooks/useTheme";
 
@@ -85,6 +85,7 @@ export function NSlider(
         thumbStyle={{ height: 64, backgroundColor: Colors.red }}
         // The wrapper adds some extra padding, which this will negate.
         style={{ height: 64 }}
+        inverted={I18nManager.isRTL}
       />
       {width !== undefined ? <NSliderMarks width={width} {...props} /> : null}
     </View>

--- a/mobile/src/components/Form/Switch.tsx
+++ b/mobile/src/components/Form/Switch.tsx
@@ -1,9 +1,9 @@
-import { I18nManager } from "react-native";
 import Animated, {
   useAnimatedStyle,
   withTiming,
 } from "react-native-reanimated";
 
+import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 
 /** Externally controlled switch component (BYO `<Pressable />`). */
@@ -20,7 +20,7 @@ export function Switch({ enabled }: { enabled: boolean }) {
       })}
     >
       <Animated.View
-        style={[{ [I18nManager.isRTL ? "right" : "left"]: 2 }, thumbStyle]}
+        style={[{ [OnRTL.decide("right", "left")]: 2 }, thumbStyle]}
         className="absolute top-0.5 size-[20px] rounded-full bg-neutral100"
       />
     </Animated.View>

--- a/mobile/src/components/Form/Switch.tsx
+++ b/mobile/src/components/Form/Switch.tsx
@@ -1,3 +1,4 @@
+import { I18nManager } from "react-native";
 import Animated, {
   useAnimatedStyle,
   withTiming,
@@ -19,8 +20,8 @@ export function Switch({ enabled }: { enabled: boolean }) {
       })}
     >
       <Animated.View
-        style={thumbStyle}
-        className="absolute left-0.5 top-0.5 size-[20px] rounded-full bg-neutral100"
+        style={[{ [I18nManager.isRTL ? "right" : "left"]: 2 }, thumbStyle]}
+        className="absolute top-0.5 size-[20px] rounded-full bg-neutral100"
       />
     </Animated.View>
   );

--- a/mobile/src/components/TopAppBar.tsx
+++ b/mobile/src/components/TopAppBar.tsx
@@ -2,10 +2,11 @@ import { getHeaderTitle } from "@react-navigation/elements";
 import type { NativeStackHeaderProps } from "@react-navigation/native-stack";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { I18nManager, View } from "react-native";
+import { View } from "react-native";
 
 import { ArrowBack } from "~/icons/ArrowBack";
 
+import { OnRTL } from "~/lib/react";
 import { SafeContainer } from "./Containment/SafeContainer";
 import { IconButton } from "./Form/Button";
 import { StyledText } from "./Typography/StyledText";
@@ -26,7 +27,7 @@ export function TopAppBar({ options, route }: NativeStackHeaderProps) {
           accessibilityLabel={t("form.back")}
           onPress={() => router.back()}
           disabled={!!options.headerLeft}
-          className={I18nManager.isRTL ? "rotate-180" : undefined}
+          className={OnRTL._use("rotate-180")}
         />
 
         <StyledText numberOfLines={2} className="shrink text-center text-xs">

--- a/mobile/src/components/TopAppBar.tsx
+++ b/mobile/src/components/TopAppBar.tsx
@@ -2,7 +2,7 @@ import { getHeaderTitle } from "@react-navigation/elements";
 import type { NativeStackHeaderProps } from "@react-navigation/native-stack";
 import { router } from "expo-router";
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
+import { I18nManager, View } from "react-native";
 
 import { ArrowBack } from "~/icons/ArrowBack";
 
@@ -26,6 +26,7 @@ export function TopAppBar({ options, route }: NativeStackHeaderProps) {
           accessibilityLabel={t("form.back")}
           onPress={() => router.back()}
           disabled={!!options.headerLeft}
+          className={I18nManager.isRTL ? "rotate-180" : undefined}
         />
 
         <StyledText numberOfLines={2} className="shrink text-center text-xs">

--- a/mobile/src/components/Typography/AccentText.tsx
+++ b/mobile/src/components/Typography/AccentText.tsx
@@ -19,7 +19,7 @@ export function AccentText({
   return (
     <Text
       className={cn(
-        "text-foreground",
+        "text-left text-foreground",
         { uppercase: accentFont === "NDot" && !originalText },
         className,
         "leading-tight",

--- a/mobile/src/components/Typography/StyledText.tsx
+++ b/mobile/src/components/Typography/StyledText.tsx
@@ -20,7 +20,7 @@ export function StyledText({
   return (
     <Text
       className={cn(
-        "text-base text-foreground",
+        "text-left text-base text-foreground",
         {
           "text-center": center,
           "text-xs text-foreground/60": dim,

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -1,7 +1,7 @@
 import { router } from "expo-router";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, Text, View } from "react-native";
+import { I18nManager, Pressable, Text, View } from "react-native";
 import Animated, {
   Easing,
   cancelAnimation,
@@ -193,7 +193,9 @@ function AnimatedVinyl(props: AnimatedVinylProps & { pressable?: boolean }) {
 
   // Since the cover size is fixed, we know how much to translate.
   const coverStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: coverPosition.value }],
+    transform: [
+      { translateX: (I18nManager.isRTL ? -1 : 1) * coverPosition.value },
+    ],
   }));
 
   const diskStyle = useAnimatedStyle(() => ({

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -1,7 +1,7 @@
 import { router } from "expo-router";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { I18nManager, Pressable, Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import Animated, {
   Easing,
   cancelAnimation,
@@ -23,7 +23,7 @@ import {
   PlaylistArtworkSheet,
 } from "~/screens/Sheets/Artwork";
 
-import { DeferRender } from "~/lib/react";
+import { DeferRender, OnRTLWorklet } from "~/lib/react";
 import { getFont } from "~/lib/style";
 import { toLowerCase } from "~/utils/string";
 import { Marquee } from "~/components/Containment/Marquee";
@@ -193,9 +193,7 @@ function AnimatedVinyl(props: AnimatedVinylProps & { pressable?: boolean }) {
 
   // Since the cover size is fixed, we know how much to translate.
   const coverStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateX: (I18nManager.isRTL ? -1 : 1) * coverPosition.value },
-    ],
+    transform: [{ translateX: OnRTLWorklet.flipSign(coverPosition.value) }],
   }));
 
   const diskStyle = useAnimatedStyle(() => ({

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -67,9 +67,11 @@ export function CurrentListLayout(
 
   return (
     <>
-      <DeferRender>
-        <RenderedSheet sheetRef={artworkSheetRef} id={props.mediaSource.id} />
-      </DeferRender>
+      {!isFavorite ? (
+        <DeferRender>
+          <RenderedSheet sheetRef={artworkSheetRef} id={props.mediaSource.id} />
+        </DeferRender>
+      ) : null}
       <View className="flex-row gap-2 pr-4">
         <ContentImage
           mediaSource={props.mediaSource}
@@ -132,6 +134,7 @@ export function CurrentListLayout(
 /** Determines the look and features of the image displayed. */
 function ContentImage(props: AnimatedVinylProps & { present: VoidFunction }) {
   const { t } = useTranslation();
+
   if (getIsFavoritePlaylist(props.mediaSource))
     return <AnimatedVinyl {...props} />;
 

--- a/mobile/src/layouts/CurrentList.tsx
+++ b/mobile/src/layouts/CurrentList.tsx
@@ -87,7 +87,7 @@ export function CurrentListLayout(
               >
                 <Text
                   style={{ fontFamily: getFont(primaryFont) }}
-                  className="text-xs text-red"
+                  className="text-left text-xs text-red"
                 >
                   {props.artist}
                 </Text>

--- a/mobile/src/lib/react.tsx
+++ b/mobile/src/lib/react.tsx
@@ -1,3 +1,5 @@
+import { I18nManager } from "react-native";
+
 import { useDelayedReady } from "~/hooks/useDelayedReady";
 
 /**
@@ -31,3 +33,20 @@ export function DeferRender(props: {
   if (!shouldRender) return null;
   return props.children;
 }
+
+export const OnRTL = {
+  _use<T>(val: T) {
+    if (I18nManager.isRTL) return val;
+  },
+
+  decide<T, U>(a: T, b: U) {
+    return I18nManager.isRTL ? a : b;
+  },
+};
+
+export const OnRTLWorklet = {
+  flipSign: (num: number) => {
+    "worklet";
+    return (I18nManager.isRTL ? -1 : 1) * num;
+  },
+};

--- a/mobile/src/lib/react.tsx
+++ b/mobile/src/lib/react.tsx
@@ -39,12 +39,17 @@ export const OnRTL = {
     if (I18nManager.isRTL) return val;
   },
 
-  decide<T, U>(a: T, b: U) {
-    return I18nManager.isRTL ? a : b;
+  decide<T, U>(valIfTrue: T, valIfFalse: U) {
+    return I18nManager.isRTL ? valIfTrue : valIfFalse;
   },
 };
 
 export const OnRTLWorklet = {
+  decide<T, U>(valIfTrue: T, valIfFalse: U) {
+    "worklet";
+    return I18nManager.isRTL ? valIfTrue : valIfFalse;
+  },
+
   flipSign: (num: number) => {
     "worklet";
     return (I18nManager.isRTL ? -1 : 1) * num;

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -2,7 +2,7 @@ import type { FlashListProps } from "@shopify/flash-list";
 import type { Href } from "expo-router";
 import { router } from "expo-router";
 import { useMemo } from "react";
-import { Pressable } from "react-native";
+import { I18nManager, Pressable } from "react-native";
 
 import { useGetColumn } from "~/hooks/useGetColumn";
 
@@ -116,6 +116,8 @@ export function useMediaCardListPreset(
       ),
       ListHeaderComponentStyle: { paddingHorizontal: 8 },
       className: "-mx-1.5 -mb-3",
+      /** If in RTL, layout breaks with columns. */
+      disableAutoLayout: I18nManager.isRTL,
     }),
     [count, width, props],
   ) satisfies FlashListProps<MediaCard.Content>;

--- a/mobile/src/modules/media/components/Vinyl.tsx
+++ b/mobile/src/modules/media/components/Vinyl.tsx
@@ -41,12 +41,12 @@ export function Vinyl(props: {
   }, [props.source]);
 
   return (
-    <View className="relative">
+    <View className="relative items-center justify-center">
       <MediaImage
         type="playlist"
         source={props.source}
         size={props.size / 2}
-        className="absolute translate-x-1/2 translate-y-1/2 rounded-full bg-red"
+        className="absolute rounded-full bg-red"
         noPlaceholder
       />
       <Svg width={props.size} height={props.size} viewBox="0 0 768 768">

--- a/mobile/src/screens/ModifyPlaylist/index.tsx
+++ b/mobile/src/screens/ModifyPlaylist/index.tsx
@@ -19,6 +19,7 @@ import { PlaylistStoreProvider, usePlaylistStore } from "./context";
 import { AddMusicSheet } from "./Sheets";
 
 import { Colors } from "~/constants/Styles";
+import { OnRTL } from "~/lib/react";
 import { mutateGuard } from "~/lib/react-query";
 import { cn } from "~/lib/style";
 import { wait } from "~/utils/promise";
@@ -172,7 +173,7 @@ const RenderItem = memo(
                   name: item.name,
                 })}
                 onPress={onPress}
-                className="mr-4 bg-red p-3"
+                className={cn("bg-red p-3", OnRTL.decide("ml-4", "mr-4"))}
               >
                 <Remove color={Colors.neutral100} />
               </Button>

--- a/mobile/src/screens/NowPlaying/Sheets.tsx
+++ b/mobile/src/screens/NowPlaying/Sheets.tsx
@@ -14,6 +14,7 @@ import type { UpcomingStore } from "./helpers/UpcomingStore";
 import { useUpcomingStore } from "./helpers/UpcomingStore";
 
 import { Colors } from "~/constants/Styles";
+import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { FlashList } from "~/components/Defaults";
 import { Button } from "~/components/Form/Button";
@@ -185,7 +186,7 @@ function RenderQueueItem({ item, index }: ListRenderItemInfo<PartialTrack>) {
         <Button
           accessibilityLabel={t("template.entryRemove", { name: item.name })}
           onPress={() => Queue.removeAtIndex(index)}
-          className="mr-4 bg-red p-3"
+          className={cn("bg-red p-3", OnRTL.decide("ml-4", "mr-4"))}
         >
           <Remove color={Colors.neutral100} />
         </Button>

--- a/mobile/src/screens/NowPlaying/TopAppBar.tsx
+++ b/mobile/src/screens/NowPlaying/TopAppBar.tsx
@@ -1,12 +1,13 @@
 import { router } from "expo-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { I18nManager, Pressable, View } from "react-native";
+import { Pressable, View } from "react-native";
 
 import { ArrowBack } from "~/icons/ArrowBack";
 import { useUserPreferencesStore } from "~/services/UserPreferences";
 import { useMusicStore } from "~/modules/media/services/Music";
 
+import { OnRTL } from "~/lib/react";
 import { Marquee } from "~/components/Containment/Marquee";
 import { SafeContainer } from "~/components/Containment/SafeContainer";
 import { IconButton } from "~/components/Form/Button";
@@ -44,7 +45,7 @@ function AppBarContent() {
         Icon={ArrowBack}
         accessibilityLabel={t("form.back")}
         onPress={() => router.back()}
-        className={I18nManager.isRTL ? "rotate-180" : undefined}
+        className={OnRTL._use("rotate-180")}
       />
       <Pressable
         onPress={() => (listHref ? router.navigate(listHref) : undefined)}

--- a/mobile/src/screens/NowPlaying/TopAppBar.tsx
+++ b/mobile/src/screens/NowPlaying/TopAppBar.tsx
@@ -1,7 +1,7 @@
 import { router } from "expo-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { I18nManager, Pressable, View } from "react-native";
 
 import { ArrowBack } from "~/icons/ArrowBack";
 import { useUserPreferencesStore } from "~/services/UserPreferences";
@@ -44,6 +44,7 @@ function AppBarContent() {
         Icon={ArrowBack}
         accessibilityLabel={t("form.back")}
         onPress={() => router.back()}
+        className={I18nManager.isRTL ? "rotate-180" : undefined}
       />
       <Pressable
         onPress={() => (listHref ? router.navigate(listHref) : undefined)}

--- a/mobile/src/screens/Sheets/Settings/Appearance.tsx
+++ b/mobile/src/screens/Sheets/Settings/Appearance.tsx
@@ -90,7 +90,7 @@ function FontSheet<T extends (typeof AccentFontOptions)[number]>(props: {
             onSelect={() => props.updateFont(font)}
           >
             <Text
-              className="text-base leading-tight text-foreground"
+              className="text-left text-base leading-tight text-foreground"
               style={{ fontFamily: getFont(font) }}
             >
               {font}

--- a/mobile/src/screens/Sheets/Settings/Scanning.tsx
+++ b/mobile/src/screens/Sheets/Settings/Scanning.tsx
@@ -18,8 +18,9 @@ import {
 } from "./helpers/ScanFilterData";
 
 import { Colors } from "~/constants/Styles";
-import { deferInitialRender } from "~/lib/react";
+import { deferInitialRender, OnRTL } from "~/lib/react";
 import { mutateGuard } from "~/lib/react-query";
+import { cn } from "~/lib/style";
 import { Marquee } from "~/components/Containment/Marquee";
 import { FlatList } from "~/components/Defaults";
 import { Button, IconButton } from "~/components/Form/Button";
@@ -92,7 +93,10 @@ function ScanFilterListSheet({
               <Button
                 accessibilityLabel={t("template.entryRemove", { name: item })}
                 onPress={() => removePath({ list: listType, path: item })}
-                className="mr-4 aspect-square h-full bg-red p-3"
+                className={cn(
+                  "aspect-square h-full bg-red p-3",
+                  OnRTL.decide("ml-4", "mr-4"),
+                )}
               >
                 <Remove color={Colors.neutral100} />
               </Button>

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -102,6 +102,7 @@ export const userPreferencesStore =
         if (state.language === "") {
           await i18next.changeLanguage(getLocales()[0]?.languageTag || "en");
           I18nManager.allowRTL(i18next.dir() === "rtl");
+          I18nManager.forceRTL(i18next.dir() === "rtl");
           const usedLanguage = i18next.resolvedLanguage;
           // Ensured the resolved value exists.
           const exists = LANGUAGES.some((l) => l.code === usedLanguage);
@@ -196,6 +197,7 @@ userPreferencesStore.subscribe(
     // Set the language used by the app.
     await i18next.changeLanguage(languageCode);
     I18nManager.allowRTL(i18next.dir() === "rtl");
+    I18nManager.forceRTL(i18next.dir() === "rtl");
     // Make sure our queries that use translated values are updated.
     clearAllQueries();
     // Make sure to refresh the playing source name if it's one of the favorite playlists.

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -1,6 +1,6 @@
 import { getLocales } from "expo-localization";
 import { useMemo } from "react";
-import { Appearance } from "react-native";
+import { Appearance, I18nManager } from "react-native";
 import { useStore } from "zustand";
 
 import i18next from "~/modules/i18n";
@@ -101,6 +101,7 @@ export const userPreferencesStore =
         // Try to use device language if no language is specified.
         if (state.language === "") {
           await i18next.changeLanguage(getLocales()[0]?.languageTag || "en");
+          I18nManager.allowRTL(i18next.dir() === "rtl");
           const usedLanguage = i18next.resolvedLanguage;
           // Ensured the resolved value exists.
           const exists = LANGUAGES.some((l) => l.code === usedLanguage);
@@ -194,6 +195,7 @@ userPreferencesStore.subscribe(
   async (languageCode) => {
     // Set the language used by the app.
     await i18next.changeLanguage(languageCode);
+    I18nManager.allowRTL(i18next.dir() === "rtl");
     // Make sure our queries that use translated values are updated.
     clearAllQueries();
     // Make sure to refresh the playing source name if it's one of the favorite playlists.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds improved support for RTL layouts, which was broken in a sense since it was enabled in `v2.3.0`? If the device language is RTL, then the app UI would be automatically updated to reflect it.
- This really only got noticed when testing the Arabic translations after an app relaunch.

How we now handle RTL is as follows:
- If a RTL language is selected in the app from an LTR language, the layout will be adjusted to RTL on **next app relaunch**.
- If a LTR language is selected in the app from an RTL language, the layout will be adjusted to LTR on **next app relaunch**.
  - Essentially, we'll ignore the device language for determine whether a RTL layout will be used.

**Some Notes:**
- RTL layout ended up breaking a lot of things, most notably animations (ie: Marquee), animated components (ie: Vinyl Design, Switch), and anything that uses left/right modifiers with absolute positioning.
- The left-most character in a text line with an ellipsis may be cut off a bit.
- FlashList will break unless we enable `disableAutoLayout` while in RTL.
- Horizontal FlashList might have some extra padding at the left-end after fully scrolling.
- Sheet content might become off-center in RTL if it's nested inside a container with some left/right padding.
- Changes to layout for RTL only applies after app relaunch.
  - `I18nManager.allowRTL()` is only useful to use LTR layout while the device language is set to RTL.
  - If we select an RTL language in the app while the device language is set to LTR, `I18nManager.forceRTL()` is needed.
- The breadcrumbs on the "Folders" screen will never be right-aligned while in RTL for whatever reason.
- A patch is needed for the slider used for the `<NSlider />` component as the `inverted` prop would reverse the styles, which would get reversed again due to `I18nManager`.
- Need to explicitly add `text-left` to left-align text as that's not the default behavior.

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- [x] Ensure nothing looks out of place while using an RTL language.
- [x] Ensure our changes doesn't break LTR layout in any way.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
