### PR TITLE
refactor: Clean up `audio.ts`

### DIFF
--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -4,18 +4,17 @@ import {
 } from "@missingcore/react-native-metadata-retriever";
 import { createId } from "@paralleldrive/cuid2";
 import { eq, inArray, isNotNull, or } from "drizzle-orm";
-import { Directory } from "expo-file-system";
 
 import { db } from "~/db";
-import { albums, artists, playlists, tracks } from "~/db/schema";
+import { albums, tracks } from "~/db/schema";
 
 import { getAlbums, updateAlbum } from "~/api/album";
 import { getTracks, updateTrack } from "~/api/track";
 import { onboardingStore } from "../services/Onboarding";
 
-import { ImageDirectory, deleteImage } from "~/lib/file-system";
+import { ImageDirectory } from "~/lib/file-system";
 import { Stopwatch } from "~/utils/debug";
-import { BATCH_PRESETS, batch } from "~/utils/promise";
+import { BATCH_PRESETS } from "~/utils/promise";
 
 type PartialTrack = {
   id: string;
@@ -24,12 +23,11 @@ type PartialTrack = {
   uri: string;
 };
 
-//#region Saving Function
 /** Save artwork for albums & tracks. */
 export async function findAndSaveArtwork() {
   const stopwatch = new Stopwatch();
 
-  // Ensure we don't unnecessarily seach for artwork.
+  // Ensure we don't unnecessarily search for artwork.
   const albumsWithCovers = await getAlbums({
     columns: ["id"],
     withTracks: false,
@@ -110,27 +108,7 @@ export async function findAndSaveArtwork() {
   );
 }
 
-/** Iterate over a list of tracks, finding and saving its artwork. */
-async function saveSinglesArtwork(
-  singles: PartialTrack[],
-  onSave: (info: { artworkUri: string; trackId: string }) => Promise<void>,
-  options?: { endEarly?: boolean; onEndIteration?: VoidFunction },
-) {
-  for (const { id: trackId, uri } of singles) {
-    // Indicate we attempted to find artwork for a track. Do this before
-    // physically attempting to save the artwork in case an OOM error occurs,
-    // in which the app will essentially become "bricked".
-    await updateTrack(trackId, { fetchedArt: true });
-    const { uri: artworkUri } = await getArtworkUri(uri);
-    if (artworkUri) {
-      await onSave({ artworkUri, trackId });
-      onboardingStore.setState((prev) => ({ found: prev.found + 1 }));
-      if (options?.endEarly) return;
-    }
-    if (options?.onEndIteration) options.onEndIteration();
-  }
-}
-
+//#region Helpers
 /**
  * Create a uri associated with the artwork on the track.
  *
@@ -151,45 +129,25 @@ export async function getArtworkUri(uri: string) {
 }
 //#endregion
 
-//#region Cleanup Function
-export async function cleanupImages() {
-  // Get all the uris of images saved in the database.
-  const usedUris = (
-    await Promise.all([
-      ...[artists, playlists].map((schema) =>
-        db
-          .select({ artwork: schema.artwork })
-          .from(schema)
-          .where(isNotNull(schema.artwork)),
-      ),
-      ...[albums, tracks].flatMap((schema) => [
-        db
-          .select({ artwork: schema.altArtwork })
-          .from(schema)
-          .where(isNotNull(schema.altArtwork)),
-        db
-          .select({ artwork: schema.embeddedArtwork })
-          .from(schema)
-          .where(isNotNull(schema.embeddedArtwork)),
-      ]),
-    ])
-  )
-    .flat()
-    .map(({ artwork }) => artwork!);
-
-  // Get & delete all unused images.
-  let deletedCount = 0;
-  await batch({
-    data: new Directory(ImageDirectory)
-      .list()
-      // There shouldn't be any directories in the "Image Directory".
-      .filter((file) => !usedUris.some((uri) => file.uri === uri)),
-    callback: (image) => deleteImage(image.uri),
-    onBatchComplete: (isFulfilled) => {
-      deletedCount += isFulfilled.length;
-    },
-  });
-
-  console.log(`Deleted ${deletedCount} unlinked images.`);
+//#region Internal Utils
+/** Iterate over a list of tracks, finding and saving its artwork. */
+async function saveSinglesArtwork(
+  singles: PartialTrack[],
+  onSave: (info: { artworkUri: string; trackId: string }) => Promise<void>,
+  options?: { endEarly?: boolean; onEndIteration?: VoidFunction },
+) {
+  for (const { id: trackId, uri } of singles) {
+    // Indicate we attempted to find artwork for a track. Do this before
+    // physically attempting to save the artwork in case an OOM error occurs,
+    // in which the app will essentially become "bricked".
+    await updateTrack(trackId, { fetchedArt: true });
+    const { uri: artworkUri } = await getArtworkUri(uri);
+    if (artworkUri) {
+      await onSave({ artworkUri, trackId });
+      onboardingStore.setState((prev) => ({ found: prev.found + 1 }));
+      if (options?.endEarly) return;
+    }
+    if (options?.onEndIteration) options.onEndIteration();
+  }
 }
 //#endregion

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -2,32 +2,19 @@ import {
   MetadataPresets,
   getMetadata,
 } from "@missingcore/react-native-metadata-retriever";
-import { inArray, lt } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { File } from "expo-file-system";
 import type { Asset as MediaLibraryAsset } from "expo-media-library";
 import { getAssetsAsync } from "expo-media-library";
 
 import { db } from "~/db";
 import type { InvalidTrack } from "~/db/schema";
-import {
-  albums,
-  albumsToArtists,
-  artists,
-  hiddenTracks,
-  invalidTracks,
-  playedMediaLists,
-  tracks,
-  tracksToArtists,
-  tracksToPlaylists,
-  waveformSamples,
-} from "~/db/schema";
+import { invalidTracks, tracks, tracksToArtists } from "~/db/schema";
 
 import { upsertAlbums } from "~/api/album";
 import { AlbumArtistsKey } from "~/api/album.utils";
 import { createArtists } from "~/api/artist";
-import { RECENT_RANGE_MS } from "~/api/recent";
 import { upsertTracks } from "~/api/track";
-import { Queue } from "~/stores/Playback/actions";
 import { preferenceStore } from "~/stores/Preference/store";
 import { onboardingStore } from "../services/Onboarding";
 
@@ -182,82 +169,6 @@ export async function findAndSaveAudio() {
     unstagedFiles: unstagedTracks,
     changed: stats.unstaged,
   };
-}
-//#endregion
-
-//#region Cleanup Functions
-/** Clean up all unused content from a validated list of found content. */
-export async function cleanupDatabase(usedTrackIds: string[]) {
-  // Remove any unused tracks.
-  const unusedTrackIds = (
-    await Promise.all(
-      [hiddenTracks, invalidTracks, tracks].map((sch) =>
-        db.select({ id: sch.id }).from(sch),
-      ),
-    )
-  )
-    .flatMap((ids) => ids.map(({ id }) => id))
-    .filter((id) => !usedTrackIds.includes(id));
-  if (unusedTrackIds.length > 0) {
-    await Promise.allSettled([
-      db.delete(hiddenTracks).where(inArray(hiddenTracks.id, unusedTrackIds)),
-      db.delete(invalidTracks).where(inArray(invalidTracks.id, unusedTrackIds)),
-      db.delete(tracks).where(inArray(tracks.id, unusedTrackIds)),
-      db
-        .delete(tracksToArtists)
-        .where(inArray(tracksToArtists.trackId, unusedTrackIds)),
-      db
-        .delete(tracksToPlaylists)
-        .where(inArray(tracksToPlaylists.trackId, unusedTrackIds)),
-      db
-        .delete(waveformSamples)
-        .where(inArray(waveformSamples.trackId, unusedTrackIds)),
-    ]);
-  }
-
-  // Clear the queue of deleted tracks.
-  await Queue.removeIds(unusedTrackIds);
-
-  // Remove anything else that's unused.
-  await removeUnusedCategories();
-}
-
-/** Remove any albums or artists that aren't used. */
-export async function removeUnusedCategories() {
-  // Remove recently played media that's beyond what we display.
-  await db
-    .delete(playedMediaLists)
-    .where(lt(playedMediaLists.lastPlayedAt, Date.now() - RECENT_RANGE_MS));
-
-  // Remove unused albums.
-  const allAlbums = await db.query.albums.findMany({
-    columns: { id: true },
-    with: { tracks: { columns: { id: true }, limit: 1 } },
-  });
-  const unusedAlbumIds = allAlbums
-    .filter(({ tracks }) => tracks.length === 0)
-    .map(({ id }) => id);
-  await db
-    .delete(albumsToArtists)
-    .where(inArray(albumsToArtists.albumId, unusedAlbumIds));
-  await db.delete(albums).where(inArray(albums.id, unusedAlbumIds));
-
-  // Remove unused artists.
-  const allArtists = await db.query.artists.findMany({
-    columns: { name: true },
-    with: {
-      //? Relations used to filter out artists with no albums & tracks.
-      albumsToArtists: { columns: { albumId: true }, limit: 1 },
-      tracksToArtists: { columns: { trackId: true }, limit: 1 },
-    },
-  });
-  const unusedArtistNames = allArtists
-    .filter(
-      ({ albumsToArtists, tracksToArtists }) =>
-        albumsToArtists.length === 0 && tracksToArtists.length === 0,
-    )
-    .map(({ name }) => name);
-  await db.delete(artists).where(inArray(artists.name, unusedArtistNames));
 }
 //#endregion
 

--- a/mobile/src/modules/scanning/helpers/cleanup.ts
+++ b/mobile/src/modules/scanning/helpers/cleanup.ts
@@ -1,0 +1,51 @@
+import { isNotNull } from "drizzle-orm";
+import { Directory } from "expo-file-system";
+
+import { db } from "~/db";
+import { albums, artists, playlists, tracks } from "~/db/schema";
+
+import { ImageDirectory, deleteImage } from "~/lib/file-system";
+import { batch } from "~/utils/promise";
+
+//#region Artwork
+export async function cleanupImages() {
+  // Get all the uris of images saved in the database.
+  const usedUris = (
+    await Promise.all([
+      ...[artists, playlists].map((schema) =>
+        db
+          .select({ artwork: schema.artwork })
+          .from(schema)
+          .where(isNotNull(schema.artwork)),
+      ),
+      ...[albums, tracks].flatMap((schema) => [
+        db
+          .select({ artwork: schema.altArtwork })
+          .from(schema)
+          .where(isNotNull(schema.altArtwork)),
+        db
+          .select({ artwork: schema.embeddedArtwork })
+          .from(schema)
+          .where(isNotNull(schema.embeddedArtwork)),
+      ]),
+    ])
+  )
+    .flat()
+    .map(({ artwork }) => artwork!);
+
+  // Get & delete all unused images.
+  let deletedCount = 0;
+  await batch({
+    data: new Directory(ImageDirectory)
+      .list()
+      // There shouldn't be any directories in the "Image Directory".
+      .filter((file) => !usedUris.some((uri) => file.uri === uri)),
+    callback: (image) => deleteImage(image.uri),
+    onBatchComplete: (isFulfilled) => {
+      deletedCount += isFulfilled.length;
+    },
+  });
+
+  console.log(`Deleted ${deletedCount} unlinked images.`);
+}
+//#endregion

--- a/mobile/src/modules/scanning/helpers/cleanup.ts
+++ b/mobile/src/modules/scanning/helpers/cleanup.ts
@@ -22,119 +22,128 @@ import { Queue } from "~/stores/Playback/actions";
 import { ImageDirectory, deleteImage } from "~/lib/file-system";
 import { batch } from "~/utils/promise";
 
-//#region Artwork
-export async function cleanupImages() {
-  // Get all the uris of images saved in the database.
-  const usedUris = (
-    await Promise.all([
-      ...[artists, playlists].map((schema) =>
-        db
-          .select({ artwork: schema.artwork })
-          .from(schema)
-          .where(isNotNull(schema.artwork)),
-      ),
-      ...[albums, tracks].flatMap((schema) => [
-        db
-          .select({ artwork: schema.altArtwork })
-          .from(schema)
-          .where(isNotNull(schema.altArtwork)),
-        db
-          .select({ artwork: schema.embeddedArtwork })
-          .from(schema)
-          .where(isNotNull(schema.embeddedArtwork)),
-      ]),
-    ])
-  )
-    .flat()
-    .map(({ artwork }) => artwork!);
-
-  // Get & delete all unused images.
-  let deletedCount = 0;
-  await batch({
-    data: new Directory(ImageDirectory)
-      .list()
-      // There shouldn't be any directories in the "Image Directory".
-      .filter((file) => !usedUris.some((uri) => file.uri === uri)),
-    callback: (image) => deleteImage(image.uri),
-    onBatchComplete: (isFulfilled) => {
-      deletedCount += isFulfilled.length;
-    },
-  });
-
-  console.log(`Deleted ${deletedCount} unlinked images.`);
-}
-//#endregion
-
-/** Clean up all unused content from a validated list of found content. */
-export async function cleanupDatabase(usedTrackIds: string[]) {
-  // Remove any unused tracks.
-  const unusedTrackIds = (
-    await Promise.all(
-      [hiddenTracks, invalidTracks, tracks].map((sch) =>
-        db.select({ id: sch.id }).from(sch),
-      ),
+/** Helper functions for cleaning up content stored by the app. */
+export const AppCleanUp = {
+  /** Clean up images stored by the app but are no longer referenced.  */
+  async images() {
+    // Get all the uris of images saved in the database.
+    const usedUris = (
+      await Promise.all([
+        ...[artists, playlists].map((schema) =>
+          db
+            .select({ artwork: schema.artwork })
+            .from(schema)
+            .where(isNotNull(schema.artwork)),
+        ),
+        ...[albums, tracks].flatMap((schema) => [
+          db
+            .select({ artwork: schema.altArtwork })
+            .from(schema)
+            .where(isNotNull(schema.altArtwork)),
+          db
+            .select({ artwork: schema.embeddedArtwork })
+            .from(schema)
+            .where(isNotNull(schema.embeddedArtwork)),
+        ]),
+      ])
     )
-  )
-    .flatMap((ids) => ids.map(({ id }) => id))
-    .filter((id) => !usedTrackIds.includes(id));
-  if (unusedTrackIds.length > 0) {
-    await Promise.allSettled([
-      db.delete(hiddenTracks).where(inArray(hiddenTracks.id, unusedTrackIds)),
-      db.delete(invalidTracks).where(inArray(invalidTracks.id, unusedTrackIds)),
-      db.delete(tracks).where(inArray(tracks.id, unusedTrackIds)),
-      db
-        .delete(tracksToArtists)
-        .where(inArray(tracksToArtists.trackId, unusedTrackIds)),
-      db
-        .delete(tracksToPlaylists)
-        .where(inArray(tracksToPlaylists.trackId, unusedTrackIds)),
-      db
-        .delete(waveformSamples)
-        .where(inArray(waveformSamples.trackId, unusedTrackIds)),
-    ]);
-  }
+      .flat()
+      .map(({ artwork }) => artwork!);
 
-  // Clear the queue of deleted tracks.
-  await Queue.removeIds(unusedTrackIds);
+    // Get & delete all unused images.
+    let deletedCount = 0;
+    await batch({
+      data: new Directory(ImageDirectory)
+        .list()
+        // There shouldn't be any directories in the "Image Directory".
+        .filter((file) => !usedUris.some((uri) => file.uri === uri)),
+      callback: (image) => deleteImage(image.uri),
+      onBatchComplete: (isFulfilled) => {
+        deletedCount += isFulfilled.length;
+      },
+    });
 
-  // Remove anything else that's unused.
-  await removeUnusedCategories();
-}
+    console.log(`Deleted ${deletedCount} unlinked images.`);
+  },
 
-/** Remove any albums or artists that aren't used. */
-export async function removeUnusedCategories() {
-  // Remove recently played media that's beyond what we display.
-  await db
-    .delete(playedMediaLists)
-    .where(lt(playedMediaLists.lastPlayedAt, Date.now() - RECENT_RANGE_MS));
+  /** Clean up content that's no longer necessary (ie: albums/artists with no tracks). */
+  async media() {
+    // Remove recently played media that's beyond what we display.
+    await db
+      .delete(playedMediaLists)
+      .where(lt(playedMediaLists.lastPlayedAt, Date.now() - RECENT_RANGE_MS));
 
-  // Remove unused albums.
-  const allAlbums = await db.query.albums.findMany({
-    columns: { id: true },
-    with: { tracks: { columns: { id: true }, limit: 1 } },
-  });
-  const unusedAlbumIds = allAlbums
-    .filter(({ tracks }) => tracks.length === 0)
-    .map(({ id }) => id);
-  await db
-    .delete(albumsToArtists)
-    .where(inArray(albumsToArtists.albumId, unusedAlbumIds));
-  await db.delete(albums).where(inArray(albums.id, unusedAlbumIds));
+    // Remove unused albums.
+    const allAlbums = await db.query.albums.findMany({
+      columns: { id: true },
+      with: { tracks: { columns: { id: true }, limit: 1 } },
+    });
+    const unusedAlbumIds = allAlbums
+      .filter(({ tracks }) => tracks.length === 0)
+      .map(({ id }) => id);
+    await db
+      .delete(albumsToArtists)
+      .where(inArray(albumsToArtists.albumId, unusedAlbumIds));
+    await db.delete(albums).where(inArray(albums.id, unusedAlbumIds));
 
-  // Remove unused artists.
-  const allArtists = await db.query.artists.findMany({
-    columns: { name: true },
-    with: {
-      //? Relations used to filter out artists with no albums & tracks.
-      albumsToArtists: { columns: { albumId: true }, limit: 1 },
-      tracksToArtists: { columns: { trackId: true }, limit: 1 },
-    },
-  });
-  const unusedArtistNames = allArtists
-    .filter(
-      ({ albumsToArtists, tracksToArtists }) =>
-        albumsToArtists.length === 0 && tracksToArtists.length === 0,
+    // Remove unused artists.
+    const allArtists = await db.query.artists.findMany({
+      columns: { name: true },
+      with: {
+        //? Relations used to filter out artists with no albums & tracks.
+        albumsToArtists: { columns: { albumId: true }, limit: 1 },
+        tracksToArtists: { columns: { trackId: true }, limit: 1 },
+      },
+    });
+    const unusedArtistNames = allArtists
+      .filter(
+        ({ albumsToArtists, tracksToArtists }) =>
+          albumsToArtists.length === 0 && tracksToArtists.length === 0,
+      )
+      .map(({ name }) => name);
+    await db.delete(artists).where(inArray(artists.name, unusedArtistNames));
+  },
+
+  /**
+   * Clean up tracks which are stored in the database but MediaStore no longer
+   * picks up. Afterwards, revalidates media to see if they're still necessary.
+   */
+  async tracks(foundTrackIds: string[]) {
+    // Get list of ids for tracks in our database that no longer get detected.
+    const foundTrackIdsSet = new Set(foundTrackIds);
+    const unusedTrackIds = (
+      await Promise.all([
+        db.select({ id: hiddenTracks.id }).from(hiddenTracks),
+        db.select({ id: invalidTracks.id }).from(invalidTracks),
+        db.select({ id: tracks.id }).from(tracks),
+      ])
     )
-    .map(({ name }) => name);
-  await db.delete(artists).where(inArray(artists.name, unusedArtistNames));
-}
+      .flatMap((ids) => ids.map(({ id }) => id))
+      .filter((id) => !foundTrackIdsSet.has(id));
+
+    if (unusedTrackIds.length > 0) {
+      await Promise.allSettled([
+        db.delete(hiddenTracks).where(inArray(hiddenTracks.id, unusedTrackIds)),
+        db
+          .delete(invalidTracks)
+          .where(inArray(invalidTracks.id, unusedTrackIds)),
+        db.delete(tracks).where(inArray(tracks.id, unusedTrackIds)),
+        db
+          .delete(tracksToArtists)
+          .where(inArray(tracksToArtists.trackId, unusedTrackIds)),
+        db
+          .delete(tracksToPlaylists)
+          .where(inArray(tracksToPlaylists.trackId, unusedTrackIds)),
+        db
+          .delete(waveformSamples)
+          .where(inArray(waveformSamples.trackId, unusedTrackIds)),
+      ]);
+    }
+
+    // Clear the queue of tracks that no longer exist.
+    await Queue.removeIds(unusedTrackIds);
+
+    // Remove anything else that's unused.
+    await this.media();
+  },
+};

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -11,8 +11,9 @@ import { Resynchronize } from "~/stores/Playback/actions";
 import { clearAllQueries } from "~/lib/react-query";
 import { ToastOptions } from "~/lib/toast";
 import { wait } from "~/utils/promise";
-import { findAndSaveArtwork, cleanupImages } from "./artwork";
+import { findAndSaveArtwork } from "./artwork";
 import { cleanupDatabase, findAndSaveAudio } from "./audio";
+import { cleanupImages } from "./cleanup";
 import { savePathComponents } from "./folder";
 
 /** Look through our library for any new or updated tracks. */

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -12,8 +12,8 @@ import { clearAllQueries } from "~/lib/react-query";
 import { ToastOptions } from "~/lib/toast";
 import { wait } from "~/utils/promise";
 import { findAndSaveArtwork } from "./artwork";
-import { cleanupDatabase, findAndSaveAudio } from "./audio";
-import { cleanupImages } from "./cleanup";
+import { findAndSaveAudio } from "./audio";
+import { cleanupDatabase, cleanupImages } from "./cleanup";
 import { savePathComponents } from "./folder";
 
 /** Look through our library for any new or updated tracks. */

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -13,7 +13,7 @@ import { ToastOptions } from "~/lib/toast";
 import { wait } from "~/utils/promise";
 import { findAndSaveArtwork } from "./artwork";
 import { findAndSaveAudio } from "./audio";
-import { cleanupDatabase, cleanupImages } from "./cleanup";
+import { AppCleanUp } from "./cleanup";
 import { savePathComponents } from "./folder";
 
 /** Look through our library for any new or updated tracks. */
@@ -61,13 +61,13 @@ export async function rescanForTracks(deepScan = false) {
 
     // Rescan library for any new tracks and delete any old ones.
     const { foundFiles, unstagedFiles } = await findAndSaveAudio();
-    await cleanupDatabase(foundFiles.map(({ id }) => id));
+    await AppCleanUp.tracks(foundFiles.map(({ id }) => id));
     // Make sure any modified tracks isn't being played.
     await Resynchronize.onModifiedTracks(unstagedFiles.map(({ id }) => id));
 
     // Find and save any images.
     await findAndSaveArtwork();
-    await cleanupImages();
+    await AppCleanUp.images();
 
     // Ensure queries are all up-to-date.
     clearAllQueries();

--- a/mobile/src/modules/scanning/hooks/useOnboarding.ts
+++ b/mobile/src/modules/scanning/hooks/useOnboarding.ts
@@ -4,12 +4,13 @@ import { useCallback, useEffect, useState } from "react";
 import { Resynchronize } from "~/stores/Playback/actions";
 import { preferenceStore } from "~/stores/Preference/store";
 import { useSetup } from "~/hooks/useSetup";
-import { findAndSaveArtwork, cleanupImages } from "../helpers/artwork";
+import { findAndSaveArtwork } from "../helpers/artwork";
 import {
   findAndSaveAudio,
   cleanupDatabase,
   removeUnusedCategories,
 } from "../helpers/audio";
+import { cleanupImages } from "../helpers/cleanup";
 import { checkForMigrations } from "../helpers/migrations";
 
 import { createImageDirectory } from "~/lib/file-system";

--- a/mobile/src/modules/scanning/hooks/useOnboarding.ts
+++ b/mobile/src/modules/scanning/hooks/useOnboarding.ts
@@ -5,12 +5,12 @@ import { Resynchronize } from "~/stores/Playback/actions";
 import { preferenceStore } from "~/stores/Preference/store";
 import { useSetup } from "~/hooks/useSetup";
 import { findAndSaveArtwork } from "../helpers/artwork";
+import { findAndSaveAudio } from "../helpers/audio";
 import {
-  findAndSaveAudio,
   cleanupDatabase,
+  cleanupImages,
   removeUnusedCategories,
-} from "../helpers/audio";
-import { cleanupImages } from "../helpers/cleanup";
+} from "../helpers/cleanup";
 import { checkForMigrations } from "../helpers/migrations";
 
 import { createImageDirectory } from "~/lib/file-system";

--- a/mobile/src/modules/scanning/hooks/useOnboarding.ts
+++ b/mobile/src/modules/scanning/hooks/useOnboarding.ts
@@ -6,11 +6,7 @@ import { preferenceStore } from "~/stores/Preference/store";
 import { useSetup } from "~/hooks/useSetup";
 import { findAndSaveArtwork } from "../helpers/artwork";
 import { findAndSaveAudio } from "../helpers/audio";
-import {
-  cleanupDatabase,
-  cleanupImages,
-  removeUnusedCategories,
-} from "../helpers/cleanup";
+import { AppCleanUp } from "../helpers/cleanup";
 import { checkForMigrations } from "../helpers/migrations";
 
 import { createImageDirectory } from "~/lib/file-system";
@@ -51,7 +47,7 @@ export function useOnboarding() {
     if (preferenceStore.getState().rescanOnLaunch) {
       // Find and save any audio files to the database.
       const { foundFiles, unstagedFiles } = await findAndSaveAudio();
-      await cleanupDatabase(foundFiles.map(({ id }) => id));
+      await AppCleanUp.tracks(foundFiles.map(({ id }) => id));
       // Make sure any modified tracks isn't being played.
       await Resynchronize.onModifiedTracks(unstagedFiles.map(({ id }) => id));
 
@@ -62,9 +58,9 @@ export function useOnboarding() {
       createImageDirectory();
       await findAndSaveArtwork();
     } else {
-      await removeUnusedCategories();
+      await AppCleanUp.media();
     }
-    await cleanupImages();
+    await AppCleanUp.images();
 
     console.log(`Finished overall in ${stopwatch.stop()}.`);
     setStatus("complete");

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -26,10 +26,8 @@ import { useTrack } from "~/queries/track";
 import { Resynchronize } from "~/stores/Playback/actions";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { removeUnusedCategories } from "~/modules/scanning/helpers/audio";
-import {
-  cleanupImages,
-  getArtworkUri,
-} from "~/modules/scanning/helpers/artwork";
+import { getArtworkUri } from "~/modules/scanning/helpers/artwork";
+import { cleanupImages } from "~/modules/scanning/helpers/cleanup";
 import { FormStateProvider, useFormStateContext } from "~/hooks/useFormState";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -26,10 +26,7 @@ import { useTrack } from "~/queries/track";
 import { Resynchronize } from "~/stores/Playback/actions";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { getArtworkUri } from "~/modules/scanning/helpers/artwork";
-import {
-  cleanupImages,
-  removeUnusedCategories,
-} from "~/modules/scanning/helpers/cleanup";
+import { AppCleanUp } from "~/modules/scanning/helpers/cleanup";
 import { FormStateProvider, useFormStateContext } from "~/hooks/useFormState";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";
@@ -384,8 +381,8 @@ async function onEditTrack(data: TrackMetadata) {
 
     // Revalidate `activeTrack` in Playback store if needed.
     await Resynchronize.onActiveTrack({ type: "track", id });
-    await cleanupImages();
-    await removeUnusedCategories();
+    await AppCleanUp.images();
+    await AppCleanUp.media();
     clearAllQueries();
     router.back();
   } catch {

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -25,9 +25,11 @@ import { updateTrack } from "~/api/track";
 import { useTrack } from "~/queries/track";
 import { Resynchronize } from "~/stores/Playback/actions";
 import { usePreferenceStore } from "~/stores/Preference/store";
-import { removeUnusedCategories } from "~/modules/scanning/helpers/audio";
 import { getArtworkUri } from "~/modules/scanning/helpers/artwork";
-import { cleanupImages } from "~/modules/scanning/helpers/cleanup";
+import {
+  cleanupImages,
+  removeUnusedCategories,
+} from "~/modules/scanning/helpers/cleanup";
 import { FormStateProvider, useFormStateContext } from "~/hooks/useFormState";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -11,7 +11,7 @@ import { deleteTrack } from "~/api/track";
 import { playbackStore } from "~/stores/Playback/store";
 import { PlaybackControls, Queue } from "~/stores/Playback/actions";
 import { preferenceStore } from "~/stores/Preference/store";
-import { removeUnusedCategories } from "~/modules/scanning/helpers/cleanup";
+import { AppCleanUp } from "~/modules/scanning/helpers/cleanup";
 import { router } from "~/navigation/utils/router";
 import { sessionStore } from "./SessionStore";
 
@@ -226,7 +226,7 @@ export async function PlaybackService() {
         await deleteTrack(erroredTrack.id, { errorName: e.code, errorMessage });
         // Attempt to play the next track.
         await Queue.removeIds([erroredTrack.id]);
-        await removeUnusedCategories();
+        await AppCleanUp.media();
         clearAllQueries();
 
         // If the queue is empty as a result of `Queue.removeIds()`, `reset()`

--- a/mobile/src/services/RNTPService.ts
+++ b/mobile/src/services/RNTPService.ts
@@ -11,7 +11,7 @@ import { deleteTrack } from "~/api/track";
 import { playbackStore } from "~/stores/Playback/store";
 import { PlaybackControls, Queue } from "~/stores/Playback/actions";
 import { preferenceStore } from "~/stores/Preference/store";
-import { removeUnusedCategories } from "~/modules/scanning/helpers/audio";
+import { removeUnusedCategories } from "~/modules/scanning/helpers/cleanup";
 import { router } from "~/navigation/utils/router";
 import { sessionStore } from "./SessionStore";
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

From adding multi-artist support for albums & tracks, the `audio.ts` file got a bit harder to read. This PR aims to make the file easier to digest by:
- Breaking out the "cleanup" code to its own file.
- Having `getTrackMetadata` handle splitting by the delimiters.
- Removing the additional complexity from not inserting albums & artists that were previously inserted.
- Add `#region` to the code to make identifying sections easier.

From removing the logic that prevented us from inserting previously inserted albums & artists, we **saw no increase in the time it takes to index tracks for the 1st time**.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
