### PR TITLE
🧪feat: Experimental restoration of smooth playback transitions

### DIFF
--- a/mobile/src/hooks/useSetup.ts
+++ b/mobile/src/hooks/useSetup.ts
@@ -1,6 +1,7 @@
 import TrackPlayer, { RepeatMode } from "@weights-ai/react-native-track-player";
 import { useEffect, useState } from "react";
 
+import { addPlayedMediaList } from "~/api/recent";
 import { playbackStore, usePlaybackStore } from "~/stores/Playback/store";
 import { preferenceStore, usePreferenceStore } from "~/stores/Preference/store";
 import { useSortPreferencesStore } from "~/modules/media/services/SortPreferences";
@@ -45,7 +46,7 @@ export function useSetup() {
       // immediately hydrated.
       await revalidateWidgets({ openApp: true });
 
-      const { repeat, activeKey } = playbackStore.getState();
+      const { repeat, playingFrom, activeKey } = playbackStore.getState();
       const { restoreLastPosition, continuePlaybackOnDismiss } =
         preferenceStore.getState();
       if (restoreLastPosition) {
@@ -59,6 +60,9 @@ export function useSetup() {
       if (repeat === RepeatModes.REPEAT_ONE) {
         await TrackPlayer.setRepeatMode(RepeatMode.Track);
       }
+
+      // Ensure the current list is at the top of recently played lists.
+      if (playingFrom) await addPlayedMediaList(playingFrom);
 
       setSetupState("ready");
     })();

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -291,10 +291,6 @@
         "stopTime": "Audio will stop playing at {{- time}}."
       }
     },
-    "smoothPlaybackTransition": {
-      "title": "Smooth Playback Transition",
-      "brief": "Hacks into the new playback implementation to have smoother transitions seen pre-v2.7.0."
-    },
     "waveformSlider": {
       "title": "Waveform Slider"
     },

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -227,10 +227,6 @@
         "volume": "App Volume"
       }
     },
-    "ignoreInterrupt": {
-      "title": "Ignore Interruptions",
-      "brief": "Continue playing audio when an interruption such as a notification or a call occurs. You will need to manually pause and unpause the music during these situations."
-    },
     "playbackDelay": {
       "title": "Natural Playback Delay",
       "description": "Delay in seconds before the next track is naturally played."
@@ -283,6 +279,10 @@
       "title": "Continue Playback on Dismiss",
       "description": "Let music playback continue when you dismiss the app from recent tasks. Force stop the app to stop playback."
     },
+    "ignoreInterrupt": {
+      "title": "Ignore Interruptions",
+      "brief": "Continue playing audio when an interruption such as a notification or a call occurs. You will need to manually pause and unpause the music during these situations."
+    },
     "sleepTimer": {
       "title": "Sleep Timer",
       "description": "Stop playing audio after the specified amount of minutes.",
@@ -290,6 +290,10 @@
         "start": "Start",
         "stopTime": "Audio will stop playing at {{- time}}."
       }
