### PR TITLE
fix: Scuffed playback when next track naturally plays

### DIFF
--- a/mobile/index.ts
+++ b/mobile/index.ts
@@ -5,7 +5,6 @@ import TrackPlayer from "@weights-ai/react-native-track-player";
 import { registerRootComponent } from "expo";
 
 import App from "./src/App";
-import { setupPlayer } from "./src/lib/react-native-track-player";
 import { PlaybackService } from "./src/services/RNTPService";
 
 registerRootComponent(App);
@@ -14,4 +13,3 @@ registerRootComponent(App);
   `react-native-track-player`.
 */
 TrackPlayer.registerPlaybackService(() => PlaybackService);
-setupPlayer(); // async

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,6 @@
 {
   "name": "music",
   "private": true,
-  "main": "index.ts",
   "version": "2.5.2",
   "description": "A Nothing inspired music player.",
   "license": "AGPL-3.0-only",

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -161,7 +161,8 @@ export async function PlaybackService() {
       resolvedLastPosition = true;
     }
 
-    if (e.index === 1) await TrackPlayer.remove(0);
+    if (e.index === 1) await TrackPlayer.move(1, 0);
+    // if (e.index === 1) await TrackPlayer.remove(0);
     await RNTPManager.reloadNextTrack();
     musicStore.setState({ lastPosition: undefined });
   });

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -162,7 +162,6 @@ export async function PlaybackService() {
     }
 
     if (e.index === 1) await TrackPlayer.remove(0);
-    // if (e.index === 1) await TrackPlayer.remove(0);
     await RNTPManager.reloadNextTrack();
     musicStore.setState({ lastPosition: undefined });
   });

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -161,7 +161,7 @@ export async function PlaybackService() {
       resolvedLastPosition = true;
     }
 
-    if (e.index === 1) await TrackPlayer.move(1, 0);
+    if (e.index === 1) await TrackPlayer.remove(0);
     // if (e.index === 1) await TrackPlayer.remove(0);
     await RNTPManager.reloadNextTrack();
     musicStore.setState({ lastPosition: undefined });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

We had a weird issue that I've recently noticed which is when the next track naturally plays:
- We hear the next track start twice.
- The track plays for a frame, then immediately pauses.
  - This only happens in a specific situation (open the app to the current track not starting at 0s, then letting it naturally play the next track).

`v2.5.2` never had this issue, so it was introduced somewhere in the `next` branch. We ended up narrowing down to the 1st commit to the branch, which is the switch over the React Navigation.

The overall cause in the end was that the `PlaybackService` ended up being registered twice. For some reason, this never happened when using `expo-router`.
- I guess the `setupPlayer()` in the entry file & `useSetup()` hook both managed to set up the RNTP service, causing our issue.

### Other Changes
- Also removed the `main` field in `package.json` as it was [leftover from using `expo-router`](https://docs.expo.dev/router/installation/#setup-entry-point).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
