### PR TITLE
feat: Update `AndroidManifest.xml` intent filters to support "Open With" on audio files

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -34,15 +34,29 @@
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/BootTheme" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
+        <!-- Expose that we're a music player. -->
         <action android:name="android.intent.action.MAIN"/>
+        <action android:name="android.intent.action.MUSIC_PLAYER"/>
+
+        <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.LAUNCHER"/>
+        <category android:name="android.intent.category.APP_MUSIC"/>
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
+
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="music"/>
-        <data android:scheme="com.cyanchill.missingcore.music"/>
+
+        <!-- Recieve intent from `file://` & `content://` URIs. -->
+        <data android:scheme="content"/>
+        <data android:scheme="file"/>
+
+        <!-- Normal audio mime types + weird mime types -->
+        <data android:mimeType="audio/*"/>
+        <data android:mimeType="application/ogg"/>
+        <data android:mimeType="application/x-ogg"/>
+        <data android:mimeType="application/itunes"/>
       </intent-filter>
     </activity>
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -36,26 +36,26 @@
       <intent-filter>
         <!-- Expose that we're a music player. -->
         <action android:name="android.intent.action.MAIN"/>
-
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.LAUNCHER"/>
         <category android:name="android.intent.category.APP_MUSIC"/>
       </intent-filter>
-      <intent-filter>
+      <intent-filter data-generated="true">
         <action android:name="android.intent.action.VIEW"/>
-
+        <data android:scheme="com.cyanchill.missingcore.music"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-
-        <!-- Recieve intent from `file://` & `content://` URIs. -->
+      </intent-filter>
+      <intent-filter data-generated="true">
+        <action android:name="android.intent.action.VIEW"/>
         <data android:scheme="content"/>
         <data android:scheme="file"/>
-
-        <!-- Normal audio mime types + weird mime types -->
         <data android:mimeType="audio/*"/>
         <data android:mimeType="application/ogg"/>
         <data android:mimeType="application/x-ogg"/>
         <data android:mimeType="application/itunes"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
       </intent-filter>
     </activity>
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -40,11 +40,11 @@
         <category android:name="android.intent.category.LAUNCHER"/>
         <category android:name="android.intent.category.APP_MUSIC"/>
       </intent-filter>
-      <intent-filter data-generated="true">
+      <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
-        <data android:scheme="com.cyanchill.missingcore.music"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="com.cyanchill.missingcore.music"/>
       </intent-filter>
       <intent-filter data-generated="true">
         <action android:name="android.intent.action.VIEW"/>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,6 @@
       <intent-filter>
         <!-- Expose that we're a music player. -->
         <action android:name="android.intent.action.MAIN"/>
