### PR TITLE
feat: List/Grid/Compact Grid & sorting support on Playlists screen

### DIFF
--- a/mobile/src/components/Form/Button/Icon.tsx
+++ b/mobile/src/components/Form/Button/Icon.tsx
@@ -75,7 +75,7 @@ export const FilledIconButton = memo(function FilledIconButton({
     <Pressable
       {...props}
       className={cn(
-        "items-center justify-center rounded-full bg-surfaceContainerLowest active:bg-surfaceContainerLow disabled:opacity-25",
+        "items-center justify-center rounded-full bg-surfaceContainerLowest active:bg-surfaceContainer disabled:opacity-25",
         buttonSize,
         props.className,
       )}

--- a/mobile/src/navigation/layouts/NScrollListLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollListLayout.tsx
@@ -61,7 +61,7 @@ export function NScrollListLayout<TData>({
   //#endregion
 
   //#region Header Components
-  const [topBarHeight, setTopBarHeight] = useState(0); //? Includes the shadow underneath the header.
+  const [topBarHeight, setTopBarHeight] = useState(154); //? Includes the shadow underneath the header.
   const headerHeight = useMemo(
     () => topBarHeight - SHADOW_HEIGHT,
     [topBarHeight],

--- a/mobile/src/navigation/layouts/NScrollListLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollListLayout.tsx
@@ -23,7 +23,7 @@ import {
   AnimatedLegendList,
   useAnimatedLegendListRef,
 } from "~/components/Defaults";
-import { FilledIconButton, IconButton } from "~/components/Form/Button/Icon";
+import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { TopDownGradient } from "~/components/Gradient";
 import { Marquee } from "~/components/Marquee";
 import { Scrollbar, useScrollbarContext } from "~/components/NScrollbar";
@@ -79,11 +79,6 @@ export function NScrollListLayout<TData>({
     cancelAnimation(translationTimer);
     translationTimer.value = 0;
   }, [headerTranslation, translationTimer, props.numColumns]);
-
-  const IconButtonComponent = useMemo(
-    () => (Actions ? IconButton : FilledIconButton),
-    [Actions],
-  );
   //#endregion
 
   //#region Scroll Animations
@@ -197,7 +192,7 @@ export function NScrollListLayout<TData>({
           </Marquee>
           <View className="flex-row items-center gap-1 rounded-full bg-surfaceContainerLowest">
             {Actions}
-            <IconButtonComponent
+            <FilledIconButton
               Icon={MoreHoriz}
               accessibilityLabel={t("feat.modalViewPreference.title")}
               onPress={() => sheetRef.current?.present()}

--- a/mobile/src/navigation/screens/albums/View.tsx
+++ b/mobile/src/navigation/screens/albums/View.tsx
@@ -20,7 +20,7 @@ export default function Albums() {
     [data, minAlbumLength],
   );
 
-  const sortedData = useViewOrder("album", filteredData, AlbumSortStrategies);
+  const sortedData = useViewOrder("album", filteredData);
   const presets = useViewLayout("album", sortedData, formatData);
 
   return (
@@ -40,14 +40,6 @@ export default function Albums() {
 
 //#region Utils
 type AlbumData = ExtractQueryData<typeof useAlbums>[number];
-
-const AlbumSortStrategies = {
-  name: null,
-  artistName: (a: AlbumData, b: AlbumData) =>
-    a.artistName.localeCompare(b.artistName),
-  duration: (a: AlbumData, b: AlbumData) => a.duration - b.duration,
-  trackCount: (a: AlbumData, b: AlbumData) => a.trackCount - b.trackCount,
-};
 
 function formatData({ id, name, artistName, artwork }: AlbumData) {
   return { id, title: name, description: artistName, imageSource: artwork };

--- a/mobile/src/navigation/screens/artists/View.tsx
+++ b/mobile/src/navigation/screens/artists/View.tsx
@@ -11,11 +11,13 @@ import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 
 import type { ExtractQueryData } from "~/lib/react-query";
 
+type ArtistData = ExtractQueryData<typeof useArtists>[number];
+
 export default function Artists() {
   const { t } = useTranslation();
   const { isPending, data } = useArtists();
 
-  const sortedData = useViewOrder("artist", data, ArtistSortStrategies);
+  const sortedData = useViewOrder("artist", data);
   const formatData = useCallback(
     (item: ArtistData) => ({
       id: item.name,
@@ -41,13 +43,3 @@ export default function Artists() {
     />
   );
 }
-
-//#region Utils
-type ArtistData = ExtractQueryData<typeof useArtists>[number];
-
-const ArtistSortStrategies = {
-  name: null,
-  duration: (a: ArtistData, b: ArtistData) => a.duration - b.duration,
-  trackCount: (a: ArtistData, b: ArtistData) => a.trackCount - b.trackCount,
-};
-//#endregion

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -180,13 +180,13 @@ function BottomAppBar({ trackId }: { trackId: string }) {
           <SleepTimerButton
             present={() => sleepTimerSheetRef.current?.present()}
           />
-          <IconButton
+          <FilledIconButton
             Icon={ViewAgenda}
             accessibilityLabel={t("term.upcoming")}
             onPress={() => navigation.navigate("Upcoming")}
             size="lg"
           />
-          <IconButton
+          <FilledIconButton
             Icon={MoreHoriz}
             accessibilityLabel={t("feat.playback.extra.options")}
             onPress={() => playbackOptionsSheetRef.current?.present()}
@@ -203,7 +203,7 @@ function SleepTimerButton(props: { present: VoidFunction }) {
   const sleepTimerActive = useSleepTimerStore((s) => s.endAt) !== null;
   return (
     <View className="relative">
-      <IconButton
+      <FilledIconButton
         Icon={Timer}
         accessibilityLabel={t("feat.sleepTimer.title")}
         onPress={props.present}

--- a/mobile/src/navigation/screens/playlists/CreateView.tsx
+++ b/mobile/src/navigation/screens/playlists/CreateView.tsx
@@ -3,7 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTranslation } from "react-i18next";
 
-import { useCreatePlaylist, usePlaylists } from "~/queries/playlist";
+import { useCreatePlaylist, usePlaylistsNames } from "~/queries/playlist";
 import { ModifyPlaylistBase } from "./ModifyViewBase";
 
 import { mutateGuardAsync } from "~/lib/react-query";
@@ -12,12 +12,12 @@ import { ToastOptions } from "~/lib/toast";
 export default function CreatePlaylist() {
   const { t } = useTranslation();
   const navigation = useNavigation<NativeStackNavigationProp<any>>();
-  const { data } = usePlaylists();
+  const { data: playlistsNames } = usePlaylistsNames();
   const createPlaylist = useCreatePlaylist();
 
   return (
     <ModifyPlaylistBase
-      usedNames={data?.map(({ name }) => name) ?? []}
+      usedNames={playlistsNames ?? []}
       onSubmit={async (playlistName, tracks) => {
         await mutateGuardAsync(
           createPlaylist,

--- a/mobile/src/navigation/screens/playlists/ModifyView.tsx
+++ b/mobile/src/navigation/screens/playlists/ModifyView.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import { getTrackArtwork } from "~/api/track.utils";
 import {
   usePlaylist,
-  usePlaylists,
+  usePlaylistsNames,
   useUpdatePlaylist,
 } from "~/queries/playlist";
 import { ModifyPlaylistBase } from "./ModifyViewBase";
@@ -25,7 +25,7 @@ export default function ModifyPlaylist({
 }: Props) {
   const { t } = useTranslation();
   const navigation = useNavigation<NativeStackNavigationProp<any>>();
-  const { data: allPlaylists } = usePlaylists();
+  const { data: playlistsNames } = usePlaylistsNames();
   const { data } = usePlaylist(id);
   const updatePlaylist = useUpdatePlaylist(id);
 
@@ -40,7 +40,7 @@ export default function ModifyPlaylist({
   return (
     <ModifyPlaylistBase
       mode="edit"
-      usedNames={allPlaylists?.map(({ name }) => name) ?? []}
+      usedNames={playlistsNames ?? []}
       initialName={id}
       initialTracks={initialTracks}
       onSubmit={async (playlistName, tracks) => {

--- a/mobile/src/navigation/screens/playlists/View.tsx
+++ b/mobile/src/navigation/screens/playlists/View.tsx
@@ -14,11 +14,13 @@ import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 import type { ExtractQueryData } from "~/lib/react-query";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 
+type PlaylistData = ExtractQueryData<typeof usePlaylists>[number];
+
 export default function Playlists() {
   const { t } = useTranslation();
   const { isPending, data } = usePlaylists();
 
-  const sortedData = useViewOrder("playlist", data, PlaylistSortStrategies);
+  const sortedData = useViewOrder("playlist", data);
   const formatData = useCallback(
     (item: PlaylistData) => ({
       id: item.name,
@@ -62,14 +64,4 @@ function PlaylistActions() {
     />
   );
 }
-//#endregion
-
-//#region Utils
-type PlaylistData = ExtractQueryData<typeof usePlaylists>[number];
-
-const PlaylistSortStrategies = {
-  name: null,
-  duration: (a: PlaylistData, b: PlaylistData) => a.duration - b.duration,
-  trackCount: (a: PlaylistData, b: PlaylistData) => a.trackCount - b.trackCount,
-};
 //#endregion

--- a/mobile/src/navigation/screens/playlists/View.tsx
+++ b/mobile/src/navigation/screens/playlists/View.tsx
@@ -1,26 +1,46 @@
 import { useNavigation } from "@react-navigation/native";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Add } from "~/resources/icons/Add";
-import { usePlaylistsForCards } from "~/queries/playlist";
-import { StickyActionListLayout } from "../../layouts/StickyActionScroll";
+import { usePlaylists } from "~/queries/playlist";
+import { useViewLayout } from "~/stores/ViewPreference/hooks/useViewLayout";
+import { useViewOrder } from "~/stores/ViewPreference/hooks/useViewOrder";
 
+import { PlaylistsViewOptionsSheet } from "~/navigation/sheets/ViewOptionsSheet";
+import { NScrollListLayout } from "~/navigation/layouts/NScrollListLayout";
+import { ContentPlaceholder } from "~/navigation/components/Placeholder";
+
+import type { ExtractQueryData } from "~/lib/react-query";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
-import { useMediaCardListPreset } from "~/modules/media/components/MediaCard";
 
 export default function Playlists() {
-  const { isPending, data } = usePlaylistsForCards();
-  const presets = useMediaCardListPreset({
-    data,
-    isPending,
-    errMsgKey: "err.msg.noPlaylists",
-  });
+  const { t } = useTranslation();
+  const { isPending, data } = usePlaylists();
+
+  const sortedData = useViewOrder("playlist", data, PlaylistSortStrategies);
+  const formatData = useCallback(
+    (item: PlaylistData) => ({
+      id: item.name,
+      title: item.name,
+      description: t("plural.track", { count: item.trackCount }),
+      imageSource: item.artwork,
+    }),
+    [t],
+  );
+  const presets = useViewLayout("playlist", sortedData, formatData);
 
   return (
-    <StickyActionListLayout
+    <NScrollListLayout
       titleKey="term.playlists"
-      StickyAction={<PlaylistActions />}
-      estimatedActionSize={48}
+      OptionsSheet={PlaylistsViewOptionsSheet}
+      Actions={<PlaylistActions />}
+      ListEmptyComponent={
+        <ContentPlaceholder
+          isPending={isPending}
+          errMsgKey="err.msg.noPlaylists"
+        />
+      }
       {...presets}
     />
   );
@@ -36,9 +56,20 @@ function PlaylistActions() {
       Icon={Add}
       accessibilityLabel={t("feat.playlist.extra.create")}
       onPress={() => navigation.navigate("CreatePlaylist")}
-      className="rounded-md bg-primary active:bg-primaryDim"
+      className="bg-primary active:bg-primaryDim"
+      size="sm"
       _iconColor="onPrimary"
     />
   );
 }
+//#endregion
+
+//#region Utils
+type PlaylistData = ExtractQueryData<typeof usePlaylists>[number];
+
+const PlaylistSortStrategies = {
+  name: null,
+  duration: (a: PlaylistData, b: PlaylistData) => a.duration - b.duration,
+  trackCount: (a: PlaylistData, b: PlaylistData) => a.trackCount - b.trackCount,
+};
 //#endregion

--- a/mobile/src/navigation/screens/tracks/sheets/TrackToPlaylistsSheet.tsx
+++ b/mobile/src/navigation/screens/tracks/sheets/TrackToPlaylistsSheet.tsx
@@ -1,4 +1,4 @@
-import { usePlaylists } from "~/queries/playlist";
+import { usePlaylistsNames } from "~/queries/playlist";
 import {
   useAddToPlaylist,
   useRemoveFromPlaylist,
@@ -18,7 +18,7 @@ import { StyledText } from "~/components/Typography/StyledText";
 const GLOBAL_SHEET_KEY = "TrackToPlaylistsSheet";
 
 export function TrackToPlaylistsSheet({ id }: { id: string }) {
-  const { data } = usePlaylists();
+  const { data: playlistsNames } = usePlaylistsNames();
   const { data: inList } = useTrackPlaylists(id);
   const addToPlaylist = useAddToPlaylist(id);
   const removeFromPlaylist = useRemoveFromPlaylist(id);
@@ -32,11 +32,11 @@ export function TrackToPlaylistsSheet({ id }: { id: string }) {
     >
       <LegendList
         getEstimatedItemSize={(index) => (index === 0 ? 54 : 62)}
-        data={data}
-        keyExtractor={({ name }) => name}
+        data={playlistsNames}
+        keyExtractor={(name) => name}
         extraData={inList}
-        renderItem={({ item, index }) => {
-          const selected = inList?.includes(item.name) ?? false;
+        renderItem={({ item: name, index }) => {
+          const selected = inList?.includes(name) ?? false;
           return (
             <CheckboxField
               checked={selected}
@@ -44,13 +44,13 @@ export function TrackToPlaylistsSheet({ id }: { id: string }) {
                 mutateGuard(
                   // @ts-expect-error - We don't care about return type.
                   selected ? removeFromPlaylist : addToPlaylist,
-                  item.name,
+                  name,
                 )
               }
               className={index > 0 ? "mt-2" : undefined}
             >
               <Marquee color="surfaceBright">
-                <StyledText>{item.name}</StyledText>
+                <StyledText>{name}</StyledText>
               </Marquee>
             </CheckboxField>
           );

--- a/mobile/src/navigation/sheets/SortSheet.tsx
+++ b/mobile/src/navigation/sheets/SortSheet.tsx
@@ -16,9 +16,12 @@ import {
   SortOptions,
   SortOptionTranslation,
 } from "~/stores/ViewPreference/constants";
-import type { MutableOrder } from "~/stores/ViewPreference/types";
+import type { MutableViewOrder } from "~/stores/ViewPreference/types";
 
-export function SortSheet(props: { ref: TrueSheetRef; screen: MutableOrder }) {
+export function SortSheet(props: {
+  ref: TrueSheetRef;
+  screen: MutableViewOrder;
+}) {
   const isAsc = useViewPreferenceStore((s) => s[`${props.screen}IsAsc`]);
   const orderedBy = useViewPreferenceStore((s) => s[`${props.screen}Order`]);
 

--- a/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
+++ b/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
@@ -12,7 +12,7 @@ import { ViewPreferenceSetters } from "~/stores/ViewPreference/actions";
 
 import { SortSheet } from "~/navigation/sheets/SortSheet";
 
-import { IconButton } from "~/components/Form/Button/Icon";
+import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { NumberStepper } from "~/components/Form/NumberStepper";
 import { SegmentedList } from "~/components/List/Segmented";
 import { DetachedSheet } from "~/components/Sheet/Detached";
@@ -112,9 +112,9 @@ function ScreenLayoutSetting({ screen }: { screen: MutableViewLayout }) {
     <SheetLabelAction
       labelKey="feat.modalViewPreference.extra.layout"
       RightElement={
-        <View className="flex-row gap-2 rounded-full bg-surfaceContainerLowest p-0.5">
+        <View className="flex-row gap-2 rounded-full bg-surfaceContainerLowest">
           {LayoutOptions.map((layout) => (
-            <IconButton
+            <FilledIconButton
               key={layout}
               Icon={LayoutIconMap[layout]}
               accessibilityLabel={t(`feat.modalViewPreference.extra.${layout}`)}

--- a/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
+++ b/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
@@ -20,7 +20,7 @@ import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
 import type { TrueSheetRef } from "~/components/Sheet/useSheetRef";
 import { useSheetRef } from "~/components/Sheet/useSheetRef";
 import { LayoutOptions } from "~/stores/ViewPreference/constants";
-import type { MutableLayout } from "~/stores/ViewPreference/types";
+import type { MutableViewLayout } from "~/stores/ViewPreference/types";
 
 //#region Albums
 export function AlbumsViewOptionsSheet(props: { ref: TrueSheetRef }) {
@@ -90,7 +90,7 @@ const LayoutIconMap = {
   compactGrid: ViewModule,
 } as const;
 
-function ScreenLayoutSetting({ screen }: { screen: MutableLayout }) {
+function ScreenLayoutSetting({ screen }: { screen: MutableViewLayout }) {
   const { t } = useTranslation();
   const layoutOption = useViewPreferenceStore((s) => s[`${screen}Layout`]);
 

--- a/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
+++ b/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
@@ -61,12 +61,26 @@ export function AlbumsViewOptionsSheet(props: { ref: TrueSheetRef }) {
 
 //#region Artists
 export function ArtistsViewOptionsSheet(props: { ref: TrueSheetRef }) {
+  return <ViewOptionsSheetTemplate ref={props.ref} screen="artist" />;
+}
+//#endregion
+
+//#region Playlists
+export function PlaylistsViewOptionsSheet(props: { ref: TrueSheetRef }) {
+  return <ViewOptionsSheetTemplate ref={props.ref} screen="playlist" />;
+}
+//#endregion
+
+//#region Sheet Template
+function ViewOptionsSheetTemplate(props: {
+  ref: TrueSheetRef;
+  screen: MutableViewLayout;
+}) {
   const sortOrderSheetRef = useSheetRef();
   return (
     <>
       <DetachedSheet ref={props.ref}>
-        <ScreenLayoutSetting screen="artist" />
-
+        <ScreenLayoutSetting screen={props.screen} />
         <SegmentedList.Item
           labelTextKey="feat.modalViewPreference.extra.sort"
           onPress={() => {
@@ -77,7 +91,7 @@ export function ArtistsViewOptionsSheet(props: { ref: TrueSheetRef }) {
           className="gap-4"
         />
       </DetachedSheet>
-      <SortSheet ref={sortOrderSheetRef} screen="artist" />
+      <SortSheet ref={sortOrderSheetRef} screen={props.screen} />
     </>
   );
 }

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -167,29 +167,45 @@ export const queries = createQueryKeyStore({
     all: {
       queryKey: null,
       queryFn: () => {
-        return (
-          db
-            .select({
-              name: playlists.name,
-              artwork: playlists.artwork,
-              duration: sum(tracks.duration),
-              trackCount: count(tracks.id),
-              /** We need to unencode this string. */
-              collageArtwork: sql<string>`json_group_array(coalesce(${tracks.artwork}, ${albums.artwork}))`,
-            })
-            .from(playlists)
-            .leftJoin(
-              tracksToPlaylists,
-              eq(tracksToPlaylists.playlistName, playlists.name),
-            )
-            //? Needs to be a `leftJoin` instead of `innerJoin` as if a playlist
-            //? is empty, it'll get removed by this.
-            .leftJoin(tracks, eq(tracks.id, tracksToPlaylists.trackId))
-            .leftJoin(albums, eq(tracks.albumId, albums.id))
-            .groupBy(playlists.name)
-            .where(ne(playlists.name, FavoritesPlaylistKey))
-            .orderBy(iAsc(playlists.name), iAsc(tracksToPlaylists.position))
-        );
+        //? Create a subquery which orders the tracks as `json_group_array` doesn't
+        //? guarantee respecting the order from `orderBy`.
+        const ordered = db
+          .select({
+            playlistName: tracksToPlaylists.playlistName,
+            position: tracksToPlaylists.position,
+            //! For some weird reason, defining this between `playlistName` &
+            //! `position` with `tracksToPlaylists.trackId` results in the
+            //! incorrect order of tracks.
+            trackId: tracks.id,
+            trackDuration: tracks.duration,
+            derivedArtwork: sql<
+              string | null
+            >`coalesce(${tracks.artwork}, ${albums.artwork})`.as(
+              "derived_artwork",
+            ),
+          })
+          .from(tracksToPlaylists)
+          .innerJoin(tracks, eq(tracks.id, tracksToPlaylists.trackId))
+          .leftJoin(albums, eq(tracks.albumId, albums.id))
+          .orderBy(
+            iAsc(tracksToPlaylists.playlistName),
+            iAsc(tracksToPlaylists.position),
+          )
+          .as("ordered");
+        return db
+          .select({
+            name: playlists.name,
+            artwork: playlists.artwork,
+            duration: sum(ordered.trackDuration),
+            trackCount: count(ordered.trackId),
+            /** We need to unencode this string. */
+            collageArtwork: sql<string>`json_group_array(${ordered.derivedArtwork})`,
+          })
+          .from(playlists)
+          .leftJoin(ordered, eq(ordered.playlistName, playlists.name))
+          .groupBy(playlists.name)
+          .where(ne(playlists.name, FavoritesPlaylistKey))
+          .orderBy(iAsc(playlists.name));
       },
     },
     detail: (playlistName: string) => ({

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -185,7 +185,7 @@ export const queries = createQueryKeyStore({
             ),
           })
           .from(tracksToPlaylists)
-          .innerJoin(tracks, eq(tracks.id, tracksToPlaylists.trackId))
+          .innerJoin(tracks, eq(tracksToPlaylists.trackId, tracks.id))
           .leftJoin(albums, eq(tracks.albumId, albums.id))
           .orderBy(
             iAsc(tracksToPlaylists.playlistName),
@@ -202,7 +202,7 @@ export const queries = createQueryKeyStore({
             collageArtwork: sql<string>`json_group_array(${ordered.derivedArtwork})`,
           })
           .from(playlists)
-          .leftJoin(ordered, eq(ordered.playlistName, playlists.name))
+          .leftJoin(ordered, eq(playlists.name, ordered.playlistName))
           .groupBy(playlists.name)
           .where(ne(playlists.name, FavoritesPlaylistKey))
           .orderBy(iAsc(playlists.name));

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -175,9 +175,7 @@ export const queries = createQueryKeyStore({
               duration: sum(tracks.duration),
               trackCount: count(tracks.id),
               /** We need to unencode this string. */
-              collageArtwork: sql<
-                Array<string | null>
-              >`json_group_array(coalesce(${tracks.artwork}, ${albums.artwork}))`,
+              collageArtwork: sql<string>`json_group_array(coalesce(${tracks.artwork}, ${albums.artwork}))`,
             })
             .from(playlists)
             .leftJoin(

--- a/mobile/src/queries/keyStore.ts
+++ b/mobile/src/queries/keyStore.ts
@@ -1,5 +1,5 @@
 import { createQueryKeyStore } from "@lukemorales/query-key-factory";
-import { count, eq, getTableColumns, ne, sum } from "drizzle-orm";
+import { count, eq, getTableColumns, ne, sql, sum } from "drizzle-orm";
 
 import { db } from "~/db";
 import {
@@ -8,6 +8,7 @@ import {
   playlists,
   tracks,
   tracksToArtists,
+  tracksToPlaylists,
 } from "~/db/schema";
 
 import { getAlbum, getAlbums } from "~/api/album";
@@ -165,13 +166,33 @@ export const queries = createQueryKeyStore({
   playlists: {
     all: {
       queryKey: null,
-      queryFn: () =>
-        getPlaylists({
-          where: [ne(playlists.name, FavoritesPlaylistKey)],
-          columns: ["name", "artwork"],
-          trackColumns: ["artwork"],
-          albumColumns: ["artwork"],
-        }),
+      queryFn: () => {
+        return (
+          db
+            .select({
+              name: playlists.name,
+              artwork: playlists.artwork,
+              duration: sum(tracks.duration),
+              trackCount: count(tracks.id),
+              /** We need to unencode this string. */
+              collageArtwork: sql<
+                Array<string | null>
+              >`json_group_array(coalesce(${tracks.artwork}, ${albums.artwork}))`,
+            })
+            .from(playlists)
+            .leftJoin(
+              tracksToPlaylists,
+              eq(tracksToPlaylists.playlistName, playlists.name),
+            )
+            //? Needs to be a `leftJoin` instead of `innerJoin` as if a playlist
+            //? is empty, it'll get removed by this.
+            .leftJoin(tracks, eq(tracks.id, tracksToPlaylists.trackId))
+            .leftJoin(albums, eq(tracks.albumId, albums.id))
+            .groupBy(playlists.name)
+            .where(ne(playlists.name, FavoritesPlaylistKey))
+            .orderBy(iAsc(playlists.name), iAsc(tracksToPlaylists.position))
+        );
+      },
     },
     detail: (playlistName: string) => ({
       queryKey: [playlistName],

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -37,9 +37,12 @@ export function usePlaylistForScreen(playlistName: string) {
   });
 }
 
-/** Get all playlists. */
-export function usePlaylists() {
-  return useQuery({ ...q.playlists.all });
+/** Get the names of all playlists. */
+export function usePlaylistsNames() {
+  return useQuery({
+    ...q.playlists.all,
+    select: (data) => data.map(({ name }) => name),
+  });
 }
 
 /** Return list of `MediaCardContent` from playlists. */

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -49,19 +49,21 @@ export function usePlaylists() {
   return useQuery({
     ...q.playlists.all,
     select: (data) =>
-      data.map(({ collageArtwork, ...playlist }) => {
-        let collage: string[] = [];
-        try {
-          const asArr: Array<string | null> = JSON.parse(collageArtwork);
-          collage = asArr.filter((artwork) => artwork !== null).slice(0, 4);
-        } catch {}
+      data
+        .map(({ collageArtwork, ...playlist }) => {
+          let collage: string[] = [];
+          try {
+            const asArr: Array<string | null> = JSON.parse(collageArtwork);
+            collage = asArr.filter((artwork) => artwork !== null).slice(0, 4);
+          } catch {}
 
-        return {
-          ...playlist,
-          duration: Number(playlist.duration) || 0,
-          artwork: playlist.artwork ?? collage,
-        };
-      }),
+          return {
+            ...playlist,
+            duration: Number(playlist.duration) || 0,
+            artwork: playlist.artwork ?? collage,
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name)),
   });
 }
 //#endregion

--- a/mobile/src/queries/playlist.ts
+++ b/mobile/src/queries/playlist.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
 import type { playlists } from "~/db/schema";
-import { formatForCurrentScreen, formatForMediaCard } from "~/db/utils";
+import { formatForCurrentScreen } from "~/db/utils";
 
 import {
   createPlaylist,
@@ -45,15 +45,23 @@ export function usePlaylistsNames() {
   });
 }
 
-/** Return list of `MediaCardContent` from playlists. */
-export function usePlaylistsForCards() {
-  const { t } = useTranslation();
+export function usePlaylists() {
   return useQuery({
     ...q.playlists.all,
     select: (data) =>
-      data.map((playlist) =>
-        formatForMediaCard({ type: "playlist", data: playlist, t }),
-      ),
+      data.map(({ collageArtwork, ...playlist }) => {
+        let collage: string[] = [];
+        try {
+          const asArr: Array<string | null> = JSON.parse(collageArtwork);
+          collage = asArr.filter((artwork) => artwork !== null).slice(0, 4);
+        } catch {}
+
+        return {
+          ...playlist,
+          duration: Number(playlist.duration) || 0,
+          artwork: playlist.artwork ?? collage,
+        };
+      }),
   });
 }
 //#endregion

--- a/mobile/src/stores/ViewPreference/actions/setters.ts
+++ b/mobile/src/stores/ViewPreference/actions/setters.ts
@@ -1,12 +1,12 @@
 import { viewPreferenceStore } from "../store";
 import type { LayoutOption, ScreenSortOptions } from "../constants";
-import type { MutableLayout, MutableOrder } from "../types";
+import type { MutableViewLayout, MutableViewOrder } from "../types";
 
-export function setLayout(screen: MutableLayout, layout: LayoutOption) {
+export function setLayout(screen: MutableViewLayout, layout: LayoutOption) {
   viewPreferenceStore.setState({ [`${screen}Layout`]: layout });
 }
 
-export function setSortOrder<TScreen extends MutableOrder>(
+export function setSortOrder<TScreen extends MutableViewOrder>(
   screen: TScreen,
   sortOrder: ScreenSortOptions<TScreen>,
 ) {

--- a/mobile/src/stores/ViewPreference/actions/togglers.ts
+++ b/mobile/src/stores/ViewPreference/actions/togglers.ts
@@ -1,7 +1,7 @@
 import { viewPreferenceStore } from "../store";
-import type { MutableOrder } from "../types";
+import type { MutableViewOrder } from "../types";
 
-export function toggleIsAsc(screen: MutableOrder) {
+export function toggleIsAsc(screen: MutableViewOrder) {
   const key = `${screen}IsAsc` as const;
   viewPreferenceStore.setState((prev) => ({ [key]: !prev[key] }));
 }

--- a/mobile/src/stores/ViewPreference/constants.ts
+++ b/mobile/src/stores/ViewPreference/constants.ts
@@ -12,11 +12,11 @@ export type LayoutOption = (typeof LayoutOptions)[number];
 type SortOption =
   | "name"
   | "artistName"
-  | "albumName"
+  // | "albumName"
   | "duration"
-  | "trackCount"
-  | "discoverTime"
-  | "lastModified";
+  | "trackCount";
+// | "discoverTime"
+// | "modificationTime";
 
 export const SortOptions = {
   album: ["name", "artistName", "duration", "trackCount"],
@@ -27,12 +27,22 @@ export const SortOptions = {
 export type ScreenSortOptions<TScreen extends MutableViewOrder> =
   (typeof SortOptions)[TScreen][number];
 
+export type SortOptionTypeMap = {
+  name: string;
+  artistName: string | null;
+  // albumName: string | null;
+  duration: number;
+  trackCount: number;
+  // discoverTime: number;
+  // modificationTime: number;
+};
+
 export const SortOptionTranslation = {
-  albumName: "term.album",
+  // albumName: "term.album",
   artistName: "term.artist",
-  discoverTime: "feat.modalViewPreference.extra.discover",
+  // discoverTime: "feat.modalViewPreference.extra.discover",
   duration: "feat.modalViewPreference.extra.duration",
-  lastModified: "feat.modalViewPreference.extra.modified",
+  // modificationTime: "feat.modalViewPreference.extra.modified",
   name: "feat.trackMetadata.extra.name",
   trackCount: "feat.modalViewPreference.extra.trackCount",
 } as const satisfies Record<SortOption, ParseKeys>;

--- a/mobile/src/stores/ViewPreference/constants.ts
+++ b/mobile/src/stores/ViewPreference/constants.ts
@@ -21,6 +21,7 @@ type SortOption =
 export const SortOptions = {
   album: ["name", "artistName", "duration", "trackCount"],
   artist: ["name", "duration", "trackCount"],
+  playlist: ["name", "duration", "trackCount"],
 } as const satisfies Record<MutableOrder, SortOption[]>;
 
 export type ScreenSortOptions<TScreen extends MutableOrder> =
@@ -51,6 +52,10 @@ export interface ViewPreferenceStore {
   artistLayout: LayoutOption;
   artistIsAsc: boolean;
   artistOrder: ScreenSortOptions<"artist">;
+
+  playlistLayout: LayoutOption;
+  playlistIsAsc: boolean;
+  playlistOrder: ScreenSortOptions<"album">;
 }
 
 export const OmittedFields: string[] = [

--- a/mobile/src/stores/ViewPreference/constants.ts
+++ b/mobile/src/stores/ViewPreference/constants.ts
@@ -1,6 +1,6 @@
 import type { ParseKeys } from "i18next";
 
-import type { MutableOrder } from "./types";
+import type { MutableViewOrder } from "./types";
 
 //#region Layout
 export const LayoutOptions = ["list", "grid", "compactGrid"] as const;
@@ -22,9 +22,9 @@ export const SortOptions = {
   album: ["name", "artistName", "duration", "trackCount"],
   artist: ["name", "duration", "trackCount"],
   playlist: ["name", "duration", "trackCount"],
-} as const satisfies Record<MutableOrder, SortOption[]>;
+} as const satisfies Record<MutableViewOrder, SortOption[]>;
 
-export type ScreenSortOptions<TScreen extends MutableOrder> =
+export type ScreenSortOptions<TScreen extends MutableViewOrder> =
   (typeof SortOptions)[TScreen][number];
 
 export const SortOptionTranslation = {

--- a/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
@@ -74,7 +74,9 @@ export function useViewLayout<TData extends Record<string, any>>(
         <MediaCard
           type={screen}
           {...item}
-          source={item.imageSource}
+          //? Simplest way of solving the type issue (we'll only pass an
+          //? array if `screen = "playlist"`).
+          source={item.imageSource as string}
           size={gridOpts.width}
           onPress={() =>
             navigation.navigate(

--- a/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import type { GCWProps } from "~/hooks/useGetColumn";
 import { useGetColumn } from "~/hooks/useGetColumn";
 import { useViewPreferenceStore } from "../store";
-import type { LayoutItem, MutableLayout } from "../types";
+import type { LayoutItem, MutableViewLayout } from "../types";
 
 import { getMediaLinkContext } from "~/navigation/utils/router";
 
@@ -28,7 +28,7 @@ const compactGridLayoutOptions: GCWProps = {
 
 /** Formats data to pass into `LegendList`. */
 export function useViewLayout<TData extends Record<string, any>>(
-  screen: MutableLayout,
+  screen: MutableViewLayout,
   data: TData[] = [],
   formatData: (data: TData) => LayoutItem,
 ) {

--- a/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
@@ -22,7 +22,7 @@ export function useViewOrder<
 
     const sortedResults = [...dataCache.current];
     //? By default, data should be sorted by the `name` field.
-    if (orderBy !== "name" && sortedResults.length > 0) {
+    if (orderBy !== "name") {
       sortedResults.sort((a, b) => {
         if (orderBy === "artistName") {
           // Put `null` values at the start of the array.

--- a/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
@@ -2,11 +2,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useViewPreferenceStore } from "../store";
 import type { ScreenSortOptions } from "../constants";
-import type { MutableOrder } from "../types";
+import type { MutableViewOrder } from "../types";
 
 /** Orders the data based on the screen. */
 export function useViewOrder<
-  TScreen extends MutableOrder,
+  TScreen extends MutableViewOrder,
   TData extends Record<string, any>,
 >(
   screen: TScreen,

--- a/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useViewPreferenceStore } from "../store";
-import type { ScreenSortOptions } from "../constants";
+import type { ScreenSortOptions, SortOptionTypeMap } from "../constants";
 import type { MutableViewOrder } from "../types";
 
 /** Orders the data based on the screen. */
 export function useViewOrder<
   TScreen extends MutableViewOrder,
-  TData extends Record<ScreenSortOptions<TScreen>, any>,
+  TData extends Pick<SortOptionTypeMap, ScreenSortOptions<TScreen>>,
 >(screen: TScreen, data: TData[] = []) {
   const isAsc = useViewPreferenceStore((s) => s[`${screen}IsAsc`]);
   const orderBy = useViewPreferenceStore((s) => s[`${screen}Order`]);
@@ -23,13 +23,16 @@ export function useViewOrder<
     const sortedResults = [...dataCache.current];
     //? By default, data should be sorted by the `name` field.
     if (orderBy !== "name" && sortedResults.length > 0) {
-      const dataType = typeof sortedResults[0]?.[orderBy];
-      if (dataType === "number" || dataType === "string") {
-        sortedResults.sort((a, b) => {
-          if (dataType === "number") return a[orderBy] - b[orderBy];
-          return a[orderBy].localeCompare(b[orderBy]);
-        });
-      }
+      sortedResults.sort((a, b) => {
+        if (orderBy === "artistName") {
+          // Put `null` values at the start of the array.
+          if (a[orderBy] === null) return -1;
+          else if (b[orderBy] === null) return 1;
+          return (a[orderBy] as string).localeCompare(b[orderBy] as string);
+        } else {
+          return (a[orderBy] as number) - (b[orderBy] as number);
+        }
+      });
     }
     if (!isAsc) sortedResults.reverse();
 

--- a/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
@@ -7,16 +7,8 @@ import type { MutableViewOrder } from "../types";
 /** Orders the data based on the screen. */
 export function useViewOrder<
   TScreen extends MutableViewOrder,
-  TData extends Record<string, any>,
->(
-  screen: TScreen,
-  data: TData[] = [],
-  /** `null` strategy should only be used for the default order. */
-  sortStrategies: Record<
-    ScreenSortOptions<TScreen>,
-    ((a: TData, b: TData) => number) | null
-  >,
-) {
+  TData extends Record<ScreenSortOptions<TScreen>, any>,
+>(screen: TScreen, data: TData[] = []) {
   const isAsc = useViewPreferenceStore((s) => s[`${screen}IsAsc`]);
   const orderBy = useViewPreferenceStore((s) => s[`${screen}Order`]);
   const [cachedComputation, setCachedComputation] = useState<
@@ -29,14 +21,21 @@ export function useViewOrder<
     if (cachedComputation[cacheKey]) return cachedComputation[cacheKey];
 
     const sortedResults = [...dataCache.current];
-    if (sortStrategies[orderBy] !== null) {
-      sortedResults.sort(sortStrategies[orderBy]);
+    //? By default, data should be sorted by the `name` field.
+    if (orderBy !== "name" && sortedResults.length > 0) {
+      const dataType = typeof sortedResults[0]?.[orderBy];
+      if (dataType === "number" || dataType === "string") {
+        sortedResults.sort((a, b) => {
+          if (dataType === "number") return a[orderBy] - b[orderBy];
+          return a[orderBy].localeCompare(b[orderBy]);
+        });
+      }
     }
     if (!isAsc) sortedResults.reverse();
 
     setCachedComputation((prev) => ({ ...prev, [cacheKey]: sortedResults }));
     return sortedResults;
-  }, [isAsc, orderBy, sortStrategies, cachedComputation]);
+  }, [isAsc, orderBy, cachedComputation]);
 
   useEffect(() => {
     if (data !== dataCache.current) {

--- a/mobile/src/stores/ViewPreference/store.ts
+++ b/mobile/src/stores/ViewPreference/store.ts
@@ -18,6 +18,10 @@ export const viewPreferenceStore = createPersistedStore<ViewPreferenceStore>(
     artistLayout: "list",
     artistIsAsc: true,
     artistOrder: "name",
+
+    playlistLayout: "grid",
+    playlistIsAsc: true,
+    playlistOrder: "name",
   }),
   {
     name: "music::view-preferences",

--- a/mobile/src/stores/ViewPreference/types.ts
+++ b/mobile/src/stores/ViewPreference/types.ts
@@ -6,7 +6,7 @@ export type LayoutItem = {
   id: string;
   title: string;
   description: string;
-  imageSource: string | null;
+  imageSource: string | null | Array<string | null>;
 };
 
 /** Screens where the order of the content can be change. */

--- a/mobile/src/stores/ViewPreference/types.ts
+++ b/mobile/src/stores/ViewPreference/types.ts
@@ -1,5 +1,5 @@
 /** Screens where the layout of the content can be change. */
-export type MutableLayout = "album" | "artist" | "playlist";
+export type MutableViewLayout = "album" | "artist" | "playlist";
 
 /** Fields that get rendered in our mutable layout. */
 export type LayoutItem = {
@@ -10,4 +10,4 @@ export type LayoutItem = {
 };
 
 /** Screens where the order of the content can be change. */
-export type MutableOrder = "album" | "artist" | "playlist";
+export type MutableViewOrder = "album" | "artist" | "playlist";

--- a/mobile/src/stores/ViewPreference/types.ts
+++ b/mobile/src/stores/ViewPreference/types.ts
@@ -1,5 +1,5 @@
 /** Screens where the layout of the content can be change. */
-export type MutableLayout = "album" | "artist";
+export type MutableLayout = "album" | "artist" | "playlist";
 
 /** Fields that get rendered in our mutable layout. */
 export type LayoutItem = {
@@ -10,4 +10,4 @@ export type LayoutItem = {
 };
 
 /** Screens where the order of the content can be change. */
-export type MutableOrder = "album" | "artist";
+export type MutableOrder = "album" | "artist" | "playlist";


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR follows #395, but for the Playlists screen. This is the last screen to have layout options (List/Grid/Compact Grid) and the first to use the `Actions` prop on `NScrollListLayout`.

For this, we had to get a bit creative with the database query - was a bit surprised that we could return an "array" field (technically as a JSON string) contained the artwork URIs sorted by the track position with a query + subquery.
- Renamed the old `usePlaylists()` to `usePlaylistsNames()` since that was what we used that query for.

### Other Changes

- Fixed issue where loading indicator didn't show up on `NScrollListLayout`.
  - This was due to the indicator rendering behind the header shadow.
- Changed the "press" color on the `FilledIconButton` for better contrast against the base button color.
  - We will now always render `FilledIconButton` for the `NScrollListLayout` header.
  - We swapped some uses of `IconButton` on a container colored `surfaceContainerLowest` to `FilledIconButton` due to the better press contrast.
- Removed `sortStrategies` argument in `useViewOrder()` and add better type-safety (since we know we'll sort on string or number fields).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
