### PR TITLE
chore: Have folders screen use new layout

### DIFF
--- a/mobile/src/navigation/hooks/useBottomActions.ts
+++ b/mobile/src/navigation/hooks/useBottomActions.ts
@@ -1,5 +1,6 @@
 import type { NavigationRoute, ParamListBase } from "@react-navigation/native";
 import { useNavigationState } from "@react-navigation/native";
+import { useMemo } from "react";
 
 import { usePlaybackStore } from "~/stores/Playback/store";
 
@@ -52,12 +53,13 @@ export function useBottomActionsInset() {
   //? if the miniplayer is rendered.
   const isMiniPlayerRendered = !!activeTrack;
 
-  // Bottom inset on home screen.
-  let withNav = 76; // 60px Navbar Height + 16px Bottom Padding
-  if (isMiniPlayerRendered) withNav += 67; // 64px MiniPlayer Height + 3px Gap
-  // Bottom inset on screens with only MiniPlayer.
-  let onlyPlayer = 0;
-  if (isMiniPlayerRendered) onlyPlayer += 80; // 64px MiniPlayer Height + 16px Bottom Padding
-
-  return { withNav, onlyPlayer };
+  return useMemo(() => {
+    // Bottom inset on home screen.
+    let withNav = 76; // 60px Navbar Height + 16px Bottom Padding
+    if (isMiniPlayerRendered) withNav += 67; // 64px MiniPlayer Height + 3px Gap
+    // Bottom inset on screens with only MiniPlayer.
+    let onlyPlayer = 0;
+    if (isMiniPlayerRendered) onlyPlayer += 80; // 64px MiniPlayer Height + 16px Bottom Padding
+    return { withNav, onlyPlayer };
+  }, [isMiniPlayerRendered]);
 }

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -1,6 +1,12 @@
 import type { LegendListProps } from "@legendapp/list";
 import type { ParseKeys } from "i18next";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import type { ViewStyle } from "react-native";
 import { View } from "react-native";
@@ -23,6 +29,7 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 
 import { useBottomActionsInset } from "~/navigation/hooks/useBottomActions";
 
