### PR TITLE
fix: `TrackPlayer.load` is slow under certain scenarios

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -3,6 +3,7 @@
 | @backpackapp-io/react-native-toast | MIT | https://github.com/backpackapp-io/react-native-toast |
 | @boterop/react-native-background-timer | MIT | https://github.com/boterop/react-native-background-timer |
 | @kaannn/react-native-waveform | MIT | https://github.com/kagantemizkan/react-native-audio-wave |
+| @legendapp/list | MIT | https://github.com/LegendApp/legend-list |
 | @lodev09/react-native-true-sheet | MIT | https://github.com/lodev09/react-native-true-sheet |
 | @lukemorales/query-key-factory | MIT | https://github.com/lukemorales/query-key-factory |
 | @missingcore/react-native-actual-path | MIT | https://github.com/MissingCore/react-native-actual-path |

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -26,6 +26,7 @@
     "@backpackapp-io/react-native-toast": "0.13.0",
     "@boterop/react-native-background-timer": "2.6.0",
     "@kaannn/react-native-waveform": "0.1.4",
+    "@legendapp/list": "2.0.19",
     "@lodev09/react-native-true-sheet": "3.4.2",
     "@lukemorales/query-key-factory": "1.3.4",
     "@missingcore/react-native-actual-path": "0.1.0",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@kaannn/react-native-waveform':
         specifier: 0.1.4
         version: 0.1.4(patch_hash=02bde95462ae30a21077feabc5ad68053c8c71b2d2b8f17eb4aa29a9ba090446)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