+    },
+    "smoothPlaybackTransition": {
+      "title": "Smooth Playback Transition",
+      "brief": "Hacks into the new playback implementation to have smoother transitions seen pre-v2.7.0."
     },
     "waveformSlider": {
       "title": "Waveform Slider"

--- a/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
@@ -12,6 +12,9 @@ export default function ExperimentalSettings() {
     (s) => s.continuePlaybackOnDismiss,
   );
   const ignoreInterrupt = usePreferenceStore((s) => s.ignoreInterrupt);
+  const smoothPlaybackTransition = usePreferenceStore(
+    (s) => s.smoothPlaybackTransition,
+  );
   const waveformSlider = usePreferenceStore((s) => s.waveformSlider);
 
   return (
@@ -29,6 +32,12 @@ export default function ExperimentalSettings() {
           description={t("feat.ignoreInterrupt.brief")}
           onPress={PreferenceTogglers.toggleIgnoreInterrupt}
           switchState={ignoreInterrupt}
+        />
+        <ListItem
+          titleKey="feat.smoothPlaybackTransition.title"
+          description={t("feat.smoothPlaybackTransition.brief")}
+          onPress={PreferenceTogglers.toggleSmoothPlaybackTransition}
+          switchState={smoothPlaybackTransition}
           last
         />
       </List>

--- a/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
@@ -34,8 +34,8 @@ export default function ExperimentalSettings() {
           switchState={ignoreInterrupt}
         />
         <ListItem
-          titleKey="feat.smoothPlaybackTransition.title"
-          description={t("feat.smoothPlaybackTransition.brief")}
+          title="Smooth Playback Transition"
+          description="Restores smooth playback transitions seen pre-v2.7.0. This will eventually become stable. You should disable this if you encounter issues."
           onPress={PreferenceTogglers.toggleSmoothPlaybackTransition}
           switchState={smoothPlaybackTransition}
           last

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -73,10 +73,15 @@ export async function PlaybackService() {
     playbackStore.setState({ lastPosition: e.position });
 
     const { repeat } = playbackStore.getState();
+    const { playbackDelay, smoothPlaybackTransition } =
+      preferenceStore.getState();
     if (
       //? Ignore if we're repeating the current track.
       repeat !== RepeatModes.REPEAT_ONE &&
-      preferenceStore.getState().smoothPlaybackTransition &&
+      //? "Natural Playback Delay" & "Smooth Playback Transition" are mutually
+      //? exclusive features.
+      playbackDelay === 0 &&
+      smoothPlaybackTransition &&
       !smoothTransitionContext.hasLoaded &&
       //? Load the next track 2s before the current track ends to minimize the
       //? need of resynchronizing the next track.

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -192,9 +192,10 @@ export async function PlaybackService() {
     //  - Also when natural playback occurs as `lastPosition` is outdated.
     if (isNaturalPlayback || lastPosition < 10) {
       const activeTrackId: string = e.track.id;
+      const lastPos = isNaturalPlayback ? 0 : lastPosition;
       playbackCountUpdator = BackgroundTimer.setTimeout(
         async () => await addPlayedTrack(activeTrackId),
-        (Math.min(e.track.duration!, 10) - lastPosition) * 1000,
+        (Math.min(e.track.duration!, 10) - lastPos) * 1000,
       );
     }
 

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -148,14 +148,19 @@ export async function PlaybackService() {
 
     //* 🧪 Smooth Playback Transition
     const { smoothPlaybackTransition } = preferenceStore.getState();
+    if (
+      smoothPlaybackTransition &&
+      //? Check for `hasLoaded` as otherwise, the `prev` controls won't work.
+      smoothTransitionContext.hasLoaded &&
+      e.index !== 0
+    ) {
+      const nextTrack = await PlaybackControls.getNextTrack();
+      playbackStore.setState(nextTrack!);
+    }
     smoothTransitionContext = {
       trackDuration: activeTrack!.duration,
       hasLoaded: false,
     };
-    if (smoothPlaybackTransition && e.index !== 0) {
-      const nextTrack = await PlaybackControls.getNextTrack();
-      playbackStore.setState(nextTrack!);
-    }
 
     //* Play Count Tracking
     if (playbackCountUpdator !== null) {

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -139,19 +139,15 @@ export async function PlaybackService() {
 
     // When this triggers for the 1st time, we want to see if we should seek
     // to the last played position.
-    const {
-      _hasRestoredPosition,
-      _restoredTrackKey,
-      lastPosition,
-      activeTrack,
-    } = playbackStore.getState();
+    const { _hasRestoredPosition, _restoredTrackKey, lastPosition } =
+      playbackStore.getState();
 
     //* Restore Last Played Position
     if (!_hasRestoredPosition) {
       playbackStore.setState({ _hasRestoredPosition: true });
       if (
         _restoredTrackKey !== undefined &&
-        extractTrackId(_restoredTrackKey) === activeTrack?.id
+        extractTrackId(_restoredTrackKey) === e.track.id
       ) {
         // Fallback to `0` to support legacy behavior where we could store `undefined`.
         await PlaybackControls.seekTo(lastPosition ?? 0);
@@ -180,7 +176,7 @@ export async function PlaybackService() {
       console.log(err);
     }
     smoothTransitionContext = {
-      trackDuration: activeTrack!.duration,
+      trackDuration: e.track.duration!,
       hasLoaded: false,
     };
     nextTrackInfo = undefined;
@@ -192,9 +188,10 @@ export async function PlaybackService() {
     // Only mark a track as played after we play 10s of it. This prevents
     // the track being marked as "played" if we skip it.
     if (lastPosition < 10) {
+      const activeTrackId: string = e.track.id;
       playbackCountUpdator = BackgroundTimer.setTimeout(
-        async () => await addPlayedTrack(activeTrack!.id),
-        (Math.min(activeTrack!.duration, 10) - lastPosition) * 1000,
+        async () => await addPlayedTrack(activeTrackId),
+        (Math.min(e.track.duration!, 10) - lastPosition) * 1000,
       );
     }
 

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -156,6 +156,7 @@ export async function PlaybackService() {
 
     //* 🧪 Smooth Playback Transition
     const { smoothPlaybackTransition } = preferenceStore.getState();
+    let isNaturalPlayback = false;
     try {
       if (
         smoothPlaybackTransition &&
@@ -164,6 +165,7 @@ export async function PlaybackService() {
         e.index !== 0 &&
         nextTrackInfo
       ) {
+        isNaturalPlayback = true;
         playbackStore.setState(nextTrackInfo);
         // Ensure the RNTP Queue stores a single track.
         await TrackPlayer.remove([...new Array(e.index).keys()]);
@@ -187,7 +189,8 @@ export async function PlaybackService() {
     }
     // Only mark a track as played after we play 10s of it. This prevents
     // the track being marked as "played" if we skip it.
-    if (lastPosition < 10) {
+    //  - Also when natural playback occurs as `lastPosition` is outdated.
+    if (isNaturalPlayback || lastPosition < 10) {
       const activeTrackId: string = e.track.id;
       playbackCountUpdator = BackgroundTimer.setTimeout(
         async () => await addPlayedTrack(activeTrackId),

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -161,6 +161,13 @@ export async function PlaybackService() {
     ) {
       const nextTrack = await PlaybackControls.getNextTrack();
       playbackStore.setState(nextTrack!);
+
+      try {
+        // Ensure the RNTP Queue stores a single track.
+        await TrackPlayer.remove([...new Array(e.index).keys()]);
+      } catch (err) {
+        console.log(err);
+      }
     }
     smoothTransitionContext = {
       trackDuration: activeTrack!.duration,

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -160,21 +160,24 @@ export async function PlaybackService() {
 
     //* 🧪 Smooth Playback Transition
     const { smoothPlaybackTransition } = preferenceStore.getState();
-    if (
-      smoothPlaybackTransition &&
-      //? Check for `hasLoaded` as otherwise, the `prev` controls won't work.
-      smoothTransitionContext.hasLoaded &&
-      e.index !== 0 &&
-      nextTrackInfo
-    ) {
-      playbackStore.setState(nextTrackInfo);
-
-      try {
+    try {
+      if (
+        smoothPlaybackTransition &&
+        //? Check for `hasLoaded` as otherwise, the `prev` controls won't work.
+        smoothTransitionContext.hasLoaded &&
+        e.index !== 0 &&
+        nextTrackInfo
+      ) {
+        playbackStore.setState(nextTrackInfo);
         // Ensure the RNTP Queue stores a single track.
         await TrackPlayer.remove([...new Array(e.index).keys()]);
-      } catch (err) {
-        console.log(err);
+      } else {
+        // Cleans up the RNTP queue if we use the media controls within the
+        // 2s track loading window.
+        await TrackPlayer.removeUpcomingTracks();
       }
+    } catch (err) {
+      console.log(err);
     }
     smoothTransitionContext = {
       trackDuration: activeTrack!.duration,

--- a/mobile/src/stores/Preference/actions/preferenceTogglers.ts
+++ b/mobile/src/stores/Preference/actions/preferenceTogglers.ts
@@ -60,6 +60,12 @@ export function toggleRestoreLastPosition() {
   }));
 }
 
+export function toggleSmoothPlaybackTransition() {
+  preferenceStore.setState((prev) => ({
+    smoothPlaybackTransition: !prev.smoothPlaybackTransition,
+  }));
+}
+
 export function toggleWaveformSlider() {
   preferenceStore.setState((prev) => ({
     waveformSlider: !prev.waveformSlider,

--- a/mobile/src/stores/Preference/constants.ts
+++ b/mobile/src/stores/Preference/constants.ts
@@ -86,6 +86,8 @@ export interface PreferenceStore {
   continuePlaybackOnDismiss: boolean;
   /** Whether we'll continue playback through any interruptions. */
   ignoreInterrupt: boolean;
+  /** Have smooth transitions that was removed with the Playback store rewrite. */
+  smoothPlaybackTransition: boolean;
   /** Utilize a waveform slider on the Now Playing screen. */
   waveformSlider: boolean;
 }

--- a/mobile/src/stores/Preference/constants.ts
+++ b/mobile/src/stores/Preference/constants.ts
@@ -86,7 +86,10 @@ export interface PreferenceStore {
   continuePlaybackOnDismiss: boolean;
   /** Whether we'll continue playback through any interruptions. */
   ignoreInterrupt: boolean;
-  /** Have smooth transitions that was removed with the Playback store rewrite. */
+  /**
+   * Have smooth transitions that was removed with the Playback store
+   * rewrite. The plan is to eventually make this stable.
+   */
   smoothPlaybackTransition: boolean;
   /** Utilize a waveform slider on the Now Playing screen. */
   waveformSlider: boolean;

--- a/mobile/src/stores/Preference/store.ts
+++ b/mobile/src/stores/Preference/store.ts
@@ -69,7 +69,7 @@ export const preferenceStore = createPersistedSubscribedStore<PreferenceStore>(
     //! Experimental Features
     continuePlaybackOnDismiss: false,
     ignoreInterrupt: false,
-    smoothPlaybackTransition: false,
+    smoothPlaybackTransition: true,
     waveformSlider: false,
   }),
   {

--- a/mobile/src/stores/Preference/store.ts
+++ b/mobile/src/stores/Preference/store.ts
@@ -69,6 +69,7 @@ export const preferenceStore = createPersistedSubscribedStore<PreferenceStore>(
     //! Experimental Features
     continuePlaybackOnDismiss: false,
     ignoreInterrupt: false,
+    smoothPlaybackTransition: false,
     waveformSlider: false,
   }),
   {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR restores (experimentally) the smooth natural playback transition (letting the track finish and the app handle playing the next track instead of media controls) that was removed with the playback rewrite in `v2.7.0`.

> [!IMPORTANT]
> This experimental feature is enabled by default as I do want eventually mark this as stable and have this be the behavior going forward. As such, **there won't be any translations for this feature**.

The switch to a single-track queue was to resolve an issue Sentry was detecting when removing the prior track when natural playback occurred and some potential sound bleed when looping back to the 1st track in the queue when repeat mode is turned off.

The restoration of the feature is possible due to our rewrite as we now always listen to the `PlaybackProgressUpdated` event. Essentially:
- We compare the emitted progress to the track duration. If we're 2s from the end of the track, we load the next track into the queue.
  - This prevents needing to resynchronizing the 2nd track, which we done in the previous playback store implementation.
- We don't load the next track in the queue if:
  - We're in "Repeat One" mode (looping the current track).
  - If we set a value for "Natural Playback Delay" as it's a mutually exclusive feature (we can't use "Natural Playback Delay" & "Smooth Playback Transition" at the same time).
  - If the next track is the 1st track in the queue.

This means that the `PlaybackQueueEnded` event will no longer be the main source of playing the next track when we don't interact with the app.
- We will only use this event to play the next track when we have `Natural Playback Delay` set to a non-zero integer.

### Other Changes
- Moving adding the current playing list on app load to `useSetup()` instead of doing it in the 1st `PlaybackActiveTrackChanged` event.
- Moved location of `ignoreInterrupt` translations in the translation file (it's now near where the translations for the experimental features are).

# Testing Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- [x] Ensure we have no sound bleed when looping back to the first track when repeat mode is disabled when the feature is enable & disabled.
- [x] Ensure we have smooth transitions between tracks when the experiment is on.
- [x] Ensure the "Natural Playback Delay" feature takes priority over "Smooth Playback Transition" (since they're mutually exclusive features).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