+import type { AnimatedLegendListRef } from "~/components/Defaults";
 import {
   AnimatedLegendList,
   AnimatedScrollView,
@@ -115,12 +122,14 @@ export function NScrollLayout(props: {
 /** LegendList with "shy header" and `NScrollbar`. */
 export function NScrollListLayout<TData>({
   titleKey,
+  listRef,
   OptionsSheet,
   Actions,
   Subheader,
   ...props
 }: Omit<LegendListProps<TData>, "onContentSizeChange" | "onLayout"> & {
   titleKey: ParseKeys;
+  listRef?: AnimatedLegendListRef;
   OptionsSheet?: (props: { ref: TrueSheetRef }) => React.JSX.Element;
   /** Additional "actions" which will appear before the "Screen Options" button. */
   Actions?: React.ReactNode;
@@ -131,6 +140,8 @@ export function NScrollListLayout<TData>({
   const insets = useSafeAreaInsets();
   const bottomInset = useBottomActionsInset();
   const internalListRef = useAnimatedLegendListRef();
+  // @ts-expect-error - Should be able to synchronize refs.
+  useImperativeHandle(listRef, () => internalListRef.current);
   const sheetRef = useSheetRef();
 
   // NScrollbar

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -121,7 +121,7 @@ export function NScrollListLayout<TData>({
   ...props
 }: Omit<LegendListProps<TData>, "onContentSizeChange" | "onLayout"> & {
   titleKey: ParseKeys;
-  OptionsSheet: (props: { ref: TrueSheetRef }) => React.JSX.Element;
+  OptionsSheet?: (props: { ref: TrueSheetRef }) => React.JSX.Element;
   /** Additional "actions" which will appear before the "Screen Options" button. */
   Actions?: React.ReactNode;
 }) {
@@ -150,14 +150,10 @@ export function NScrollListLayout<TData>({
     resetOn: props.numColumns,
   });
 
-  return (
-    <View className="relative flex-1">
-      <OptionsSheet ref={sheetRef} />
-      <ShyHeader
-        titleKey={titleKey}
-        getTrueHeight={setTopBarHeight}
-        style={shyHeaderContext.headerStyle}
-      >
+  const RenderedHeaderActions = useMemo(() => {
+    if (!Actions && !OptionsSheet) return null;
+    return (
+      <>
         {Actions}
         <FilledIconButton
           Icon={MoreHoriz}
@@ -165,6 +161,19 @@ export function NScrollListLayout<TData>({
           onPress={() => sheetRef.current?.present()}
           size="sm"
         />
+      </>
+    );
+  }, [t, Actions, OptionsSheet, sheetRef]);
+
+  return (
+    <View className="relative flex-1">
+      {OptionsSheet ? <OptionsSheet ref={sheetRef} /> : null}
+      <ShyHeader
+        titleKey={titleKey}
+        getTrueHeight={setTopBarHeight}
+        style={shyHeaderContext.headerStyle}
+      >
+        {RenderedHeaderActions}
       </ShyHeader>
 
       <AnimatedLegendList

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -76,9 +76,8 @@ export function NScrollLayout(props: {
         titleKey={props.titleKey}
         getTrueHeight={setTopBarHeight}
         style={shyHeaderContext.headerStyle}
-      >
-        {props.Actions}
-      </ShyHeader>
+        Actions={props.Actions}
+      />
 
       <AnimatedScrollView
         // @ts-expect-error - We can pass refs since React 19.
@@ -118,12 +117,15 @@ export function NScrollListLayout<TData>({
   titleKey,
   OptionsSheet,
   Actions,
+  Subheader,
   ...props
 }: Omit<LegendListProps<TData>, "onContentSizeChange" | "onLayout"> & {
   titleKey: ParseKeys;
   OptionsSheet?: (props: { ref: TrueSheetRef }) => React.JSX.Element;
   /** Additional "actions" which will appear before the "Screen Options" button. */
   Actions?: React.ReactNode;
+  /** Component rendered after the header but before the shadow. */
+  Subheader?: React.ReactNode;
 }) {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -172,8 +174,9 @@ export function NScrollListLayout<TData>({
         titleKey={titleKey}
         getTrueHeight={setTopBarHeight}
         style={shyHeaderContext.headerStyle}
+        Actions={RenderedHeaderActions}
       >
-        {RenderedHeaderActions}
+        {Subheader}
       </ShyHeader>
 
       <AnimatedLegendList
@@ -212,7 +215,7 @@ function ShyHeader(props: {
   titleKey: ParseKeys;
   getTrueHeight: (height: number) => void;
   style: AnimatedStyle<ViewStyle>;
-  /** These are the "actions" that get rendered next to the title. */
+  Actions?: React.ReactNode;
   children?: React.ReactNode;
 }) {
   const { t } = useTranslation();
@@ -231,12 +234,13 @@ function ShyHeader(props: {
         <Marquee>
           <AccentText className="text-4xl">{t(props.titleKey)}</AccentText>
         </Marquee>
-        {props.children ? (
+        {props.Actions ? (
           <View className="flex-row items-center gap-1 rounded-full bg-surfaceContainerLowest">
-            {props.children}
+            {props.Actions}
           </View>
         ) : null}
       </View>
+      {props.children}
       <TopDownGradient height={SHADOW_HEIGHT} />
     </Animated.View>
   );

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -238,20 +238,19 @@ function ShyHeader(props: {
       style={props.style}
       className="absolute top-0 left-0 z-50 w-full"
     >
-      <View
-        style={{ paddingTop: insets.top + 32 }}
-        className="flex-row items-center justify-between gap-4 bg-surface px-4"
-      >
-        <Marquee>
-          <AccentText className="text-4xl">{t(props.titleKey)}</AccentText>
-        </Marquee>
-        {props.Actions ? (
-          <View className="flex-row items-center gap-1 rounded-full bg-surfaceContainerLowest">
-            {props.Actions}
-          </View>
-        ) : null}
+      <View style={{ paddingTop: insets.top + 32 }} className="bg-surface px-4">
+        <View className="flex-row items-center justify-between gap-4">
+          <Marquee>
+            <AccentText className="text-4xl">{t(props.titleKey)}</AccentText>
+          </Marquee>
+          {props.Actions ? (
+            <View className="flex-row items-center gap-1 rounded-full bg-surfaceContainerLowest">
+              {props.Actions}
+            </View>
+          ) : null}
+        </View>
+        {props.children}
       </View>
-      {props.children}
       <TopDownGradient height={SHADOW_HEIGHT} />
     </Animated.View>
   );

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -126,6 +126,7 @@ export function NScrollListLayout<TData>({
   OptionsSheet,
   Actions,
   Subheader,
+  estimatedSubheaderHeight = 0,
   ...props
 }: Omit<LegendListProps<TData>, "onContentSizeChange" | "onLayout"> & {
   titleKey: ParseKeys;
@@ -135,6 +136,8 @@ export function NScrollListLayout<TData>({
   Actions?: React.ReactNode;
   /** Component rendered after the header but before the shadow. */
   Subheader?: React.ReactNode;
+  /** Estimated height of subheader to improve "initial" height calculations. */
+  estimatedSubheaderHeight?: number;
 }) {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -151,7 +154,9 @@ export function NScrollListLayout<TData>({
   const bottomOffset = bottomInset.withNav + 16;
 
   // Shy Header
-  const [topBarHeight, setTopBarHeight] = useState(154); //? Includes the shadow underneath the header.
+  const [topBarHeight, setTopBarHeight] = useState(
+    130 + estimatedSubheaderHeight,
+  ); //? Includes the shadow underneath the header.
   const headerHeight = useMemo(
     () => topBarHeight - SHADOW_HEIGHT,
     [topBarHeight],

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -39,7 +39,7 @@ import { AccentText } from "~/components/Typography/AccentText";
 const INVALID_STATE = -1;
 const SNAP_PERCENT = 0.35;
 
-const SHADOW_HEIGHT = 48;
+const SHADOW_HEIGHT = 24;
 
 //#region NScrollLayout
 /** ScrollView with "shy header" and `NScrollbar`. */
@@ -59,7 +59,7 @@ export function NScrollLayout(props: {
   const bottomOffset = bottomInset.withNav + 16;
 
   // Shy Header
-  const [topBarHeight, setTopBarHeight] = useState(154); //? Includes the shadow underneath the header.
+  const [topBarHeight, setTopBarHeight] = useState(130); //? Includes the shadow underneath the header.
   const headerHeight = useMemo(
     () => topBarHeight - SHADOW_HEIGHT,
     [topBarHeight],
@@ -247,6 +247,11 @@ function useShyHeaderContext(args: {
   const translationTimer = useSharedValue(0);
   const headerStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: -headerTranslation.value }],
+    opacity: clamp(
+      0,
+      (args.headerHeight - headerTranslation.value) / args.headerHeight,
+      1,
+    ),
   }));
 
   // Reset `headerTranslation` when the layout changes.

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -18,7 +18,9 @@ import Animated, {
 } from "react-native-reanimated";
 
 import { useFolderContent } from "~/queries/folder";
-import { StickyActionListLayout } from "../../layouts/StickyActionScroll";
+
+import { NScrollListLayout } from "~/navigation/layouts/NScrollLayout";
+import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 
 import { OnRTL, OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
@@ -31,7 +33,6 @@ import {
 } from "~/modules/media/components/Track";
 import type { TrackContent } from "~/modules/media/components/Track.type";
 import { SearchResult } from "~/modules/search/components/SearchResult";
-import { ContentPlaceholder } from "../../components/Placeholder";
 
 /** Animated scrollview supporting gestures. */
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
@@ -96,11 +97,10 @@ export default function Folders({
   }, [dirSegments, isFocused, setDirSegments]);
 
   return (
-    <StickyActionListLayout
+    <NScrollListLayout
       listRef={listRef}
       titleKey="term.folders"
-      insetDelta={8}
-      estimatedItemSize={56} // 48px Height + 8px Margin Top
+      estimatedItemSize={56} // 48px Height + 8px Margin Bottom
       data={renderedData}
       keyExtractor={(item) => (isTrackContent(item) ? item.id : item.path)}
       renderItem={({ item }) =>
@@ -116,17 +116,15 @@ export default function Folders({
           />
         )
       }
-      ListEmptyComponent={
-        <ContentPlaceholder isPending={isPending} className="h-screen" />
-      }
-      scrollEnabled={!isPending}
-      StickyAction={
+      Subheader={
         <Breadcrumbs
           dirSegments={dirSegments}
           setDirSegments={setDirSegments}
         />
       }
-      estimatedActionSize={48}
+      ListEmptyComponent={<ContentPlaceholder isPending={isPending} />}
+      scrollEnabled={!isPending}
+      className="-mb-2"
     />
   );
 }
@@ -181,7 +179,7 @@ function Breadcrumbs({
       horizontal
       showsHorizontalScrollIndicator={false}
       style={{ width: screenWidth - 32 }}
-      className="rounded-md bg-surfaceContainerLowest"
+      className="mx-4 rounded-md bg-surfaceContainerLowest"
       contentContainerClassName="px-4"
     >
       <Animated.View

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -36,9 +36,6 @@ import {
 import type { TrackContent } from "~/modules/media/components/Track.type";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
-/** Animated scrollview supporting gestures. */
-const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
-
 type Props = StaticScreenProps<{ path?: string }>;
 
 export default function Folders({
@@ -154,6 +151,11 @@ function keyExtractor(item: MergedData) {
 //#endregion
 
 //#region Breadcrumbs
+/** Animated scrollview supporting gestures. */
+const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
+
+const RemoveAnimation = OnRTL.decide(FadeOutLeft, FadeOutRight);
+
 function Breadcrumbs({
   dirSegments,
   setDirSegments,
@@ -198,7 +200,7 @@ function Breadcrumbs({
       ref={breadcrumbsRef}
       horizontal
       showsHorizontalScrollIndicator={false}
-      className="w-full rounded-md bg-surfaceContainerLowest"
+      className="mt-2 w-full rounded-md bg-surfaceContainerLowest"
       contentContainerClassName="px-4"
     >
       <Animated.View
@@ -208,17 +210,11 @@ function Breadcrumbs({
         {[undefined, ...dirSegments].map((dirName, idx) => (
           <Fragment key={idx}>
             {idx > 0 ? (
-              <Animated.View
-                entering={FadeInLeft}
-                exiting={OnRTL.decide(FadeOutLeft, FadeOutRight)}
-              >
+              <Animated.View entering={FadeInLeft} exiting={RemoveAnimation}>
                 <StyledText className="px-1 text-xs">/</StyledText>
               </Animated.View>
             ) : null}
-            <Animated.View
-              entering={FadeInLeft}
-              exiting={OnRTL.decide(FadeOutLeft, FadeOutRight)}
-            >
+            <Animated.View entering={FadeInLeft} exiting={RemoveAnimation}>
               <Pressable
                 // Pop the segments we pushed onto the stack and update
                 // the path segments atom accordingly.

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -17,6 +17,8 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
+import type { FileNode } from "~/db/schema";
+
 import { useFolderContent } from "~/queries/folder";
 
 import { NScrollListLayout } from "~/navigation/layouts/NScrollLayout";
@@ -44,22 +46,12 @@ export default function Folders({
     params: { path },
   },
 }: Props) {
+  //#region Directory Management
   const navigation = useNavigation();
   const isFocused = useIsFocused();
   const listRef = useAnimatedLegendListRef();
+
   const [dirSegments, _setDirSegments] = useState<string[]>([]);
-
-  const fullPath = dirSegments.join("/");
-  const trackSource = { type: "folder", id: `${fullPath}/` } as const;
-
-  const { isPending, data } = useFolderContent(fullPath);
-  const listData = useTrackListPlayingIndication(trackSource, data?.tracks);
-
-  const renderedData = useMemo(
-    () => [...(data?.subDirectories ?? []), ...(listData ?? [])],
-    [data, listData],
-  );
-
   /** Modified state setter that scrolls to the top of the page. */
   const setDirSegments: React.Dispatch<React.SetStateAction<string[]>> =
     useCallback(
@@ -71,7 +63,7 @@ export default function Folders({
       [listRef],
     );
 
-  // Enable the ability to navigate to a specific folder programmatically.
+  //? Enable the ability to navigate to a specific folder programmatically.
   useEffect(() => {
     if (!isFocused || !path) return;
     // Exclude the `/` at the end of the path.
@@ -80,9 +72,8 @@ export default function Folders({
     navigation.setParams({ path: undefined });
   }, [navigation, isFocused, path, setDirSegments]);
 
-  // Enables our "fake tabs" be affected by the navigation back gesture.
+  //? Treat each directory as part of the stack which gets popped when a back gesture is detected.
   useEffect(() => {
-    // Prevent event from working when this screen isn't focused.
     if (!isFocused) return;
     const subscription = BackHandler.addEventListener(
       "hardwareBackPress",
@@ -95,6 +86,39 @@ export default function Folders({
     );
     return () => subscription.remove();
   }, [dirSegments, isFocused, setDirSegments]);
+  //#endregion
+
+  //#region Data Fetching
+  const fullPath = dirSegments.join("/");
+  const trackSource = useMemo(
+    () => ({ type: "folder", id: `${fullPath}/` }) as const,
+    [fullPath],
+  );
+
+  const { isPending, data } = useFolderContent(fullPath);
+  const listData = useTrackListPlayingIndication(trackSource, data?.tracks);
+
+  const renderedData = useMemo(
+    () => [...(data?.subDirectories ?? []), ...(listData ?? [])],
+    [data, listData],
+  );
+  //#endregion
+
+  const renderItem = useCallback(
+    ({ item }: { item: MergedData }) =>
+      isTrackContent(item) ? (
+        <Track {...item} trackSource={trackSource} className="mb-2" />
+      ) : (
+        <SearchResult
+          button
+          type="folder"
+          title={item.name}
+          onPress={() => setDirSegments((prev) => [...prev, item.name])}
+          className="mb-2 pr-4"
+        />
+      ),
+    [trackSource, setDirSegments],
+  );
 
   return (
     <NScrollListLayout
@@ -102,20 +126,8 @@ export default function Folders({
       titleKey="term.folders"
       estimatedItemSize={56} // 48px Height + 8px Margin Bottom
       data={renderedData}
-      keyExtractor={(item) => (isTrackContent(item) ? item.id : item.path)}
-      renderItem={({ item }) =>
-        isTrackContent(item) ? (
-          <Track {...item} trackSource={trackSource} className="mb-2" />
-        ) : (
-          <SearchResult
-            button
-            type="folder"
-            title={item.name}
-            onPress={() => setDirSegments((prev) => [...prev, item.name])}
-            className="mb-2 pr-4"
-          />
-        )
-      }
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
       Subheader={
         <Breadcrumbs
           dirSegments={dirSegments}
@@ -129,9 +141,17 @@ export default function Folders({
   );
 }
 
+//#region List Utils
+type MergedData = FileNode | TrackContent;
+
 function isTrackContent(data: unknown): data is TrackContent {
   return Object.hasOwn(data as TrackContent, "id");
 }
+
+function keyExtractor(item: MergedData) {
+  return isTrackContent(item) ? item.id : item.path;
+}
+//#endregion
 
 //#region Breadcrumbs
 function Breadcrumbs({

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -125,14 +125,15 @@ export default function Folders({
       data={renderedData}
       keyExtractor={keyExtractor}
       renderItem={renderItem}
+      ListEmptyComponent={<ContentPlaceholder isPending={isPending} />}
+      scrollEnabled={!isPending}
       Subheader={
         <Breadcrumbs
           dirSegments={dirSegments}
           setDirSegments={setDirSegments}
         />
       }
-      ListEmptyComponent={<ContentPlaceholder isPending={isPending} />}
-      scrollEnabled={!isPending}
+      estimatedSubheaderHeight={56}
       className="-mb-2"
     />
   );

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -198,8 +198,7 @@ function Breadcrumbs({
       ref={breadcrumbsRef}
       horizontal
       showsHorizontalScrollIndicator={false}
-      style={{ width: screenWidth - 32 }}
-      className="mx-4 rounded-md bg-surfaceContainerLowest"
+      className="w-full rounded-md bg-surfaceContainerLowest"
       contentContainerClassName="px-4"
     >
       <Animated.View


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR updates the "Folders" screen to use the new layout. In general, not much has changed:
- There were some adjustments to the header for NScrollLayout and making some props optional.
- The breadcrumbs are pinned to the header in the layout, so we can scroll the breadcrumbs offscreen as we scroll down and have them reappear when we scroll up.

> [!NOTE]
> There's no sorting support for this screen.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
