### PR TITLE
feat: Swipe gestures on miniplayer

### DIFF
--- a/docs/supported-gestures.md
+++ b/docs/supported-gestures.md
@@ -10,6 +10,7 @@ This involves swiping left on some content to reveal actions related to that con
 - **`Filter List Entries`:** You can swipe left to reveal the delete button on an allowlist or blocklist filter. This makes it harder to accidentally delete a filter (as this would require 2 steps to delete) as we've previously not had a modal to confirm the action.
 - **`Queue List`:** You can swipe left on tracks that are part of the queue in the "Upcoming" modal (indicated by the `Q`) to reveal the remove button.
 - **`Playlist Tracks`:** You can swipe left on tracks in the playlist screen or playlist modification screen (create or edit) to reveal an option to remove the track from that playlist.
+- **`Miniplayer`:** Given miniplayer gestures are enabled, swiping on the **text** portion left/right will play the next/prev track.
 
 <table>
   <thead>

--- a/mobile/src/components/BounceSwipe.tsx
+++ b/mobile/src/components/BounceSwipe.tsx
@@ -19,10 +19,10 @@ type BounceSwipeProps = {
   activationThreshold?: number;
   /** Max distance we can swipe (defaults to `48`). */
   swipeThreshold?: number;
-  /** Callback when we swipe fully to the left. */
-  onLeftSwipe?: VoidFunction;
-  /** Callback when we swipe fully to the right. */
-  onRightSwipe?: VoidFunction;
+  /** Callback when we the right indicator is shown. */
+  onLeftIndicatorVisible?: VoidFunction;
+  /** Callback when we the left indicator is shown. */
+  onRightIndicatorVisible?: VoidFunction;
   /** Visual element when swiping left. */
   LeftIndicator?: React.ReactNode;
   /** Visual element when swiping left. */
@@ -48,9 +48,9 @@ export function BounceSwipe({
     })
     .onUpdate(({ absoluteX }) => {
       swipeAmount.value = clamp(
-        props.onLeftSwipe ? -swipeThreshold : 0,
+        props.onLeftIndicatorVisible ? -swipeThreshold : 0,
         absoluteX - initX.value!,
-        props.onRightSwipe ? swipeThreshold : 0,
+        props.onRightIndicatorVisible ? swipeThreshold : 0,
       );
     })
     .onEnd(() => {
@@ -58,8 +58,8 @@ export function BounceSwipe({
 
       if (metThreshold) {
         const usedRightAction = swipeAmount.value < 0;
-        if (usedRightAction) runOnJS(props.onRightSwipe!)();
-        else runOnJS(props.onLeftSwipe!)();
+        if (usedRightAction) runOnJS(props.onRightIndicatorVisible!)();
+        else runOnJS(props.onLeftIndicatorVisible!)();
       }
 
       // Cleanup

--- a/mobile/src/components/BounceSwipe.tsx
+++ b/mobile/src/components/BounceSwipe.tsx
@@ -1,0 +1,89 @@
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  clamp,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+import { cn } from "~/lib/style";
+
+type BounceSwipeProps = {
+  children: React.ReactNode;
+  /** Distance to swipe to trigger an action (defaults to `24`). */
+  activationThreshold?: number;
+  /** Max distance we can swipe (defaults to `48`). */
+  swipeThreshold?: number;
+  /** Callback when we swipe fully to the left. */
+  onLeftSwipe?: VoidFunction;
+  /** Callback when we swipe fully to the right. */
+  onRightSwipe?: VoidFunction;
+  /** Visual element when swiping left. */
+  LeftIndicator?: React.ReactNode;
+  /** Visual element when swiping left. */
+  RightIndicator?: React.ReactNode;
+  className?: string;
+  wrapperClassName?: string;
+};
+
+export function BounceSwipe({
+  activationThreshold = 24,
+  swipeThreshold = 48,
+  ...props
+}: BounceSwipeProps) {
+  const contentHeight = useSharedValue(0);
+  const initX = useSharedValue<number | null>(null);
+  const swipeAmount = useSharedValue(0);
+
+  const swipeGesture = Gesture.Pan()
+    .onStart(({ absoluteX }) => {
+      initX.value = absoluteX;
+    })
+    .onUpdate(({ absoluteX }) => {
+      swipeAmount.value = clamp(
+        props.onLeftSwipe ? -swipeThreshold : 0,
+        absoluteX - initX.value!,
+        props.onRightSwipe ? swipeThreshold : 0,
+      );
+    })
+    .onEnd(() => {
+      const metThreshold = Math.abs(swipeAmount.value) >= activationThreshold;
+
+      if (metThreshold) {
+        const usedRightAction = swipeAmount.value < 0;
+        if (usedRightAction) runOnJS(props.onRightSwipe!)();
+        else runOnJS(props.onLeftSwipe!)();
+      }
+
+      // Cleanup
+      initX.value = null;
+      swipeAmount.value = withTiming(0, { duration: 150 });
+    });
+
+  const containerStyle = useAnimatedStyle(() => ({
+    // Prevent visual layout shift on mount.
+    opacity: contentHeight.value === 0 ? 0 : 1,
+    transform: [
+      { translateX: swipeAmount.value ?? 0 },
+      { translateY: -contentHeight.value / 2 },
+    ],
+  }));
+
+  return (
+    <View className={cn("relative h-full", props.wrapperClassName)}>
+      <GestureDetector gesture={swipeGesture}>
+        <Animated.View
+          onLayout={({ nativeEvent }) => {
+            contentHeight.value = nativeEvent.layout.height;
+          }}
+          style={containerStyle}
+          className={cn("absolute left-0 right-0 top-1/2", props.className)}
+        >
+          <View>{props.children}</View>
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+}

--- a/mobile/src/components/BounceSwipe.tsx
+++ b/mobile/src/components/BounceSwipe.tsx
@@ -5,6 +5,7 @@ import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
+  withDelay,
   withTiming,
 } from "react-native-reanimated";
 
@@ -19,6 +20,12 @@ type BounceSwipeProps = {
   activationThreshold?: number;
   /** Max distance we can swipe (defaults to `48`). */
   swipeThreshold?: number;
+  /**
+   * Delay for the swiped content bounces back. This helps prevent
+   * the animation from freezing if the callback blocks the JS thread.
+   */
+  bounceBackDelay?: number;
+
   /** Callback when we the right indicator is shown. */
   onLeftIndicatorVisible?: VoidFunction;
   /** Callback when we the left indicator is shown. */
@@ -27,6 +34,7 @@ type BounceSwipeProps = {
   LeftIndicator?: React.ReactNode;
   /** Visual element when swiping left. */
   RightIndicator?: React.ReactNode;
+
   className?: string;
   wrapperClassName?: string;
 };
@@ -34,6 +42,7 @@ type BounceSwipeProps = {
 export function BounceSwipe({
   activationThreshold = 32,
   swipeThreshold = 48,
+  bounceBackDelay = 150,
   LeftIndicator = <SwipeIndicator rotate />,
   RightIndicator = <SwipeIndicator />,
   ...props
@@ -64,7 +73,8 @@ export function BounceSwipe({
 
       // Cleanup
       initX.value = null;
-      swipeAmount.value = withTiming(0, { duration: 150 });
+      // Call after a delay in case the callback blocks the JS thread.
+      swipeAmount.value = withDelay(bounceBackDelay, withTiming(0));
     });
 
   const containerStyle = useAnimatedStyle(() => ({

--- a/mobile/src/components/BounceSwipe.tsx
+++ b/mobile/src/components/BounceSwipe.tsx
@@ -8,6 +8,9 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
+import { NothingArrowRight } from "~/resources/icons/NothingArrowRight";
+import { useTheme } from "~/hooks/useTheme";
+
 import { cn } from "~/lib/style";
 
 type BounceSwipeProps = {
@@ -29,8 +32,10 @@ type BounceSwipeProps = {
 };
 
 export function BounceSwipe({
-  activationThreshold = 24,
+  activationThreshold = 32,
   swipeThreshold = 48,
+  LeftIndicator = <SwipeIndicator rotate />,
+  RightIndicator = <SwipeIndicator />,
   ...props
 }: BounceSwipeProps) {
   const contentHeight = useSharedValue(0);
@@ -72,7 +77,9 @@ export function BounceSwipe({
   }));
 
   return (
-    <View className={cn("relative h-full", props.wrapperClassName)}>
+    <View
+      className={cn("relative h-full overflow-hidden", props.wrapperClassName)}
+    >
       <GestureDetector gesture={swipeGesture}>
         <Animated.View
           onLayout={({ nativeEvent }) => {
@@ -81,9 +88,24 @@ export function BounceSwipe({
           style={containerStyle}
           className={cn("absolute left-0 right-0 top-1/2", props.className)}
         >
-          <View>{props.children}</View>
+          <View className="absolute left-0 top-1/2 -translate-x-full -translate-y-1/2">
+            {LeftIndicator}
+          </View>
+          {props.children}
+          <View className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-full">
+            {RightIndicator}
+          </View>
         </Animated.View>
       </GestureDetector>
+    </View>
+  );
+}
+
+function SwipeIndicator({ rotate = false }) {
+  const { foreground } = useTheme();
+  return (
+    <View className={cn("pl-3", { "rotate-180": rotate })}>
+      <NothingArrowRight size={32} color={foreground} />
     </View>
   );
 }

--- a/mobile/src/components/BounceSwipeable.tsx
+++ b/mobile/src/components/BounceSwipeable.tsx
@@ -13,7 +13,7 @@ import Animated, {
 import { NothingArrowRight } from "~/resources/icons/NothingArrowRight";
 import { useTheme } from "~/hooks/useTheme";
 
-import { OnRTLWorklet } from "~/lib/react";
+import { OnRTL, OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 
 type BounceSwipeableProps = {
@@ -136,11 +136,17 @@ export function BounceSwipeable({
           style={containerStyle}
           className={cn("absolute left-0 right-0 top-1/2", props.className)}
         >
-          <View className="absolute left-0 top-1/2 -translate-x-full -translate-y-1/2">
+          <View
+            style={{ [OnRTL.decide("right", "left")]: 0 }}
+            className="absolute top-1/2 -translate-x-full -translate-y-1/2"
+          >
             {LeftIndicator}
           </View>
           {props.children}
-          <View className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-full">
+          <View
+            style={{ [OnRTL.decide("left", "right")]: 0 }}
+            className="absolute top-1/2 -translate-y-1/2 translate-x-full"
+          >
             {RightIndicator}
           </View>
         </Animated.View>
@@ -173,7 +179,9 @@ const ShadowProps = {
 function SwipeIndicator({ rotate = false }) {
   const { foreground } = useTheme();
   return (
-    <View className={cn("pl-3", { "rotate-180": rotate })}>
+    <View
+      className={cn(OnRTL.decide("pr-3", "pl-3"), { "rotate-180": rotate })}
+    >
       <NothingArrowRight size={32} color={foreground} />
     </View>
   );

--- a/mobile/src/components/BounceSwipeable.tsx
+++ b/mobile/src/components/BounceSwipeable.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "~/hooks/useTheme";
 
 import { cn } from "~/lib/style";
 
-type BounceSwipeProps = {
+type BounceSwipeableProps = {
   children: React.ReactNode;
   /** Distance to swipe to trigger an action (defaults to `24`). */
   activationThreshold?: number;
@@ -39,14 +39,14 @@ type BounceSwipeProps = {
   wrapperClassName?: string;
 };
 
-export function BounceSwipe({
+export function BounceSwipeable({
   activationThreshold = 32,
   swipeThreshold = 48,
   bounceBackDelay = 150,
   LeftIndicator = <SwipeIndicator rotate />,
   RightIndicator = <SwipeIndicator />,
   ...props
-}: BounceSwipeProps) {
+}: BounceSwipeableProps) {
   const contentHeight = useSharedValue(0);
   const initX = useSharedValue<number | null>(null);
   const swipeAmount = useSharedValue(0);

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -145,7 +145,7 @@
         "setHomeTab": "Open {{- name}} tab on app launch."
       }
     },
-    "miniplayerGesture": {
+    "miniplayerGestures": {
       "title": "Miniplayer Gestures"
     },
     "nowPlayingDesign": {

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -145,6 +145,9 @@
         "setHomeTab": "Open {{- name}} tab on app launch."
       }
     },
+    "miniplayerGesture": {
+      "title": "Miniplayer Gestures"
+    },
     "nowPlayingDesign": {
       "title": "Now Playing Screen Design",
       "extra": {

--- a/mobile/src/navigation/components/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/MiniPlayer.tsx
@@ -30,19 +30,17 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
   return (
     <Animated.View
       layout={LinearTransition}
-      className={cn("overflow-hidden rounded-md bg-canvas", {
-        "rounded-b-sm": stacked,
-      })}
+      className={cn("overflow-hidden rounded-md", { "rounded-b-sm": stacked })}
     >
       <Pressable
         onPress={() => navigation.navigate("NowPlaying")}
-        className="flex-row items-center bg-surface p-2 active:opacity-75"
+        className="flex-row items-center bg-surface px-2"
       >
         <MediaImage
           type="track"
           size={48}
           source={track.artwork}
-          className="rounded-sm"
+          className="my-2 rounded-sm"
         />
 
         <BounceSwipeable

--- a/mobile/src/navigation/components/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/MiniPlayer.tsx
@@ -48,6 +48,7 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
         <BounceSwipeable
           onLeftIndicatorVisible={MusicControls.prev}
           onRightIndicatorVisible={MusicControls.next}
+          shadowConfig={{ color: "surface" }}
           wrapperClassName="ml-2 shrink grow"
         >
           <Marquee color="surface">

--- a/mobile/src/navigation/components/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/MiniPlayer.tsx
@@ -10,7 +10,7 @@ import { MusicControls } from "~/modules/media/services/Playback";
 import { useIsPlaying } from "~/modules/media/hooks/useIsPlaying";
 
 import { cn } from "~/lib/style";
-import { BounceSwipe } from "~/components/BounceSwipe";
+import { BounceSwipeable } from "~/components/BounceSwipeable";
 import { Marquee } from "~/components/Containment/Marquee";
 import { IconButton } from "~/components/Form/Button";
 import { StyledText } from "~/components/Typography/StyledText";
@@ -45,7 +45,7 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
           className="rounded-sm"
         />
 
-        <BounceSwipe
+        <BounceSwipeable
           onLeftIndicatorVisible={MusicControls.prev}
           onRightIndicatorVisible={MusicControls.next}
           wrapperClassName="ml-2 shrink grow"
@@ -56,7 +56,7 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
           <Marquee color="surface">
             <StyledText dim>{track.artistName ?? "—"}</StyledText>
           </Marquee>
-        </BounceSwipe>
+        </BounceSwipeable>
 
         <IconButton
           Icon={isPlaying ? Pause : PlayArrow}

--- a/mobile/src/navigation/components/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/MiniPlayer.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { Pressable } from "react-native";
 import Animated, { LinearTransition } from "react-native-reanimated";
 
 import { Pause } from "~/resources/icons/Pause";
@@ -9,15 +9,11 @@ import { useMusicStore } from "~/modules/media/services/Music";
 import { MusicControls } from "~/modules/media/services/Playback";
 import { useIsPlaying } from "~/modules/media/hooks/useIsPlaying";
 
-import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
+import { BounceSwipe } from "~/components/BounceSwipe";
 import { Marquee } from "~/components/Containment/Marquee";
 import { IconButton } from "~/components/Form/Button";
 import { StyledText } from "~/components/Typography/StyledText";
-import {
-  NextButton,
-  PreviousButton,
-} from "~/modules/media/components/MediaControls";
 import { MediaImage } from "~/modules/media/components/MediaImage";
 
 /**
@@ -49,29 +45,26 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
           className="rounded-sm"
         />
 
-        <View className="ml-2 shrink grow">
+        <BounceSwipe
+          onLeftSwipe={MusicControls.prev}
+          onRightSwipe={MusicControls.next}
+          wrapperClassName="ml-2 shrink grow"
+        >
           <Marquee color="surface">
             <StyledText>{track.name}</StyledText>
           </Marquee>
           <Marquee color="surface">
             <StyledText dim>{track.artistName ?? "—"}</StyledText>
           </Marquee>
-        </View>
+        </BounceSwipe>
 
-        <View
-          style={{ flexDirection: OnRTL.decide("row-reverse", "row") }}
-          className="items-center"
-        >
-          <PreviousButton />
-          <IconButton
-            Icon={isPlaying ? Pause : PlayArrow}
-            accessibilityLabel={t(`term.${isPlaying ? "pause" : "play"}`)}
-            onPress={MusicControls.playToggle}
-            active
-            large
-          />
-          <NextButton />
-        </View>
+        <IconButton
+          Icon={isPlaying ? Pause : PlayArrow}
+          accessibilityLabel={t(`term.${isPlaying ? "pause" : "play"}`)}
+          onPress={MusicControls.playToggle}
+          active
+          large
+        />
       </Pressable>
     </Animated.View>
   );

--- a/mobile/src/navigation/components/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/MiniPlayer.tsx
@@ -46,8 +46,8 @@ export function MiniPlayer({ hidden = false, stacked = false }) {
         />
 
         <BounceSwipe
-          onLeftSwipe={MusicControls.prev}
-          onRightSwipe={MusicControls.next}
+          onLeftIndicatorVisible={MusicControls.prev}
+          onRightIndicatorVisible={MusicControls.next}
           wrapperClassName="ml-2 shrink grow"
         >
           <Marquee color="surface">

--- a/mobile/src/navigation/screens/settings/AppearanceSettingsView/index.tsx
+++ b/mobile/src/navigation/screens/settings/AppearanceSettingsView/index.tsx
@@ -70,7 +70,7 @@ export default function AppearanceSettings() {
             first
           />
           <ListItem
-            titleKey="feat.miniplayerGesture.title"
+            titleKey="feat.miniplayerGestures.title"
             onPress={toggleMiniplayerGestures}
             switchState={miniplayerGestures}
           />

--- a/mobile/src/navigation/screens/settings/AppearanceSettingsView/index.tsx
+++ b/mobile/src/navigation/screens/settings/AppearanceSettingsView/index.tsx
@@ -19,6 +19,9 @@ export default function AppearanceSettings() {
   const accentFont = useUserPreferencesStore((state) => state.accentFont);
   const primaryFont = useUserPreferencesStore((state) => state.primaryFont);
   const theme = useUserPreferencesStore((state) => state.theme);
+  const miniplayerGestures = useUserPreferencesStore(
+    (state) => state.miniplayerGestures,
+  );
   const nowPlayingDesign = useUserPreferencesStore(
     (state) => state.nowPlayingDesign,
   );
@@ -67,6 +70,11 @@ export default function AppearanceSettings() {
             first
           />
           <ListItem
+            titleKey="feat.miniplayerGesture.title"
+            onPress={toggleMiniplayerGestures}
+            switchState={miniplayerGestures}
+          />
+          <ListItem
             titleKey="feat.nowPlayingDesign.title"
             description={t(`feat.nowPlayingDesign.extra.${nowPlayingDesign}`)}
             onPress={() => nowPlayingDesignSheetRef.current?.present()}
@@ -86,6 +94,11 @@ export default function AppearanceSettings() {
     </>
   );
 }
+
+const toggleMiniplayerGestures = () =>
+  userPreferencesStore.setState((prev) => ({
+    miniplayerGestures: !prev.miniplayerGestures,
+  }));
 
 const toggleIgnoreRTLLayout = () => {
   const nextState = !userPreferencesStore.getState().ignoreRTLLayout;

--- a/mobile/src/resources/icons/NothingArrowRight.tsx
+++ b/mobile/src/resources/icons/NothingArrowRight.tsx
@@ -1,0 +1,19 @@
+import Svg, { Circle } from "react-native-svg";
+
+import { useTheme } from "~/hooks/useTheme";
+import type { Icon } from "./type";
+
+// Custom SVG made in Figma.
+export function NothingArrowRight({ size = 24, color }: Icon) {
+  const { foreground } = useTheme();
+  const usedColor = color ?? foreground;
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill={usedColor}>
+      <Circle cx="9" cy="18" r="1" />
+      <Circle cx="12" cy="15" r="1" />
+      <Circle cx="15" cy="12" r="1" />
+      <Circle cx="12" cy="9" r="1" />
+      <Circle cx="9" cy="6" r="1" />
+    </Svg>
+  );
+}

--- a/mobile/src/services/UserPreferences.ts
+++ b/mobile/src/services/UserPreferences.ts
@@ -51,6 +51,8 @@ interface UserPreferencesStore {
   /** Font used for text. */
   primaryFont: (typeof PrimaryFontOptions)[number];
 
+  /** If we want swipe controls on the miniplayer. */
+  miniplayerGestures: boolean;
   /** Design used for the "Now Playing" screen. */
   nowPlayingDesign: (typeof NowPlayingDesignOptions)[number];
 
@@ -123,6 +125,7 @@ export const userPreferencesStore =
       accentFont: "NType",
       primaryFont: "Roboto",
 
+      miniplayerGestures: false,
       nowPlayingDesign: "vinyl",
 
       homeTab: "home",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds the ability to replace the next/prev buttons on the miniplayer with a swipe gesture on the text-portion of the miniplayer (by default, this is turned off).
- Can be changed via `Miniplayer Gestures` setting in `Settings > Appearance` screen.

You may not be able to swipe again immediately if we switch to a track with large-sized artwork attached.

### Other Changes
- Remove press-styling on miniplayer as it triggers when we start the swipe gesture, which is annoying.
- New `BounceSwipeable` component which is like `Swipeable`, but activates the action on the swipe.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