-        <action android:name="android.intent.action.MUSIC_PLAYER"/>
 
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -10,6 +10,7 @@ export default (): ExpoConfig => ({
   orientation: "portrait",
   primaryColor: "#C8102E",
   icon: "./assets/icon.png",
+  scheme: ["com.cyanchill.missingcore.music"],
   backgroundColor: "#F2F2F2",
   userInterfaceStyle: "automatic",
   assetBundlePatterns: ["**/*"],
@@ -37,13 +38,6 @@ export default (): ExpoConfig => ({
       {
         action: "MAIN",
         category: ["DEFAULT", "LAUNCHER", "APP_MUSIC"],
-      },
-      // To attempt to launch the app by default after building instead of
-      // an app with the "content" or "uri" schemes.
-      {
-        action: "VIEW",
-        category: ["DEFAULT", "BROWSABLE"],
-        data: [{ scheme: "com.cyanchill.missingcore.music" }],
       },
       // Allows us to "Open With" on music files.
       {

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -10,7 +10,6 @@ export default (): ExpoConfig => ({
   orientation: "portrait",
   primaryColor: "#C8102E",
   icon: "./assets/icon.png",
-  scheme: ["music", "com.cyanchill.missingcore.music"],
   backgroundColor: "#F2F2F2",
   userInterfaceStyle: "automatic",
   assetBundlePatterns: ["**/*"],
@@ -31,6 +30,36 @@ export default (): ExpoConfig => ({
       "android.permission.READ_MEDIA_IMAGES",
       "android.permission.READ_MEDIA_VIDEO",
       "android.permission.READ_MEDIA_VISUAL_USER_SELECTED",
+    ],
+    intentFilters: [
+      // Whenever we rebuild the `AndroidManifest.xml` file, we should delete
+      // the generated "MAIN" intent filter.
+      {
+        action: "MAIN",
+        category: ["DEFAULT", "LAUNCHER", "APP_MUSIC"],
+      },
+      // To attempt to launch the app by default after building instead of
+      // an app with the "content" or "uri" schemes.
+      {
+        action: "VIEW",
+        category: ["DEFAULT", "BROWSABLE"],
+        data: [{ scheme: "com.cyanchill.missingcore.music" }],
+      },
+      // Allows us to "Open With" on music files.
+      {
+        action: "VIEW",
+        category: ["DEFAULT", "BROWSABLE"],
+        data: [
+          // Recieve intent from `file://` & `content://` URIs.
+          { scheme: "content" },
+          { scheme: "file" },
+          // Normal audio mime types + weird mime types we can "Open With".
+          { mimeType: "audio/*" },
+          { mimeType: "application/ogg" },
+          { mimeType: "application/x-ogg" },
+          { mimeType: "application/itunes" },
+        ],
+      },
     ],
   },
   plugins: [

--- a/mobile/src/app/+native-intent.tsx
+++ b/mobile/src/app/+native-intent.tsx
@@ -3,7 +3,8 @@ import { getActualPath } from "@missingcore/react-native-actual-path";
 import { db } from "~/db";
 
 import { playFromMediaList } from "~/modules/media/services/Playback";
-import { ReservedPlaylists } from "~/modules/media/constants";
+
+import { addTrailingSlash } from "~/utils/string";
 
 type Props = {
   path: string;
@@ -28,7 +29,11 @@ export async function redirectSystemPath({ path, initial }: Props) {
 
       if (track) {
         await playFromMediaList({
-          source: { type: "playlist", id: ReservedPlaylists.tracks },
+          source: {
+            type: "folder",
+            // Remove the `file:///` at the front of the uri.
+            id: addTrailingSlash(track.parentFolder!.slice(8)),
+          },
           trackId: track.id,
         });
       }

--- a/mobile/src/app/+native-intent.tsx
+++ b/mobile/src/app/+native-intent.tsx
@@ -47,8 +47,11 @@ async function getTrackFromContentPath(path: string) {
   // 1. See if file uri is part of `path`.
   const [_, ...uriSegments] = path.slice(10).split("/");
   const track = await db.query.tracks.findFirst({
-    where: (fields, { eq }) =>
-      eq(fields.uri, `file:///${uriSegments.join("/")}`),
+    where: (fields, { and, eq, isNull }) =>
+      and(
+        eq(fields.uri, `file:///${uriSegments.join("/")}`),
+        isNull(fields.hiddenAt),
+      ),
   });
   if (track) return track;
 
@@ -56,6 +59,7 @@ async function getTrackFromContentPath(path: string) {
   const derivedPath = await getActualPath(path);
   if (!derivedPath) return;
   return await db.query.tracks.findFirst({
-    where: (fields, { eq }) => eq(fields.uri, `file://${derivedPath}`),
+    where: (fields, { and, eq, isNull }) =>
+      and(eq(fields.uri, `file://${derivedPath}`), isNull(fields.hiddenAt)),
   });
 }

--- a/mobile/src/app/+native-intent.tsx
+++ b/mobile/src/app/+native-intent.tsx
@@ -1,0 +1,33 @@
+type Props = {
+  path: string;
+  initial: boolean;
+};
+
+/**
+ * `expo-router`'s way of handling deep links. In our case, we can use it
+ * to handle:
+ *  - Opening the app via the media notification if the app was dismissed.
+ *    - If we click on the media notification while the app is open, we
+ *    get `initial = false`.
+ *  - Opening the app via "Open With".
+ *
+ * @see https://docs.expo.dev/router/advanced/native-intent/
+ */
+export async function redirectSystemPath({ path, initial }: Props) {
+  try {
+    if (initial) {
+      // Handle when we click on the player notification when we don't have
+      // the app opened.
+      if (path === "trackplayer://notification.click") {
+        return "/";
+      }
+
+      return path;
+    }
+    return path;
+  } catch {
+    // Do not crash inside this function! Instead you should redirect users
+    // to a custom route to handle unexpected errors, where they are able to report the incident
+    return path;
+  }
+}

--- a/mobile/src/app/+native-intent.tsx
+++ b/mobile/src/app/+native-intent.tsx
@@ -60,8 +60,8 @@ export async function redirectSystemPath({ path, initial }: Props) {
 
 /** Get the track that we used "Open With" on. */
 async function getTrackFromContentPath(path: string) {
-  // 1. See if file uri is part of `path`.
-  const [_, ...uriSegments] = path.slice(10).split("/");
+  // 1. See if file uri is part of `path` ((after removing `content://`).
+  const [_referrer, ...uriSegments] = path.slice(10).split("/");
   const track = await db.query.tracks.findFirst({
     where: (fields, { and, eq, isNull }) =>
       and(

--- a/mobile/src/app/+native-intent.tsx
+++ b/mobile/src/app/+native-intent.tsx
@@ -60,7 +60,7 @@ export async function redirectSystemPath({ path, initial }: Props) {
 
 /** Get the track that we used "Open With" on. */
 async function getTrackFromContentPath(path: string) {
-  // 1. See if file uri is part of `path` ((after removing `content://`).
+  // 1. See if file uri is part of `path` (after removing `content://`).
   const [_referrer, ...uriSegments] = path.slice(10).split("/");
   const track = await db.query.tracks.findFirst({
     where: (fields, { and, eq, isNull }) =>

--- a/mobile/src/app/notification.click.tsx
+++ b/mobile/src/app/notification.click.tsx
@@ -1,9 +1,0 @@
-import { Redirect } from "expo-router";
-
-/**
- * Screen if we click the player notification when we don't have the app
- * opened.
- */
-export default function PlayerNotificationClicked() {
-  return <Redirect href="/" />;
-}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds support for opening an audio file with this app when we select "Open With".

### Handling "Open With"
Handling playback from doing an "Open With" isn't straight forwards as it's treated like a deep link in React Native & `expo-router`. `expo-router` handles deep-linking (what the "Open With" does) via the routes, which is annoying. However, there's a [special `+native-intent.tsx` file](https://docs.expo.dev/router/advanced/native-intent/) that we can use to intercept these deep links and rewrite the path.
- This allows us to remove the `notification.click.tsx` route as it was added due to potentially the media notification staying when we closed the app, and when we click on it, we would encounter the "Now Found" route.

From some investigation, the uris returned from the deep link can vary - it could be a content uri with the file path encoded in it, or be a content uri containing the the file id.

The code I have should work with most cases. I did find one case which was with the old default Files app bundled with Android devices which has the "Open With" from the "Downloads" folder referencing a file in the app's cache directory and not the actual location.

### Some Notes
- Main reference is the `AndroidManifest.xml` file of the default Android music app: https://android.googlesource.com/platform/packages/apps/Music/+/jb-release/AndroidManifest.xml.
  - We don't need `android.intent.action.MUSIC_PLAYER` since [`android.intent.category.APP_MUSIC` replaces it since API 15 (Android 4.0.3)](https://developer.android.com/reference/android/provider/MediaStore.html#INTENT_ACTION_MUSIC_PLAYER). 
- "Open With" will only show up for the correct schemes - for having this app show up for audio files, we need the scheme to be `content` & `file` for their respective uri types.
  - We have 2 separate `VIEW` intent filters since after building, Expo would randomly open up the "Contacts" app.
- These intent filters can be added on via the `app.config.ts` file, though the main `MAIN` intent filter doesn't get edited, it just adds another `MAIN` intent filter.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
