### PR TITLE
cherry-pick: Switch to LegendList

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -3,6 +3,7 @@
 | @backpackapp-io/react-native-toast | MIT | https://github.com/backpackapp-io/react-native-toast |
 | @boterop/react-native-background-timer | MIT | https://github.com/boterop/react-native-background-timer |
 | @kaannn/react-native-waveform | MIT | https://github.com/kagantemizkan/react-native-audio-wave |
+| @legendapp/list | MIT | https://github.com/LegendApp/legend-list |
 | @lodev09/react-native-true-sheet | MIT | https://github.com/lodev09/react-native-true-sheet |
 | @lukemorales/query-key-factory | MIT | https://github.com/lukemorales/query-key-factory |
 | @miblanchard/react-native-slider | MIT | https://github.com/miblanchard/react-native-slider |

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -27,6 +27,7 @@
     "@backpackapp-io/react-native-toast": "0.13.0",
     "@boterop/react-native-background-timer": "2.6.0",
     "@kaannn/react-native-waveform": "0.1.4",
+    "@legendapp/list": "^2.0.18",
     "@lodev09/react-native-true-sheet": "2.0.6",
     "@lukemorales/query-key-factory": "1.3.4",
     "@miblanchard/react-native-slider": "github:MissingCore/react-native-slider#4fa4f2097bdabaf4bc3866202debc84482020d5f",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@kaannn/react-native-waveform':
         specifier: 0.1.4
         version: 0.1.4(patch_hash=3081156a19fafea96a43750b5394a0b3fb443f55d943a53aa00387b84e19dbf4)(react-native@0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@legendapp/list':
+        specifier: ^2.0.18
+        version: 2.0.18(react-native@0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@lodev09/react-native-true-sheet':
         specifier: 2.0.6
         version: 2.0.6(react-native@0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1303,6 +1306,12 @@ packages:
 
   '@kaannn/react-native-waveform@0.1.4':
     resolution: {integrity: sha512-kQnkmlQhSxOCH1FE+n5V7RfP5Owsy9gXpCQEuFd0DCFC6J+0sR+00aQHvy81hoDt+Lqg2HbTEcxk8r5aGfmpzg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  '@legendapp/list@2.0.18':
+    resolution: {integrity: sha512-Uo51s+9u+QvQCathLFEckb+OK2eXECuhHo+e+Gn+GlSR4V8tClvCSHOOdagsT/Dsto05jC9Yt5onhqxjLENn7A==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -6867,6 +6876,12 @@ snapshots:
     dependencies:
       react: 19.0.0
       react-native: 0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)
+
+  '@legendapp/list@2.0.18(react-native@0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+      react-native: 0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)
+      use-sync-external-store: 1.6.0(react@19.0.0)
 
   '@lodev09/react-native-true-sheet@2.0.6(react-native@0.79.7(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:

--- a/mobile/src/components/Containment/List.tsx
+++ b/mobile/src/components/Containment/List.tsx
@@ -32,7 +32,7 @@ export function useListPresets<TData extends Record<string, any>>({
 }) {
   return useMemo(
     () => ({
-      estimatedItemSize: 70,
+      getEstimatedItemSize: (index: number) => (index === 0 ? 67 : 70),
       data,
       renderItem: ({ item, index }: { item: TData; index: number }) => (
         <ListItem

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -83,8 +83,6 @@ const WrappedFlashList = cssInterop(RawFlashList, {
   contentContainerClassName: "contentContainerStyle",
 }) as FlashListSignature;
 
-const RawAnimatedFlashList = Animated.createAnimatedComponent(WrappedFlashList);
-
 export function FlashList<T>(props: FlashListProps<T>) {
   return (
     <WrappedFlashList
@@ -101,29 +99,8 @@ export function FlashList<T>(props: FlashListProps<T>) {
   );
 }
 
-export function AnimatedFlashList<T>(props: FlashListProps<T>) {
-  return (
-    // @ts-expect-error - Things are compatible.
-    <RawAnimatedFlashList
-      // To prevent `TypeError: Cannot read property 'y' of undefined`
-      // crash from a list with `numColumns` and `ListEmptyComponent`.
-      key={
-        props.data?.length === 0 && props.numColumns !== undefined
-          ? `empty-list-with-${props.numColumns}-cols`
-          : `non-empty-list-with-${props.numColumns}-cols`
-      }
-      {...ScrollablePresets}
-      {...props}
-    />
-  );
-}
-
 export function useFlashListRef<T = any>() {
   return useRef<RawFlashList<T>>(null);
-}
-
-export function useAnimatedFlashListRef<T = any>() {
-  return useAnimatedRef<RawFlashList<T>>();
 }
 //#endregion
 

--- a/mobile/src/components/Defaults.tsx
+++ b/mobile/src/components/Defaults.tsx
@@ -1,3 +1,9 @@
+import type {
+  LegendListProps as RawLegendListProps,
+  LegendListRef,
+} from "@legendapp/list";
+import { LegendList as RawLegendList } from "@legendapp/list";
+import { AnimatedLegendList as RawAnimatedLegendList } from "@legendapp/list/reanimated";
 import type { FlashListProps as RawFlashListProps } from "@shopify/flash-list";
 import { FlashList as RawFlashList } from "@shopify/flash-list";
 import { cssInterop } from "nativewind";
@@ -13,6 +19,7 @@ import {
 } from "react-native";
 import type { FlashDragListProps } from "react-native-draglist/dist/FlashList";
 import RawFlashDragList from "react-native-draglist/dist/FlashList";
+import type { AnimatedRef } from "react-native-reanimated";
 import Animated, { useAnimatedRef } from "react-native-reanimated";
 
 /** Presets for scrollview-like components. */
@@ -127,5 +134,43 @@ const WrappedFlashDragList = cssInterop(RawFlashDragList, {
 
 export function FlashDragList<T>(props: FlashDragListProps<T>) {
   return <WrappedFlashDragList {...ScrollablePresets} {...props} />;
+}
+//#endregion
+
+//#region LegendList
+type LegendListProps<T> = Omit<RawLegendListProps<T>, "data"> & {
+  ref?: React.Ref<LegendListRef>;
+  data?: readonly T[];
+};
+
+const WrappedLegendList = cssInterop(RawLegendList, {
+  contentContainerClassName: "contentContainerStyle",
+}) as typeof RawLegendList;
+
+const WrappedAnimatedLegendList = cssInterop(RawAnimatedLegendList, {
+  contentContainerClassName: "contentContainerStyle",
+}) as typeof RawAnimatedLegendList;
+
+export function LegendList<T>(props: LegendListProps<T>) {
+  // @ts-expect-error - List internally handles recieving `undefined`.
+  return <WrappedLegendList recycleItems {...ScrollablePresets} {...props} />;
+}
+
+export function AnimatedLegendList<T>(props: LegendListProps<T>) {
+  return (
+    // @ts-expect-error - List internally handles recieving `undefined`.
+    <WrappedAnimatedLegendList recycleItems {...ScrollablePresets} {...props} />
+  );
+}
+
+// @ts-expect-error - Things are compatible.
+export type AnimatedLegendListRef = AnimatedRef<LegendListRef>;
+
+export function useLegendListRef() {
+  return useRef<LegendListRef>(null);
+}
+
+export function useAnimatedLegendListRef() {
+  return useAnimatedRef() as unknown as AnimatedLegendListRef;
 }
 //#endregion

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -1,7 +1,7 @@
+import type { LegendListProps } from "@legendapp/list";
 import { useNavigation } from "@react-navigation/native";
-import type { FlashListProps } from "@shopify/flash-list";
 import { useMemo } from "react";
-import { I18nManager, Pressable } from "react-native";
+import { Pressable } from "react-native";
 
 import { useGetColumn } from "~/hooks/useGetColumn";
 import { getMediaLinkContext } from "~/navigation/utils/router";
@@ -62,7 +62,7 @@ export const MediaCardPlaceholderContent: MediaCardContent = {
 //#region useMediaCardListPreset
 /** Presets used to render a list of `<MediaCard />`. */
 export function useMediaCardListPreset(
-  props: Omit<React.ComponentProps<typeof ContentPlaceholder>, "className"> & {
+  args: Omit<React.ComponentProps<typeof ContentPlaceholder>, "className"> & {
     data?: readonly MediaCardContent[];
     /**
      * Renders a special entry before all other data. This assumes at `data[0]`,
@@ -85,17 +85,17 @@ export function useMediaCardListPreset(
   return useMemo(
     () => ({
       numColumns: count,
-      // ~40px for text content under `<MediaImage />` + 16px Margin Bottom
+      // ~40px for text content under `<MediaImage />` + 12px Margin Bottom
       estimatedItemSize: width + 40 + 12,
-      data: props.data,
+      data: args.data,
       keyExtractor: ({ id, type }) => `${type}_${id}`,
       /*
         Utilized janky margin method to implement gaps in FlashList with columns.
           - https://github.com/shopify/flash-list/discussions/804#discussioncomment-5509022
       */
       renderItem: ({ item, index }) =>
-        props.RenderFirst && index === 0 ? (
-          <props.RenderFirst size={width} className="mx-1.5 mb-3" />
+        args.RenderFirst && index === 0 ? (
+          <args.RenderFirst size={width} className="mx-1.5 mb-3" />
         ) : (
           <MediaCard
             {...item}
@@ -106,16 +106,16 @@ export function useMediaCardListPreset(
         ),
       ListEmptyComponent: (
         <ContentPlaceholder
-          isPending={props.isPending}
-          errMsgKey={props.errMsgKey}
+          isPending={args.isPending}
+          errMsgKey={args.errMsgKey}
         />
       ),
       ListHeaderComponentStyle: { paddingHorizontal: 8 },
       className: "-mx-1.5 -mb-3",
-      /** If in RTL, layout breaks with columns. */
-      disableAutoLayout: I18nManager.isRTL,
     }),
-    [navigation, count, width, props],
-  ) satisfies FlashListProps<MediaCardContent>;
+    [args, navigation, count, width],
+  ) satisfies Omit<LegendListProps<MediaCardContent>, "data"> & {
+    data?: readonly MediaCardContent[];
+  };
 }
 //#endregion

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -1,4 +1,4 @@
-import type { FlashListProps } from "@shopify/flash-list";
+import type { LegendListProps } from "@legendapp/list";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -87,33 +87,35 @@ export function useTrackListPlayingIndication<T extends TrackContent>(
 
 //#region useTrackListPreset
 /** Presets used to render a list of `<Track />`. */
-export function useTrackListPreset(props: {
+export function useTrackListPreset(args: {
   data?: readonly TrackContent[];
   trackSource: PlayFromSource;
   isPending?: boolean;
 }) {
   // @ts-expect-error - Readonly is fine.
-  const data = useTrackListPlayingIndication(props.trackSource, props.data);
+  const data = useTrackListPlayingIndication(args.trackSource, args.data);
   return useMemo(
     () => ({
-      estimatedItemSize: 56, // 48px Height + 8px Margin Top
+      getEstimatedItemSize: (index) => (index === 0 ? 48 : 56),
       data,
       keyExtractor: ({ id }) => id,
       renderItem: ({ item, index }) => (
         <Track
           {...item}
-          trackSource={props.trackSource}
+          trackSource={args.trackSource}
           className={index > 0 ? "mt-2" : undefined}
         />
       ),
       ListEmptyComponent: (
         <ContentPlaceholder
-          isPending={props.isPending}
+          isPending={args.isPending}
           errMsgKey="err.msg.noTracks"
         />
       ),
     }),
-    [props, data],
-  ) satisfies FlashListProps<TrackContent>;
+    [args, data],
+  ) satisfies Omit<LegendListProps<TrackContent>, "data"> & {
+    data?: readonly TrackContent[];
+  };
 }
 //#endregion

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -162,10 +162,10 @@ function SearchResultsList<TScope extends SearchCategories>(
           ) : undefined
         }
         nestedScrollEnabled={props.forSheets}
+        contentContainerClassName="pb-4"
         contentContainerStyle={{
           paddingTop: tabsWithData.length > 0 ? filterHeight : 24,
         }}
-        contentContainerClassName="pb-4"
       />
 
       <LinearGradient

--- a/mobile/src/navigation/layouts/StickyActionScroll.tsx
+++ b/mobile/src/navigation/layouts/StickyActionScroll.tsx
@@ -1,11 +1,10 @@
-import type { FlashList, FlashListProps } from "@shopify/flash-list";
+import type { LegendListProps } from "@legendapp/list";
 import { LinearGradient } from "expo-linear-gradient";
 import type { ParseKeys } from "i18next";
 import { useCallback, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { LayoutChangeEvent } from "react-native";
 import { useWindowDimensions } from "react-native";
-import type { AnimatedRef } from "react-native-reanimated";
 import Animated, {
   FadeIn,
   clamp,
@@ -19,9 +18,10 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 import { useTheme } from "~/hooks/useTheme";
 import { useBottomActionsInset } from "../hooks/useBottomActions";
 
+import type { AnimatedLegendListRef } from "~/components/Defaults";
 import {
-  AnimatedFlashList,
-  useAnimatedFlashListRef,
+  AnimatedLegendList,
+  useAnimatedLegendListRef,
 } from "~/components/Defaults";
 import { Scrollbar, useScrollbarContext } from "~/components/NScrollbar";
 import { AccentText } from "~/components/Typography/AccentText";
@@ -38,7 +38,7 @@ export function StickyActionListLayout<TData>({
   insetDelta = 0,
   showScrollbar = true,
   ...props
-}: Omit<FlashListProps<TData>, "onContentSizeChange" | "onLayout"> & {
+}: Omit<LegendListProps<TData>, "onContentSizeChange" | "onLayout"> & {
   /** Key to title in translations. */
   titleKey: ParseKeys;
   /** Optional action displayed in layout. */
@@ -46,7 +46,7 @@ export function StickyActionListLayout<TData>({
   /** Height of the StickyAction. */
   estimatedActionSize?: number;
   /** Pass a ref to the animated FlashList. */
-  listRef?: AnimatedRef<FlashList<any>>;
+  listRef?: AnimatedLegendListRef;
   /**
    * How much we want to cut away from the bottom inset adjustment. Useful
    * for giving a more accurate `estimatedItemSize` when faking "gaps".
@@ -61,7 +61,7 @@ export function StickyActionListLayout<TData>({
   const bottomInset = useBottomActionsInset();
   const { canvas } = useTheme();
   const quickScroll = usePreferenceStore((s) => s.quickScroll);
-  const internalListRef = useAnimatedFlashListRef();
+  const internalListRef = useAnimatedLegendListRef();
   // @ts-expect-error - Should be able to synchronize refs.
   useImperativeHandle(listRef, () => internalListRef.current);
 
@@ -105,7 +105,7 @@ export function StickyActionListLayout<TData>({
 
   return (
     <>
-      <AnimatedFlashList
+      <AnimatedLegendList
         ref={internalListRef}
         {...layoutHandlers}
         onScroll={scrollHandler}
@@ -121,6 +121,7 @@ export function StickyActionListLayout<TData>({
             {t(titleKey)}
           </AccentText>
         }
+        maintainVisibleContentPosition={false}
         {...props}
         contentContainerStyle={{
           padding: 16,

--- a/mobile/src/navigation/screens/HomeView.tsx
+++ b/mobile/src/navigation/screens/HomeView.tsx
@@ -10,7 +10,7 @@ import { StandardScrollLayout } from "../layouts/StandardScroll";
 
 import { cn } from "~/lib/style";
 import { abbreviateNum } from "~/utils/number";
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 import { Button, IconButton } from "~/components/Form/Button";
 import { AccentText } from "~/components/Typography/AccentText";
 import { TEm, TStyledText } from "~/components/Typography/StyledText";
@@ -52,7 +52,7 @@ function Favorites() {
     RenderFirst: FavoriteTracks,
   });
 
-  return <FlashList {...presets} />;
+  return <LegendList {...presets} />;
 }
 
 /**

--- a/mobile/src/navigation/screens/RecentlyPlayedView.tsx
+++ b/mobile/src/navigation/screens/RecentlyPlayedView.tsx
@@ -15,7 +15,7 @@ import { getMediaLinkContext } from "../utils/router";
 
 import { OnRTL } from "~/lib/react";
 import { queryClient } from "~/lib/react-query";
-import { FlashList } from "~/components/Defaults";
+import { FlashList, LegendList } from "~/components/Defaults";
 import { ReservedPlaylists } from "~/modules/media/constants";
 import { MediaCard } from "~/modules/media/components/MediaCard";
 import type { MediaCardContent } from "~/modules/media/components/MediaCard.type";
@@ -63,8 +63,8 @@ export default function RecentlyPlayed() {
   }
 
   return (
-    <FlashList
-      estimatedItemSize={56} // 48px Height + 8px Margin Top
+    <LegendList
+      getEstimatedItemSize={(index) => (index === 0 ? 48 : 56)}
       data={recentlyPlayedTracks.data}
       keyExtractor={({ id }) => id}
       renderItem={({ item, index }) => (
@@ -91,8 +91,8 @@ function RecentlyPlayedLists(props: { data?: MediaCardContent[] }) {
     gutters: 32,
     minWidth: 100,
   });
-  if (props.data?.length === 0) return null;
 
+  if (props.data?.length === 0) return null;
   return (
     <FlashList
       estimatedItemSize={width + 12} // Column width + gap from padding left

--- a/mobile/src/navigation/screens/albums/CurrentView.tsx
+++ b/mobile/src/navigation/screens/albums/CurrentView.tsx
@@ -1,16 +1,17 @@
 import type { StaticScreenProps } from "@react-navigation/native";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { Favorite } from "~/resources/icons/Favorite";
 import { useAlbumForScreen, useFavoriteAlbum } from "~/queries/album";
+import { usePreferenceStore } from "~/stores/Preference/store";
 import { useBottomActionsInset } from "../../hooks/useBottomActions";
 import { CurrentListLayout } from "../../layouts/CurrentList";
 
 import { mutateGuard } from "~/lib/react-query";
 import { isNumber } from "~/utils/validation";
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { Em, StyledText } from "~/components/Typography/StyledText";
 import {
@@ -35,6 +36,7 @@ export default function Album({
   const bottomInset = useBottomActionsInset();
   const { isPending, error, data } = useAlbumForScreen(albumId);
   const favoriteAlbum = useFavoriteAlbum(albumId);
+  const primaryFont = usePreferenceStore((s) => s.primaryFont);
 
   const trackSource = { type: "album", id: albumId } as const;
   const listData = useTrackListPlayingIndication(trackSource, data?.tracks);
@@ -54,6 +56,14 @@ export default function Album({
 
     return sectionListTracks;
   }, [listData]);
+
+  const guessItemSize = useCallback(
+    (index: number, item: any) => {
+      if (!isNumber(item)) return index === 0 ? 48 : 56;
+      return (primaryFont === "Inter" ? 15 : 14) + (index === 0 ? 0 : 8);
+    },
+    [primaryFont],
+  );
 
   if (isPending || error) return <PagePlaceholder isPending={isPending} />;
 
@@ -89,8 +99,8 @@ export default function Album({
         imageSource={data.imageSource}
         mediaSource={trackSource}
       >
-        <FlashList
-          estimatedItemSize={56} // 48px Height + 8px Margin Top
+        <LegendList
+          getEstimatedItemSize={guessItemSize}
           data={formattedData}
           keyExtractor={(item) => (isNumber(item) ? `${item}` : item.id)}
           getItemType={(item) => (isNumber(item) ? "label" : "row")}

--- a/mobile/src/navigation/screens/artists/CurrentView.tsx
+++ b/mobile/src/navigation/screens/artists/CurrentView.tsx
@@ -11,7 +11,7 @@ import { useBottomActionsInset } from "../../hooks/useBottomActions";
 import { CurrentListLayout } from "../../layouts/CurrentList";
 
 import { OnRTL } from "~/lib/react";
-import { FlashList } from "~/components/Defaults";
+import { FlashList, LegendList } from "~/components/Defaults";
 import { TEm } from "~/components/Typography/StyledText";
 import { MediaCard } from "~/modules/media/components/MediaCard";
 import { useTrackListPreset } from "~/modules/media/components/Track";
@@ -58,7 +58,7 @@ export default function Artist({
         imageSource={data.imageSource}
         mediaSource={trackSource}
       >
-        <FlashList
+        <LegendList
           {...presets}
           ListHeaderComponent={<ArtistAlbums albums={data.albums} />}
           ListEmptyComponent={

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -23,7 +23,7 @@ import { StickyActionListLayout } from "../../layouts/StickyActionScroll";
 import { OnRTL, OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { addTrailingSlash } from "~/utils/string";
-import { useAnimatedFlashListRef } from "~/components/Defaults";
+import { useAnimatedLegendListRef } from "~/components/Defaults";
 import { StyledText } from "~/components/Typography/StyledText";
 import {
   Track,
@@ -45,7 +45,7 @@ export default function Folders({
 }: Props) {
   const navigation = useNavigation();
   const isFocused = useIsFocused();
-  const listRef = useAnimatedFlashListRef();
+  const listRef = useAnimatedLegendListRef();
   const [dirSegments, _setDirSegments] = useState<string[]>([]);
 
   const fullPath = dirSegments.join("/");

--- a/mobile/src/navigation/screens/playlists/CurrentView/index.tsx
+++ b/mobile/src/navigation/screens/playlists/CurrentView/index.tsx
@@ -13,7 +13,7 @@ import { CurrentListLayout } from "../../../layouts/CurrentList";
 import { ExportM3USheet } from "./ExportM3USheet";
 
 import { mutateGuard } from "~/lib/react-query";
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import type { MenuAction } from "~/components/Menu";
 import { useSheetRef } from "~/components/Sheet/useSheetRef";
@@ -89,7 +89,7 @@ export default function Playlist({
         imageSource={data.imageSource}
         mediaSource={trackSource}
       >
-        <FlashList
+        <LegendList
           {...presets}
           contentContainerClassName="px-4 pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}

--- a/mobile/src/navigation/screens/settings/HiddenTracksView.tsx
+++ b/mobile/src/navigation/screens/settings/HiddenTracksView.tsx
@@ -11,7 +11,7 @@ import { VisibilityOff } from "~/resources/icons/VisibilityOff";
 
 import { clearAllQueries } from "~/lib/react-query";
 import { bgWait } from "~/utils/promise";
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 import { IconButton } from "~/components/Form/Button";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 import {
@@ -54,11 +54,12 @@ function ScreenContents(props: {
   }, []);
 
   return (
-    <FlashList
+    <LegendList
       ref={handleOnUnmount}
-      estimatedItemSize={56} // 48px Height + 8px Margin Top
+      getEstimatedItemSize={(index) => (index === 0 ? 48 : 56)}
       data={dataSnapshot}
-      keyExtractor={({ id }) => id}
+      //? Removing the 1st item will lead the new 1st item to have extra top margin.
+      keyExtractor={({ id }, index) => `${id}_${index}`}
       renderItem={({ item, index }) => (
         <SearchResult
           type="track"

--- a/mobile/src/navigation/screens/settings/SaveErrorsView.tsx
+++ b/mobile/src/navigation/screens/settings/SaveErrorsView.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { db } from "~/db";
 
 import { useListPresets } from "~/components/Containment/List";
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 import { ContentPlaceholder } from "../../components/Placeholder";
 
 export default function SaveErrors() {
@@ -17,7 +17,7 @@ export default function SaveErrors() {
   });
 
   return (
-    <FlashList
+    <LegendList
       keyExtractor={({ id }) => id}
       ListEmptyComponent={<ContentPlaceholder errMsgKey="err.msg.noErrors" />}
       contentContainerClassName="p-4"

--- a/mobile/src/navigation/screens/settings/ThirdPartyView.tsx
+++ b/mobile/src/navigation/screens/settings/ThirdPartyView.tsx
@@ -3,7 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import LicensesList from "~/resources/licenses.json";
 
 import { useListPresets } from "~/components/Containment/List";
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 
 export default function ThirdParty() {
   const navigation = useNavigation();
@@ -20,7 +20,7 @@ export default function ThirdParty() {
   });
 
   return (
-    <FlashList
+    <LegendList
       keyExtractor={([id]) => id}
       contentContainerClassName="p-4"
       {...presets}

--- a/mobile/src/navigation/screens/tracks/FavoritesView.tsx
+++ b/mobile/src/navigation/screens/tracks/FavoritesView.tsx
@@ -4,7 +4,7 @@ import { useFavoriteTracksForScreen } from "~/queries/favorite";
 import { useBottomActionsInset } from "../../hooks/useBottomActions";
 import { CurrentListLayout } from "../../layouts/CurrentList";
 
-import { FlashList } from "~/components/Defaults";
+import { LegendList } from "~/components/Defaults";
 import { ReservedPlaylists } from "~/modules/media/constants";
 import { useTrackListPreset } from "~/modules/media/components/Track";
 import { CurrentListMenu } from "../../components/CurrentListMenu";
@@ -43,7 +43,7 @@ export default function FavoriteTracks() {
         imageSource={data.imageSource}
         mediaSource={trackSource}
       >
-        <FlashList
+        <LegendList
           {...presets}
           contentContainerClassName="px-4 pt-4"
           contentContainerStyle={{ paddingBottom: bottomInset.onlyPlayer + 16 }}

--- a/mobile/src/navigation/screens/tracks/Sheet.tsx
+++ b/mobile/src/navigation/screens/tracks/Sheet.tsx
@@ -47,7 +47,7 @@ import {
 } from "~/utils/number";
 import { Card } from "~/components/Containment/Card";
 import { Marquee } from "~/components/Containment/Marquee";
-import { FlashList, ScrollView, useIsScrollable } from "~/components/Defaults";
+import { LegendList, ScrollView, useIsScrollable } from "~/components/Defaults";
 import { Divider } from "~/components/Divider";
 import { Button, IconButton } from "~/components/Form/Button";
 import { Checkbox } from "~/components/Form/Selection";
@@ -386,10 +386,11 @@ function TrackToPlaylistSheet({ id }: { id: string }) {
       titleKey="feat.modalTrack.extra.addToPlaylist"
       snapTop
     >
-      <FlashList
-        estimatedItemSize={58} // 54px Height + 4px Margin Top
+      <LegendList
+        getEstimatedItemSize={(index) => (index === 0 ? 54 : 58)}
         data={data}
         keyExtractor={({ name }) => name}
+        extraData={inList}
         renderItem={({ item, index }) => {
           const selected = inList?.includes(item.name) ?? false;
           return (

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -23,6 +23,14 @@
     "license": "MIT",
     "licenseText": "MIT License\n\nCopyright (c) 2025 Kağan Temizkan\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
+  "@legendapp/list": {
+    "name": "@legendapp/list",
+    "version": "2.0.18",
+    "copyright": "Copyright (c) 2022 Moo.do LLC",
+    "source": "https://github.com/LegendApp/legend-list",
+    "license": "MIT",
+    "licenseText": "MIT License\n\nCopyright (c) 2022 Moo.do LLC\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+  },
   "@lodev09/react-native-true-sheet": {
     "name": "@lodev09/react-native-true-sheet",
     "version": "2.0.6",
@@ -457,7 +465,7 @@
   },
   "react-native-screens": {
     "name": "react-native-screens",
-    "version": "4.19.0",
+    "version": "4.18.0",
     "copyright": "Copyright (c) 2018 Software Mansion <swmansion.com>",
     "source": "https://github.com/software-mansion/react-native-screens",
     "license": "MIT",


### PR DESCRIPTION
> [!IMPORTANT]
> We plan on not moving in this direction (bringing as much down from `dev`) for the potential `v2.9.0` release as we still face those regressions.

This is based off of #357.
- The only difference is with `SearchEngine.tsx`, where we converted it back to FlashList in 244c7c3ee60e66e920334018ea5b90457ce3520b.