+      '@legendapp/list':
+        specifier: 2.0.19
+        version: 2.0.19(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
       '@lodev09/react-native-true-sheet':
         specifier: 3.4.2
         version: 3.4.2(patch_hash=a236b9bf74e9f29d81327ec6e984d46977a4805373593e38f4fb1bdad56ef9c9)(@react-navigation/native@7.1.28(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
@@ -1500,6 +1503,12 @@ packages:
 
   '@kaannn/react-native-waveform@0.1.4':
     resolution: {integrity: sha512-kQnkmlQhSxOCH1FE+n5V7RfP5Owsy9gXpCQEuFd0DCFC6J+0sR+00aQHvy81hoDt+Lqg2HbTEcxk8r5aGfmpzg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  '@legendapp/list@2.0.19':
+    resolution: {integrity: sha512-zDWg8yg0smKxxk+M7gwAbZAnf5uczohPA+IjqLSkImz7+e9ytxeT0Mq35RBO9RTKODOXfV/aIgm1uqUHLBEdmg==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -7035,6 +7044,12 @@ snapshots:
     dependencies:
       react: 19.1.4
       react-native: 0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4)
+
+  '@legendapp/list@2.0.19(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      react: 19.1.4
+      react-native: 0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4)
+      use-sync-external-store: 1.6.0(react@19.1.4)
 
   '@lodev09/react-native-true-sheet@3.4.2(patch_hash=a236b9bf74e9f29d81327ec6e984d46977a4805373593e38f4fb1bdad56ef9c9)(@react-navigation/native@7.1.28(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)':
     dependencies:

--- a/mobile/src/components/Base/LegendList.tsx
+++ b/mobile/src/components/Base/LegendList.tsx
@@ -1,0 +1,42 @@
+import type {
+  LegendListRef as RawLegendListRef,
+  LegendListRenderItemProps,
+} from "@legendapp/list";
+import type { AnimatedLegendListProps } from "@legendapp/list/reanimated";
+import { AnimatedLegendList } from "@legendapp/list/reanimated";
+import { memo, useRef } from "react";
+import { withUniwind } from "uniwind";
+
+type LegendListSignature = <T>(
+  props: AnimatedLegendListProps<T> & { ref?: LegendListRef },
+) => React.JSX.Element;
+
+export type LegendListRef = React.RefObject<RawLegendListRef | null>;
+
+export type LegendListProps<T = any> = Omit<
+  AnimatedLegendListProps<T>,
+  "data"
+> & { data?: readonly T[] };
+
+export type ListRenderItemInfo<T = any> = LegendListRenderItemProps<T>;
+
+const WrappedAnimatedLegendList = withUniwind(
+  AnimatedLegendList,
+) as LegendListSignature;
+
+export const LegendList = memo(function LegendList(props) {
+  return (
+    <WrappedAnimatedLegendList
+      key={`list-with-${props.numColumns}-cols`}
+      overScrollMode="never"
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
+      recycleItems
+      {...props}
+    />
+  );
+}) as LegendListSignature;
+
+export function useLegendListRef() {
+  return useRef<LegendListRef>(null);
+}

--- a/mobile/src/components/Base/LegendList.tsx
+++ b/mobile/src/components/Base/LegendList.tsx
@@ -5,18 +5,22 @@ import type {
 import type { AnimatedLegendListProps } from "@legendapp/list/reanimated";
 import { AnimatedLegendList } from "@legendapp/list/reanimated";
 import { memo, useRef } from "react";
+import type { AnimatedRef } from "react-native-reanimated";
+import { useAnimatedRef } from "react-native-reanimated";
 import { withUniwind } from "uniwind";
 
-type LegendListSignature = <T>(
-  props: AnimatedLegendListProps<T> & { ref?: LegendListRef },
-) => React.JSX.Element;
+type LegendListSignature = <T>(props: LegendListProps<T>) => React.JSX.Element;
+
+type JoinedLegendListRef = LegendListRef | AnimatedLegendListRef;
 
 export type LegendListRef = React.RefObject<RawLegendListRef | null>;
+// @ts-expect-error - Argument should be compatible.
+export type AnimatedLegendListRef = AnimatedRef<RawLegendListRef>;
 
 export type LegendListProps<T = any> = Omit<
-  AnimatedLegendListProps<T>,
+  Omit<AnimatedLegendListProps<T>, "ref">,
   "data"
-> & { data?: readonly T[] };
+> & { ref?: JoinedLegendListRef; data?: readonly T[] };
 
 export type ListRenderItemInfo<T = any> = LegendListRenderItemProps<T>;
 
@@ -38,5 +42,8 @@ export const LegendList = memo(function LegendList(props) {
 }) as LegendListSignature;
 
 export function useLegendListRef() {
-  return useRef<LegendListRef>(null);
+  return useRef<RawLegendListRef>(null);
+}
+export function useAnimatedLegendListRef() {
+  return useAnimatedRef() as unknown as AnimatedLegendListRef;
 }

--- a/mobile/src/lib/react-query.ts
+++ b/mobile/src/lib/react-query.ts
@@ -53,6 +53,6 @@ export function clearAllQueries(client: QueryClient = queryClient) {
 }
 
 /** Extracts the type of the `data` returned from `useQuery`. */
-export type ExtractQueryData<T extends () => UseQueryResult<any>> = NonNullable<
-  ReturnType<T>["data"]
->;
+export type ExtractQueryData<
+  T extends (...args: any[]) => UseQueryResult<any>,
+> = NonNullable<ReturnType<T>["data"]>;

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -6,8 +6,7 @@ import { useGetColumn } from "~/hooks/useGetColumn";
 import { getMediaLinkContext } from "~/navigation/utils/router";
 
 import { cn } from "~/lib/style";
-import type { FlatListProps } from "~/components/Base/List";
-import { getRowItemLayout } from "~/components/Base/List";
+import type { LegendListProps } from "~/components/Base/LegendList";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 import type { MediaCardContent, MediaCardProps } from "./MediaCard.type";
@@ -63,6 +62,8 @@ export function useMediaCardListPreset(
   return useMemo(
     () => ({
       numColumns: count,
+      // ~40px for text content under `<MediaImage />` + 12px Margin Bottom
+      estimatedItemSize: width + 40 + 12,
       data: args.data,
       // Use this as the key instead of just `id` in case `data` is mixed.
       keyExtractor: ({ id, type }) => `${type}_${id}`,
@@ -78,8 +79,6 @@ export function useMediaCardListPreset(
           className="mx-1.5 mb-3"
         />
       ),
-      // ~40px for text content under `<MediaImage />` + 12px Margin Bottom
-      getItemLayout: getRowItemLayout(width + 40 + 12),
       ListEmptyComponent: (
         <ContentPlaceholder
           isPending={args.isPending || args.data === undefined}
@@ -90,8 +89,6 @@ export function useMediaCardListPreset(
       className: "-mx-1.5 -mb-3",
     }),
     [args, navigation, count, width],
-  ) satisfies Omit<FlatListProps<MediaCardContent>, "data"> & {
-    data?: readonly MediaCardContent[];
-  };
+  ) satisfies LegendListProps<MediaCardContent>;
 }
 //#endregion

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -6,8 +6,7 @@ import { usePlaybackStore } from "~/stores/Playback/store";
 import { PlaybackControls } from "~/stores/Playback/actions";
 import { presentTrackSheet } from "~/stores/Session/actions";
 
-import type { FlatListProps } from "~/components/Base/List";
-import { getListItemLayout } from "~/components/Base/List";
+import type { LegendListProps } from "~/components/Base/LegendList";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 import { ContentPlaceholder } from "~/navigation/components/Placeholder";
@@ -92,12 +91,12 @@ export function useTrackListPreset(args: {
   const data = useTrackListPlayingIndication(args.trackSource, args.data);
   return useMemo(
     () => ({
+      estimatedItemSize: 56, // 48px Height + 8px Margin Bottom
       data,
       keyExtractor: ({ id }) => id,
       renderItem: ({ item }) => (
         <Track {...item} trackSource={args.trackSource} className="mb-2" />
       ),
-      getItemLayout: getListItemLayout,
       ListEmptyComponent: (
         <ContentPlaceholder
           isPending={args.isPending || args.data === undefined}
@@ -107,8 +106,6 @@ export function useTrackListPreset(args: {
       className: "-mb-2",
     }),
     [args, data],
-  ) satisfies Omit<FlatListProps<TrackContent>, "data"> & {
-    data?: readonly TrackContent[];
-  };
+  ) satisfies LegendListProps<TrackContent>;
 }
 //#endregion

--- a/mobile/src/navigation/layouts/CurrentListLayout.tsx
+++ b/mobile/src/navigation/layouts/CurrentListLayout.tsx
@@ -42,8 +42,7 @@ export function CurrentListLayout<TData>({
   listInfo,
   SubHeader,
   ...props
-}: Omit<LegendListProps<TData>, "data"> & {
-  data?: TData[];
+}: LegendListProps<TData> & {
   listInfo: ListInfoProps;
   SubHeader?: React.ReactNode;
 } & Omit<ListArtworkProps, "size">) {

--- a/mobile/src/navigation/layouts/CurrentListLayout.tsx
+++ b/mobile/src/navigation/layouts/CurrentListLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import { View, useWindowDimensions } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
@@ -17,8 +17,8 @@ import { useDelayedReady } from "~/hooks/useDelayedReady";
 
 import { cn } from "~/lib/style";
 import { clamp } from "~/utils/number";
-import type { FlatListProps } from "~/components/Base/List";
-import { FlatList, calculateItemsLayouts } from "~/components/Base/List";
+import type { LegendListProps } from "~/components/Base/LegendList";
+import { LegendList } from "~/components/Base/LegendList";
 import { TopDownGradient } from "~/components/Gradient";
 import { Marquee } from "~/components/Marquee";
 import { Em, StyledText } from "~/components/Typography/StyledText";
@@ -42,7 +42,7 @@ export function CurrentListLayout<TData>({
   listInfo,
   SubHeader,
   ...props
-}: Omit<FlatListProps<TData>, "data"> & {
+}: Omit<LegendListProps<TData>, "data"> & {
   data?: TData[];
   listInfo: ListInfoProps;
   SubHeader?: React.ReactNode;
@@ -94,29 +94,26 @@ export function CurrentListLayout<TData>({
   //#endregion
 
   //#region Layout Estimations
-  const itemLayouts = useMemo(
-    () =>
-      calculateItemsLayouts(data, { itemHeight: 48, labelHeight: 16, gap: 8 }),
-    [data],
-  );
+  const guessItemSize = useCallback((index: number, item: any) => {
+    if (typeof item === "number" || typeof item === "string") {
+      return 16 + (index === 0 ? 8 : 16);
+    }
+    return 56; // 48px Height + 8px Margin Bottom
+  }, []);
 
-  const getItemLayout: FlatListProps<TData>["getItemLayout"] = useCallback(
-    (_: unknown, index: number) => {
-      const layoutInfo = itemLayouts[index];
-      // Fallback to default layout object if index is out of bounds.
-      if (!layoutInfo) return { length: 0, offset: 0, index };
-      return layoutInfo;
-    },
-    [itemLayouts],
-  );
+  const getItemType = useCallback((item: any) => {
+    if (typeof item === "number" || typeof item === "string") return "label";
+    return "row";
+  }, []);
   //#endregion
 
   return (
     <>
-      <FlatList
+      <LegendList
         {...props}
+        getEstimatedItemSize={guessItemSize}
         data={data}
-        getItemLayout={getItemLayout}
+        getItemType={getItemType}
         onScroll={scrollHandler}
         ListHeaderComponent={
           <View>

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -9,7 +9,6 @@ import {
 import { useTranslation } from "react-i18next";
 import type { ViewStyle } from "react-native";
 import { View } from "react-native";
-
 import type { AnimatedStyle, ScrollHandler } from "react-native-reanimated";
 import Animated, {
   cancelAnimation,
@@ -28,10 +27,13 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 import { useBottomActionsInset } from "~/navigation/hooks/useBottomActions";
 
 import type {
-  AnimatedFlatListRef,
-  FlatListProps,
-} from "~/components/Base/List";
-import { FlatList, useAnimatedFlatListRef } from "~/components/Base/List";
+  AnimatedLegendListRef,
+  LegendListProps,
+} from "~/components/Base/LegendList";
+import {
+  LegendList,
+  useAnimatedLegendListRef,
+} from "~/components/Base/LegendList";
 import {
   ScrollView,
   useAnimatedScrollViewRef,
@@ -129,9 +131,9 @@ export function NScrollListLayout<TData>({
   Subheader,
   estimatedSubheaderHeight = 0,
   ...props
-}: Omit<FlatListProps<TData>, "onContentSizeChange" | "onLayout"> & {
+}: Omit<LegendListProps<TData>, "onContentSizeChange" | "onLayout"> & {
   titleKey: ParseKeys;
-  listRef?: AnimatedFlatListRef;
+  listRef?: AnimatedLegendListRef;
   OptionsSheet?: (props: { ref: TrueSheetRef }) => React.JSX.Element;
   /** Additional "actions" which will appear before the "Screen Options" button. */
   Actions?: React.ReactNode;
@@ -143,7 +145,7 @@ export function NScrollListLayout<TData>({
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const bottomInset = useBottomActionsInset();
-  const internalListRef = useAnimatedFlatListRef();
+  const internalListRef = useAnimatedLegendListRef();
   // @ts-expect-error - Should be able to synchronize refs.
   useImperativeHandle(listRef, () => internalListRef.current);
   const sheetRef = useSheetRef();
@@ -196,7 +198,7 @@ export function NScrollListLayout<TData>({
         {Subheader}
       </ShyHeader>
 
-      <FlatList
+      <LegendList
         ref={internalListRef}
         {...scrollBarContext.layoutHandlers}
         onScroll={shyHeaderContext.scrollHandler}

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -122,7 +122,7 @@ export function NScrollLayout(props: {
 //#endregion
 
 //#region NScrollListLayout
-/** FlatList with "shy header" and `NScrollbar`. */
+/** LegendList with "shy header" and `NScrollbar`. */
 export function NScrollListLayout<TData>({
   titleKey,
   listRef,
@@ -202,6 +202,7 @@ export function NScrollListLayout<TData>({
         ref={internalListRef}
         {...scrollBarContext.layoutHandlers}
         onScroll={shyHeaderContext.scrollHandler}
+        maintainVisibleContentPosition={false}
         {...props}
         contentContainerStyle={{
           paddingHorizontal: 16,

--- a/mobile/src/navigation/screens/HomeView.tsx
+++ b/mobile/src/navigation/screens/HomeView.tsx
@@ -6,7 +6,7 @@ import { useFavoriteListsForCards } from "~/queries/favorite";
 
 import { NScrollLayout } from "~/navigation/layouts/NScrollLayout";
 
-import { FlatList } from "~/components/Base/List";
+import { LegendList } from "~/components/Base/LegendList";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { TEm } from "~/components/Typography/StyledText";
 import { useMediaCardListPreset } from "~/modules/media/components/MediaCard";
@@ -38,6 +38,6 @@ export default function Home() {
 function Favorites() {
   const { data } = useFavoriteListsForCards();
   const presets = useMediaCardListPreset({ data });
-  return <FlatList scrollEnabled={false} {...presets} />;
+  return <LegendList {...presets} />;
 }
 //#endregion

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -26,10 +26,7 @@ import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 import { OnRTL, OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { addTrailingSlash } from "~/utils/string";
-import {
-  getListItemLayout,
-  useAnimatedFlatListRef,
-} from "~/components/Base/List";
+import { useAnimatedLegendListRef } from "~/components/Base/LegendList";
 import { useAnimatedScrollViewRef } from "~/components/Base/ScrollView";
 import { StyledText } from "~/components/Typography/StyledText";
 import {
@@ -49,7 +46,7 @@ export default function Folders({
   //#region Directory Management
   const navigation = useNavigation();
   const isFocused = useIsFocused();
-  const listRef = useAnimatedFlatListRef();
+  const listRef = useAnimatedLegendListRef();
 
   const [dirSegments, _setDirSegments] = useState<string[]>([]);
   /** Modified state setter that scrolls to the top of the page. */
@@ -124,10 +121,10 @@ export default function Folders({
     <NScrollListLayout
       listRef={listRef}
       titleKey="term.folders"
+      estimatedItemSize={56} // 48px Height + 8px Margin Bottom
       data={renderedData}
       keyExtractor={keyExtractor}
       renderItem={renderItem}
-      getItemLayout={getListItemLayout}
       ListEmptyComponent={<ContentPlaceholder isPending={isPending} />}
       scrollEnabled={!isPending}
       Subheader={

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -20,6 +20,13 @@
     "license": "MIT",
     "licenseText": "MIT License\n\nCopyright (c) 2025 Kağan Temizkan\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
+  "@legendapp/list": {
+    "name": "@legendapp/list",
+    "version": "2.0.19",
+    "source": "https://github.com/LegendApp/legend-list",
+    "license": "MIT",
+    "licenseText": "MIT License\n\nCopyright (c) 2022 Moo.do LLC\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+  },
   "@lodev09/react-native-true-sheet": {
     "name": "@lodev09/react-native-true-sheet",
     "version": "3.4.2",

--- a/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
@@ -9,8 +9,7 @@ import type { LayoutItem, MutableViewLayout } from "../types";
 import { getMediaLinkContext } from "~/navigation/utils/router";
 
 import { cn } from "~/lib/style";
-import type { FlatListProps } from "~/components/Base/List";
-import { getListItemLayout, getRowItemLayout } from "~/components/Base/List";
+import type { LegendListProps } from "~/components/Base/LegendList";
 import { MediaCard } from "~/modules/media/components/MediaCard";
 import { SearchResult } from "~/modules/search/components/SearchResult";
 
@@ -48,6 +47,7 @@ export function useViewLayout<TData extends Record<string, any>>(
   const listLayoutArgs = useMemo(
     () =>
       ({
+        estimatedItemSize: 56, // 48px Height + 8px Margin Bottom
         renderItem: ({ item: { id, ...item } }) => (
           <SearchResult
             button
@@ -59,9 +59,8 @@ export function useViewLayout<TData extends Record<string, any>>(
             className={cn("mb-2 pr-4", { "rounded-full": screen === "artist" })}
           />
         ),
-        getItemLayout: getListItemLayout,
         className: "-mb-2",
-      }) satisfies Omit<FlatListProps<LayoutItem>, "data">,
+      }) satisfies LegendListProps<LayoutItem>,
     [navigation, screen],
   );
 
@@ -72,6 +71,8 @@ export function useViewLayout<TData extends Record<string, any>>(
     const usedGap = isGrid ? 12 : 8;
     return {
       numColumns: gridOpts.count,
+      // ~40px for text content under `<MediaImage />` + 8/12px Margin Bottom
+      estimatedItemSize: gridOpts.width + 40 + usedGap,
       renderItem: ({ item }) => (
         <MediaCard
           type={screen}
@@ -88,10 +89,8 @@ export function useViewLayout<TData extends Record<string, any>>(
           className={cn("mx-1.5 mb-3", { "mx-1 mb-2": !isGrid })}
         />
       ),
-      // ~40px for text content under `<MediaImage />` + 8/12px Margin Bottom
-      getItemLayout: getRowItemLayout(gridOpts.width + 40 + usedGap),
       className: isGrid ? "-mx-1.5 -mb-3" : "-mx-1 -mb-2",
-    } satisfies Omit<FlatListProps<LayoutItem>, "data">;
+    } satisfies LegendListProps<LayoutItem>;
   }, [navigation, layoutOption, screen, gridLayout, compactGridLayout]);
   //#endregion
 
@@ -101,7 +100,7 @@ export function useViewLayout<TData extends Record<string, any>>(
         data: formattedData,
         keyExtractor: ({ id }) => id,
         ...(layoutOption === "list" ? listLayoutArgs : gridLayoutArgs),
-      }) satisfies FlatListProps<LayoutItem>,
+      }) satisfies LegendListProps<LayoutItem>,
     [layoutOption, formattedData, listLayoutArgs, gridLayoutArgs],
   );
 }

--- a/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
@@ -26,7 +26,7 @@ const compactGridLayoutOptions: GCWProps = {
   minWidth: 72,
 };
 
-/** Formats data to pass into `FlatList`. */
+/** Formats data to pass into `LegendList`. */
 export function useViewLayout<TData extends Record<string, any>>(
   screen: MutableViewLayout,
   data: TData[] | undefined,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

After migrating all of our lists to `FlatList`, we noticed some performance issues with playing the next/prev track via miniplayer gestures. As it turns out, `TrackPlayer.load` took longer and longer to complete as more home screens were mounted.

My theory is maybe that it has to do with memory usage, with `FlatList` keeping more items in view (7 screens worth). This becomes problematic on the home screens as they'll stay mounted.
- Though another potential factor is the under-the-hood changes with the New Architecture.

For example, when switching tracks, `TrackPlayer.load` took:
- Just "Home" screen loaded: `~0.1331s`
- All home screens loaded: `~0.9988s`

After switching to LegendList with the same tests:
- Just "Home" screen loaded: `~0.0978s`
- All home screens loaded: `~0.2643s`

Though, we still notice some delay when on the "Now Playing" screen (adds an extra `~100ms`) and while on the screen for the current playing list (adds an extra `~100-150ms`). This is kind of unavoidable due to those screens having animations and large images & svgs (artwork + vinyl).
- The worse case scenario (all home screens loaded, "Current List" in stack, on "Now Playing" screen) has the next/prev button take `~0.5305s` (with all `FlatList`, it took `~1.3915s`).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
