### PR TITLE
fix: Inconsistent firing of `onPress` on React Native `<Pressable />`

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -129,7 +129,8 @@
       "react-native-bootsplash": "patches/react-native-bootsplash.patch",
       "@kaannn/react-native-waveform": "patches/@kaannn__react-native-waveform.patch",
       "@lodev09/react-native-true-sheet": "patches/@lodev09__react-native-true-sheet.patch",
-      "react-native-paper": "patches/react-native-paper.patch"
+      "react-native-paper": "patches/react-native-paper.patch",
+      "uniwind": "patches/uniwind.patch"
     }
   }
 }

--- a/mobile/patches/uniwind.patch
+++ b/mobile/patches/uniwind.patch
@@ -1,0 +1,189 @@
+diff --git a/dist/common/components/native/RNGHPressable.js b/dist/common/components/native/RNGHPressable.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..4dc66292edda1c43de8f68b448830a1d953ad4ed
+--- /dev/null
++++ b/dist/common/components/native/RNGHPressable.js
+@@ -0,0 +1,29 @@
++"use strict";
++
++Object.defineProperty(exports, "__esModule", {
++  value: true
++});
++module.exports = exports.RNGHPressable = void 0;
++var _jsxRuntime = require("react/jsx-runtime");
++var _reactNativeGestureHandler = require("react-native-gesture-handler");
++var _native = require("../../core/native");
++var _utils = require("../utils");
++var _useStyle = require("./useStyle");
++const RNGHPressable = exports.RNGHPressable = (0, _utils.copyComponentProperties)(_reactNativeGestureHandler.Pressable, props => {
++  const style = (0, _useStyle.useStyle)(props.className, props, {
++    isDisabled: Boolean(props.disabled)
++  });
++  return /* @__PURE__ */(0, _jsxRuntime.jsx)(_reactNativeGestureHandler.Pressable, {
++    ...props,
++    style: state => {
++      if (state.pressed) {
++        return [_native.UniwindStore.getStyles(props.className, props, {
++          isDisabled: Boolean(props.disabled),
++          isPressed: true
++        }).styles, typeof props.style === "function" ? props.style(state) : props.style];
++      }
++      return [style, typeof props.style === "function" ? props.style(state) : props.style];
++    }
++  });
++});
++module.exports = RNGHPressable;
+\ No newline at end of file
+diff --git a/dist/common/index.js b/dist/common/index.js
+index 38ae81962f8102146539572c54a087f9957e793c..59da3607eac21fe8d3ad684db3ffbe5ffc771ae0 100644
+--- a/dist/common/index.js
++++ b/dist/common/index.js
+@@ -3,6 +3,12 @@
+ Object.defineProperty(exports, "__esModule", {
+   value: true
+ });
++Object.defineProperty(exports, "RNGHPressable", {
++  enumerable: true,
++  get: function () {
++    return _RNGHPressable.default;
++  }
++});
+ Object.defineProperty(exports, "Uniwind", {
+   enumerable: true,
+   get: function () {
+@@ -33,6 +39,8 @@ Object.defineProperty(exports, "withUniwind", {
+     return _hoc.withUniwind;
+   }
+ });
++var _RNGHPressable = _interopRequireDefault(require("./components/native/RNGHPressable"));
+ var _core = require("./core");
+ var _hoc = require("./hoc");
+ var _hooks = require("./hooks");
++function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+\ No newline at end of file
+diff --git a/dist/module/components/native/RNGHPressable.d.ts b/dist/module/components/native/RNGHPressable.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..5db19b2d860a8a5672959ea9536d31f8b6b06b29
+--- /dev/null
++++ b/dist/module/components/native/RNGHPressable.d.ts
+@@ -0,0 +1,3 @@
++import { PressableProps } from 'react-native-gesture-handler';
++export declare const RNGHPressable: (props: PressableProps) => React.JSX.Element;
++export default RNGHPressable;
+diff --git a/dist/module/components/native/RNGHPressable.js b/dist/module/components/native/RNGHPressable.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..a4666810929925d3ee402af75ab59324dabc9e98
+--- /dev/null
++++ b/dist/module/components/native/RNGHPressable.js
+@@ -0,0 +1,34 @@
++import { jsx } from "react/jsx-runtime";
++import { Pressable as RNPressable } from "react-native-gesture-handler";
++import { UniwindStore } from "../../core/native/index.js";
++import { copyComponentProperties } from "../utils.js";
++import { useStyle } from "./useStyle.js";
++export const RNGHPressable = copyComponentProperties(RNPressable, (props) => {
++  const style = useStyle(
++    props.className,
++    props,
++    {
++      isDisabled: Boolean(props.disabled)
++    }
++  );
++  return /* @__PURE__ */ jsx(
++    RNPressable,
++    {
++      ...props,
++      style: (state) => {
++        if (state.pressed) {
++          return [
++            UniwindStore.getStyles(
++              props.className,
++              props,
++              { isDisabled: Boolean(props.disabled), isPressed: true }
++            ).styles,
++            typeof props.style === "function" ? props.style(state) : props.style
++          ];
++        }
++        return [style, typeof props.style === "function" ? props.style(state) : props.style];
++      }
++    }
++  );
++});
++export default RNGHPressable;
+diff --git a/dist/module/index.d.ts b/dist/module/index.d.ts
+index 5bdf9de44872d1dc8d2319c0ca00fc8e1d35875f..2343e90b33e6db896f89ae6cd05d09e6443238f8 100644
+--- a/dist/module/index.d.ts
++++ b/dist/module/index.d.ts
+@@ -1,5 +1,7 @@
++import RNGHPressable from './components/native/RNGHPressable';
+ export { Uniwind } from './core';
+ export { withUniwind } from './hoc';
+ export type { ApplyUniwind, ApplyUniwindOptions } from './hoc/types';
+ export { useCSSVariable, useResolveClassNames, useUniwind } from './hooks';
+ export type { UniwindConfig } from './types';
++export { RNGHPressable };
+diff --git a/dist/module/index.js b/dist/module/index.js
+index acb1a9a968d14e0ceb21820449482eba4b21948e..e9f7fddea8f37a7e703fded1ea84152044a2d946 100644
+--- a/dist/module/index.js
++++ b/dist/module/index.js
+@@ -1,3 +1,5 @@
++import RNGHPressable from "./components/native/RNGHPressable.js";
+ export { Uniwind } from "./core/index.js";
+ export { withUniwind } from "./hoc/index.js";
+ export { useCSSVariable, useResolveClassNames, useUniwind } from "./hooks/index.js";
++export { RNGHPressable };
+diff --git a/src/components/native/RNGHPressable.tsx b/src/components/native/RNGHPressable.tsx
+new file mode 100644
+index 0000000000000000000000000000000000000000..13a94eeff99db3bff47b2c86f441cfd1d8e3c66a
+--- /dev/null
++++ b/src/components/native/RNGHPressable.tsx
+@@ -0,0 +1,36 @@
++import { Pressable as RNPressable, PressableProps } from 'react-native-gesture-handler'
++import { UniwindStore } from '../../core/native'
++import { copyComponentProperties } from '../utils'
++import { useStyle } from './useStyle'
++
++export const RNGHPressable = copyComponentProperties(RNPressable, (props: PressableProps) => {
++    const style = useStyle(
++        props.className,
++        props,
++        {
++            isDisabled: Boolean(props.disabled),
++        },
++    )
++
++    return (
++        <RNPressable
++            {...props}
++            style={state => {
++                if (state.pressed) {
++                    return [
++                        UniwindStore.getStyles(
++                            props.className,
++                            props,
++                            { isDisabled: Boolean(props.disabled), isPressed: true },
++                        ).styles,
++                        typeof props.style === 'function' ? props.style(state) : props.style,
++                    ]
++                }
++
++                return [style, typeof props.style === 'function' ? props.style(state) : props.style]
++            }}
++        />
++    )
++})
++
++export default RNGHPressable
+diff --git a/src/index.ts b/src/index.ts
+index f57b0c1cbf6de19f5199a3d47479ed4021a11143..43c51197ecbd78cddff0c7ee8ef0d95dcc2737a9 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,5 +1,8 @@
++import RNGHPressable from './components/native/RNGHPressable'
++
+ export { Uniwind } from './core'
+ export { withUniwind } from './hoc'
+ export type { ApplyUniwind, ApplyUniwindOptions } from './hoc/types'
+ export { useCSSVariable, useResolveClassNames, useUniwind } from './hooks'
+ export type { UniwindConfig } from './types'
++export { RNGHPressable }

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -26,6 +26,9 @@ patchedDependencies:
   react-native-paper:
     hash: 4861a614642079819628426e488de07f5f16a3b2dffa6a600746ee38d7883eb9
     path: patches/react-native-paper.patch
+  uniwind:
+    hash: 795f6f959d4e9fd725c53533595c97c4a173c9d14c84a26d1ec5e70349f99e2f
+    path: patches/uniwind.patch
 
 importers:
 
@@ -192,7 +195,7 @@ importers:
         version: 3.5.0
       uniwind:
         specifier: 1.3.2
-        version: 1.3.2(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)(tailwindcss@4.2.0)
+        version: 1.3.2(patch_hash=795f6f959d4e9fd725c53533595c97c4a173c9d14c84a26d1ec5e70349f99e2f)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)(tailwindcss@4.2.0)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -11340,7 +11343,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  uniwind@1.3.2(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)(tailwindcss@4.2.0):
+  uniwind@1.3.2(patch_hash=795f6f959d4e9fd725c53533595c97c4a173c9d14c84a26d1ec5e70349f99e2f)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)(tailwindcss@4.2.0):
     dependencies:
       '@tailwindcss/node': 4.1.17
       '@tailwindcss/oxide': 4.1.17

--- a/mobile/src/components/Base/GestureHandlerRootView.tsx
+++ b/mobile/src/components/Base/GestureHandlerRootView.tsx
@@ -1,0 +1,4 @@
+import { GestureHandlerRootView as RawGestureHandlerRootView } from "react-native-gesture-handler";
+import { withUniwind } from "uniwind";
+
+export const GestureHandlerRootView = withUniwind(RawGestureHandlerRootView);

--- a/mobile/src/components/Base/Pressable.tsx
+++ b/mobile/src/components/Base/Pressable.tsx
@@ -4,5 +4,7 @@ import type { PressableProps as RNGHPressableProps } from "react-native-gesture-
 import { RNGHPressable } from "uniwind";
 
 export type PressableProps = RNPressableProps;
-
 export const Pressable = RNPresasble;
+
+export type { RNGHPressableProps };
+export { RNGHPressable };

--- a/mobile/src/components/Base/Pressable.tsx
+++ b/mobile/src/components/Base/Pressable.tsx
@@ -1,6 +1,8 @@
+import type { PressableProps as RNPressableProps } from "react-native";
+import { Pressable as RNPresasble } from "react-native";
 import type { PressableProps as RNGHPressableProps } from "react-native-gesture-handler";
 import { RNGHPressable } from "uniwind";
 
-export type PressableProps = RNGHPressableProps;
+export type PressableProps = RNPressableProps;
 
-export const Pressable = RNGHPressable;
+export const Pressable = RNPresasble;

--- a/mobile/src/components/Base/Pressable.tsx
+++ b/mobile/src/components/Base/Pressable.tsx
@@ -1,0 +1,6 @@
+import type { PressableProps as RNGHPressableProps } from "react-native-gesture-handler";
+import { RNGHPressable } from "uniwind";
+
+export type PressableProps = RNGHPressableProps;
+
+export const Pressable = RNGHPressable;

--- a/mobile/src/components/Form/Button/Icon.tsx
+++ b/mobile/src/components/Form/Button/Icon.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { View } from "react-native";
 
 import type { Icon } from "~/resources/icons/type";
@@ -6,8 +6,8 @@ import { useTheme } from "~/hooks/useTheme";
 
 import type { ColorRole } from "~/lib/style";
 import { cn } from "~/lib/style";
-import type { PressProps } from "./types";
-import { Pressable } from "../../Base/Pressable";
+import type { PressProps, RNGHPressProps } from "./types";
+import { Pressable, RNGHPressable } from "../../Base/Pressable";
 
 export type ButtonSize = "xs" | "sm" | "md" | "lg";
 
@@ -18,7 +18,7 @@ const ButtonConfig = {
   lg: { buttonSize: "min-h-12 min-w-12", iconSize: 32 },
 } as const;
 
-type IconButtonProps = PressProps & {
+type IconButtonProps = {
   Icon: (props: Icon) => React.JSX.Element;
   accessibilityLabel: string;
   /** Defaults to `md`. */
@@ -27,7 +27,7 @@ type IconButtonProps = PressProps & {
   filled?: boolean;
   className?: string;
   _iconColor?: ColorRole;
-};
+} & ((PressProps & { rngh: true }) | (RNGHPressProps & { rngh?: boolean }));
 
 //#region Default
 export const IconButton = memo(function IconButton({
@@ -40,8 +40,14 @@ export const IconButton = memo(function IconButton({
   const { surfaceContainerHigh } = useTheme();
   const { buttonSize, iconSize } = ButtonConfig[size];
 
+  const Wrapper = useMemo(
+    () => (props.rngh ? RNGHPressable : Pressable),
+    [props.rngh],
+  );
+
   return (
-    <Pressable
+    //@ts-expect-error - Pressable props are compatible.
+    <Wrapper
       {...props}
       className={cn(
         "items-center justify-center rounded-full disabled:opacity-25",
@@ -58,7 +64,7 @@ export const IconButton = memo(function IconButton({
           <Icon size={iconSize} color={_iconColor} filled={filled} />
         </View>
       )}
-    </Pressable>
+    </Wrapper>
   );
 });
 //#endregion
@@ -72,8 +78,15 @@ export const FilledIconButton = memo(function FilledIconButton({
   ...props
 }: IconButtonProps) {
   const { buttonSize, iconSize } = ButtonConfig[size];
+
+  const Wrapper = useMemo(
+    () => (props.rngh ? RNGHPressable : Pressable),
+    [props.rngh],
+  );
+
   return (
-    <Pressable
+    //@ts-expect-error - Pressable props are compatible.
+    <Wrapper
       {...props}
       className={cn(
         "items-center justify-center rounded-full bg-surfaceContainerLowest active:bg-surfaceContainer disabled:opacity-25",
@@ -82,7 +95,7 @@ export const FilledIconButton = memo(function FilledIconButton({
       )}
     >
       <Icon size={iconSize} color={_iconColor} filled={filled} />
-    </Pressable>
+    </Wrapper>
   );
 });
 //#endregion

--- a/mobile/src/components/Form/Button/Icon.tsx
+++ b/mobile/src/components/Form/Button/Icon.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import type { Icon } from "~/resources/icons/type";
 import { useTheme } from "~/hooks/useTheme";
@@ -7,6 +7,7 @@ import { useTheme } from "~/hooks/useTheme";
 import type { ColorRole } from "~/lib/style";
 import { cn } from "~/lib/style";
 import type { PressProps } from "./types";
+import { Pressable } from "../../Base/Pressable";
 
 export type ButtonSize = "xs" | "sm" | "md" | "lg";
 

--- a/mobile/src/components/Form/Button/Icon.tsx
+++ b/mobile/src/components/Form/Button/Icon.tsx
@@ -27,7 +27,7 @@ type IconButtonProps = {
   filled?: boolean;
   className?: string;
   _iconColor?: ColorRole;
-} & ((PressProps & { rngh: true }) | (RNGHPressProps & { rngh?: boolean }));
+} & ((PressProps & { rngh?: boolean }) | (RNGHPressProps & { rngh: true }));
 
 //#region Default
 export const IconButton = memo(function IconButton({

--- a/mobile/src/components/Form/Button/index.tsx
+++ b/mobile/src/components/Form/Button/index.tsx
@@ -1,9 +1,9 @@
 import type { ParseKeys } from "i18next";
 import { memo } from "react";
-import type { PressableProps } from "react-native";
-import { Pressable } from "react-native";
 
 import { cn } from "~/lib/style";
+import type { PressableProps } from "../../Base/Pressable";
+import { Pressable } from "../../Base/Pressable";
 import { TEm } from "../../Typography/StyledText";
 
 //#region Default

--- a/mobile/src/components/Form/Button/types.ts
+++ b/mobile/src/components/Form/Button/types.ts
@@ -1,4 +1,4 @@
-import type { PressableProps } from "react-native";
+import type { PressableProps } from "../../Base/Pressable";
 
 /** The most "used" action props used on `<Pressable />`. */
 export type PressProps = Pick<

--- a/mobile/src/components/Form/Button/types.ts
+++ b/mobile/src/components/Form/Button/types.ts
@@ -1,8 +1,19 @@
-import type { PressableProps } from "../../Base/Pressable";
+import type { PressableProps, RNGHPressableProps } from "../../Base/Pressable";
 
 /** The most "used" action props used on `<Pressable />`. */
 export type PressProps = Pick<
   PressableProps,
+  | "disabled"
+  | "delayLongPress"
+  | "onLongPress"
+  | "onPress"
+  | "onPressIn"
+  | "onPressOut"
+>;
+
+/** The most "used" action props used on `<Pressable />`. */
+export type RNGHPressProps = Pick<
+  RNGHPressableProps,
   | "disabled"
   | "delayLongPress"
   | "onLongPress"

--- a/mobile/src/components/Form/Checkbox.tsx
+++ b/mobile/src/components/Form/Checkbox.tsx
@@ -1,10 +1,11 @@
 import type { ParseKeys } from "i18next";
 import { memo } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { Check } from "~/resources/icons/Check";
 
 import { cn } from "~/lib/style";
+import { Pressable } from "../Base/Pressable";
 import { TStyledText } from "../Typography/StyledText";
 
 //#region Base

--- a/mobile/src/components/Form/Radio.tsx
+++ b/mobile/src/components/Form/Radio.tsx
@@ -1,9 +1,10 @@
 import { memo } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { Check } from "~/resources/icons/Check";
 
 import { cn } from "~/lib/style";
+import { Pressable } from "../Base/Pressable";
 
 //#region Base
 function Radio({ selected }: { selected: boolean }) {

--- a/mobile/src/components/Form/SegmentedPicker.tsx
+++ b/mobile/src/components/Form/SegmentedPicker.tsx
@@ -1,4 +1,4 @@
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -8,6 +8,7 @@ import Animated, {
 import type { Icon } from "~/resources/icons/type";
 
 import { cn } from "~/lib/style";
+import { Pressable } from "../Base/Pressable";
 import { Em } from "../Typography/StyledText";
 
 export type PickerOption = {

--- a/mobile/src/components/List/RemovableItem.tsx
+++ b/mobile/src/components/List/RemovableItem.tsx
@@ -5,7 +5,7 @@ import { View } from "react-native";
 import { DoNotDisturbOn } from "~/resources/icons/DoNotDisturbOn";
 
 import { cn } from "~/lib/style";
-import { Pressable } from "../Base/Pressable";
+import { RNGHPressable } from "../Base/Pressable";
 import { IconButton } from "../Form/Button/Icon";
 
 type RemovableItemProps = {
@@ -28,7 +28,7 @@ export const RemovableItem = memo(function RemovableItem(
   const { t } = useTranslation();
 
   const Wrapper = useMemo(
-    () => (props.onPress ? Pressable : View),
+    () => (props.onPress ? RNGHPressable : View),
     [props.onPress],
   );
 
@@ -48,6 +48,7 @@ export const RemovableItem = memo(function RemovableItem(
         onPress={props.onRemove}
         disabled={props.disableRemove}
         size="xs"
+        rngh
       />
       {props.children}
     </Wrapper>

--- a/mobile/src/components/List/RemovableItem.tsx
+++ b/mobile/src/components/List/RemovableItem.tsx
@@ -1,10 +1,11 @@
 import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { DoNotDisturbOn } from "~/resources/icons/DoNotDisturbOn";
 
 import { cn } from "~/lib/style";
+import { Pressable } from "../Base/Pressable";
 import { IconButton } from "../Form/Button/Icon";
 
 type RemovableItemProps = {

--- a/mobile/src/components/List/index.tsx
+++ b/mobile/src/components/List/index.tsx
@@ -1,10 +1,11 @@
 import { memo, useMemo } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { cn } from "~/lib/style";
 import type { ListItemContentProps } from "./ListItemContent";
 import { ListItemContent } from "./ListItemContent";
+import { Pressable } from "../Base/Pressable";
 import type { PressProps } from "../Form/Button/types";
 
 export type ListItemProps = ListItemContentProps &

--- a/mobile/src/components/Modal.tsx
+++ b/mobile/src/components/Modal.tsx
@@ -1,10 +1,14 @@
 import type { ParseKeys } from "i18next";
 import { Modal as RNModal, View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { withUniwind } from "uniwind";
 
 import { cn } from "~/lib/style";
 import type { PressableProps } from "./Base/Pressable";
 import { ExtendedTButton } from "./Form/Button";
 import { TStyledText } from "./Typography/StyledText";
+
+const WrappedGestureHandlerRootView = withUniwind(GestureHandlerRootView);
 
 export function Modal(props: { visible: boolean; children: React.ReactNode }) {
   return (
@@ -15,11 +19,11 @@ export function Modal(props: { visible: boolean; children: React.ReactNode }) {
       navigationBarTranslucent
       transparent
     >
-      <View className="flex-1 items-center justify-center bg-black/50 px-4">
+      <WrappedGestureHandlerRootView className="flex-1 items-center justify-center bg-black/50 px-4">
         <View className="w-full gap-8 rounded-xl bg-surfaceContainerLowest p-4 pt-6">
           {props.children}
         </View>
-      </View>
+      </WrappedGestureHandlerRootView>
     </RNModal>
   );
 }

--- a/mobile/src/components/Modal.tsx
+++ b/mobile/src/components/Modal.tsx
@@ -1,14 +1,11 @@
 import type { ParseKeys } from "i18next";
 import { Modal as RNModal, View } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { withUniwind } from "uniwind";
 
 import { cn } from "~/lib/style";
+import { GestureHandlerRootView } from "./Base/GestureHandlerRootView";
 import type { PressableProps } from "./Base/Pressable";
 import { ExtendedTButton } from "./Form/Button";
 import { TStyledText } from "./Typography/StyledText";
-
-const WrappedGestureHandlerRootView = withUniwind(GestureHandlerRootView);
 
 export function Modal(props: { visible: boolean; children: React.ReactNode }) {
   return (
@@ -19,11 +16,11 @@ export function Modal(props: { visible: boolean; children: React.ReactNode }) {
       navigationBarTranslucent
       transparent
     >
-      <WrappedGestureHandlerRootView className="flex-1 items-center justify-center bg-black/50 px-4">
+      <GestureHandlerRootView className="flex-1 items-center justify-center bg-black/50 px-4">
         <View className="w-full gap-8 rounded-xl bg-surfaceContainerLowest p-4 pt-6">
           {props.children}
         </View>
-      </WrappedGestureHandlerRootView>
+      </GestureHandlerRootView>
     </RNModal>
   );
 }

--- a/mobile/src/components/Modal.tsx
+++ b/mobile/src/components/Modal.tsx
@@ -1,8 +1,8 @@
 import type { ParseKeys } from "i18next";
-import type { PressableProps } from "react-native";
 import { Modal as RNModal, View } from "react-native";
 
 import { cn } from "~/lib/style";
+import type { PressableProps } from "./Base/Pressable";
 import { ExtendedTButton } from "./Form/Button";
 import { TStyledText } from "./Typography/StyledText";
 

--- a/mobile/src/components/Sheet/HorizontalRadioList.tsx
+++ b/mobile/src/components/Sheet/HorizontalRadioList.tsx
@@ -1,7 +1,8 @@
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { cn } from "~/lib/style";
 import { FlatList } from "../Base/List";
+import { Pressable } from "../Base/Pressable";
 
 export function HorizontalRadioList<T extends string>(props: {
   data: readonly T[];

--- a/mobile/src/components/Sheet/index.tsx
+++ b/mobile/src/components/Sheet/index.tsx
@@ -5,19 +5,16 @@ import type { ParseKeys } from "i18next";
 import { useState } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 import { View } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { withUniwind } from "uniwind";
 
 import { useIsKeyboardVisible } from "~/stores/ListenerState";
 import { useSafeAreaHeight } from "~/hooks/useSafeAreaHeight";
 
 import { cn } from "~/lib/style";
 import type { TrueSheetRef } from "./useSheetRef";
+import { GestureHandlerRootView } from "../Base/GestureHandlerRootView";
 import { Marquee } from "../Marquee";
 import { TEm } from "../Typography/StyledText";
-
-const WrappedGestureHandlerRootView = withUniwind(GestureHandlerRootView);
 
 interface SheetProps extends Pick<
   TrueSheetProps,
@@ -105,7 +102,7 @@ export function DetachedSheet(props: SheetProps) {
           "h-full": props.snapTop,
         })}
       >
-        <WrappedGestureHandlerRootView
+        <GestureHandlerRootView
           style={[
             { maxHeight: maxHeight - (EDGE_SPACER + bottom), gap },
             props.contentContainerStyle,
@@ -129,7 +126,7 @@ export function DetachedSheet(props: SheetProps) {
             ) : null}
           </View>
           {props.children}
-        </WrappedGestureHandlerRootView>
+        </GestureHandlerRootView>
       </View>
       <Toasts
         // @ts-expect-error - We added the `sheetOpts` prop via a patch.

--- a/mobile/src/modules/media/components/ArtistsLink.tsx
+++ b/mobile/src/modules/media/components/ArtistsLink.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from "@react-navigation/native";
-import { Pressable } from "react-native";
 
 import {
   navigateToArtist,
@@ -8,6 +7,7 @@ import {
 
 import type { ColorRole } from "~/lib/style";
 import { cn } from "~/lib/style";
+import { Pressable } from "~/components/Base/Pressable";
 import { Marquee } from "~/components/Marquee";
 import { StyledText } from "~/components/Typography/StyledText";
 import type { PopStrategy } from "~/stores/Session/types";

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -1,12 +1,12 @@
 import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";
-import { Pressable } from "react-native";
 
 import { useGetColumn } from "~/hooks/useGetColumn";
 import { getMediaLinkContext } from "~/navigation/utils/router";
 
 import { cn } from "~/lib/style";
 import type { LegendListProps } from "~/components/Base/LegendList";
+import { Pressable } from "~/components/Base/Pressable";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 import type { MediaCardContent, MediaCardProps } from "./MediaCard.type";

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -6,7 +6,7 @@ import { getMediaLinkContext } from "~/navigation/utils/router";
 
 import { cn } from "~/lib/style";
 import type { LegendListProps } from "~/components/Base/LegendList";
-import { Pressable } from "~/components/Base/Pressable";
+import { RNGHPressable } from "~/components/Base/Pressable";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ContentPlaceholder } from "~/navigation/components/Placeholder";
 import type { MediaCardContent, MediaCardProps } from "./MediaCard.type";
@@ -26,7 +26,7 @@ export function MediaCard({
   ...imgProps
 }: MediaCardProps) {
   return (
-    <Pressable
+    <RNGHPressable
       onPress={onPress}
       style={{ maxWidth: imgProps.size }}
       // Using `grow` instead of `w-full` because only 1 item gets shown otherwise.
@@ -39,7 +39,7 @@ export function MediaCard({
       <StyledText dim numberOfLines={1}>
         {description}
       </StyledText>
-    </Pressable>
+    </RNGHPressable>
   );
 }
 //#endregion

--- a/mobile/src/navigation/components/BottomActions.tsx
+++ b/mobile/src/navigation/components/BottomActions.tsx
@@ -3,7 +3,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useState } from "react";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 import Animated, { LinearTransition } from "react-native-reanimated";
 
 import { Search } from "~/resources/icons/Search";
@@ -18,6 +18,7 @@ import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { capitalize } from "~/utils/string";
 import { FlatList, useFlatListRef } from "~/components/Base/List";
+import { Pressable } from "~/components/Base/Pressable";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { StyledText } from "~/components/Typography/StyledText";
 import type { Tab } from "~/stores/Preference/types";

--- a/mobile/src/navigation/components/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/MiniPlayer.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from "@react-navigation/native";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { Pause } from "~/resources/icons/Pause";
 import { PlayArrow } from "~/resources/icons/PlayArrow";
@@ -12,6 +12,7 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 
 import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
+import { Pressable } from "~/components/Base/Pressable";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { Marquee } from "~/components/Marquee";
 import { Swipeable } from "~/components/Swipeable";

--- a/mobile/src/navigation/providers/AppProvider.tsx
+++ b/mobile/src/navigation/providers/AppProvider.tsx
@@ -4,7 +4,6 @@ import { NavigationBar } from "@zoontek/react-native-navigation-bar";
 import { platformApiLevel } from "expo-device";
 import { useMemo } from "react";
 import { StatusBar, View } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { Provider as PaperProvider } from "react-native-paper";
 import {
@@ -17,6 +16,7 @@ import { ListenerStateStoreProvider } from "~/stores/ListenerState";
 import { useCurrentTheme } from "~/hooks/useTheme";
 
 import { queryClient } from "~/lib/react-query";
+import { GestureHandlerRootView } from "~/components/Base/GestureHandlerRootView";
 
 /** All providers used by the app. */
 export function AppProvider(props: { children: React.ReactNode }) {

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -1,7 +1,7 @@
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
-import { BackHandler, Pressable, useWindowDimensions } from "react-native";
+import { BackHandler, useWindowDimensions } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import Animated, {
   FadeInLeft,
@@ -27,6 +27,7 @@ import { OnRTL, OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { addTrailingSlash } from "~/utils/string";
 import { useAnimatedLegendListRef } from "~/components/Base/LegendList";
+import { Pressable } from "~/components/Base/Pressable";
 import { useAnimatedScrollViewRef } from "~/components/Base/ScrollView";
 import { StyledText } from "~/components/Typography/StyledText";
 import {

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import type { TrackWithRelations } from "~/db/schema";
 
@@ -30,6 +30,7 @@ import { useSleepTimerStore } from "./sheets/SleepTimerSheet/store";
 
 import { OnRTL } from "~/lib/react";
 import { mutateGuard } from "~/lib/react-query";
+import { Pressable } from "~/components/Base/Pressable";
 import { FilledIconButton, IconButton } from "~/components/Form/Button/Icon";
 import { Marquee } from "~/components/Marquee";
 import { SafeContainer } from "~/components/SafeContainer";

--- a/mobile/src/navigation/screens/now-playing/components/Artwork.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/Artwork.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from "jotai";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   useAnimatedStyle,
@@ -16,6 +16,7 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 import { isSeekingAtom } from "../helpers/Seekbar.context";
 import { useVinylSeekbar } from "../helpers/useVinylSeekbar";
 
+import { Pressable } from "~/components/Base/Pressable";
 import { MediaImage } from "~/modules/media/components/MediaImage";
 import { Vinyl } from "~/modules/media/components/Vinyl";
 

--- a/mobile/src/navigation/screens/now-playing/components/TopAppBar.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/TopAppBar.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { ArrowBack } from "~/resources/icons/ArrowBack";
 import { usePlaybackStore } from "~/stores/Playback/store";
@@ -11,6 +11,7 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 import { getMediaLinkContext } from "~/navigation/utils/router";
 
 import { OnRTL } from "~/lib/react";
+import { Pressable } from "~/components/Base/Pressable";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { Marquee } from "~/components/Marquee";
 import { SafeContainer } from "~/components/SafeContainer";

--- a/mobile/src/navigation/screens/now-playing/sheets/PlaybackOptionsSheet.tsx
+++ b/mobile/src/navigation/screens/now-playing/sheets/PlaybackOptionsSheet.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import TrackPlayer from "@weights-ai/react-native-track-player";
 import { useCallback, useState } from "react";
-import { Pressable } from "react-native";
 
 import { ActivityZone } from "~/resources/icons/ActivityZone";
 import { SlowMotionVideo } from "~/resources/icons/SlowMotionVideo";
@@ -18,6 +17,7 @@ import { getMediaLinkContext } from "~/navigation/utils/router";
 import { AppearanceSheet } from "./AppearanceSheet";
 import { PlaybackSpeedSheet } from "./PlaybackSpeedSheet";
 
+import { Pressable } from "~/components/Base/Pressable";
 import { ScrollView } from "~/components/Base/ScrollView";
 import { NumberStepper } from "~/components/Form/NumberStepper";
 import { CachedSlider } from "~/components/Form/Slider";

--- a/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
@@ -1,5 +1,5 @@
 import { openBrowserAsync } from "expo-web-browser";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import { KeyboardArrowDown } from "~/resources/icons/KeyboardArrowDown";
 import { OpenInNew } from "~/resources/icons/OpenInNew";
@@ -12,6 +12,7 @@ import {
 import { TRANSLATIONS } from "~/constants/Links";
 import { OnRTL } from "~/lib/react";
 import { FlatList } from "~/components/Base/List";
+import { Pressable } from "~/components/Base/Pressable";
 import { ExtendedTButton } from "~/components/Form/Button";
 import { ClickwrapCheckbox } from "~/components/Form/Checkbox";
 import { RadioField } from "~/components/Form/Radio";

--- a/mobile/src/navigation/screens/tracks/sheets/TrackSheet.tsx
+++ b/mobile/src/navigation/screens/tracks/sheets/TrackSheet.tsx
@@ -1,7 +1,7 @@
 import { TrueSheet } from "@lodev09/react-native-true-sheet";
 import { useNavigation, useNavigationState } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 
 import type { TrackWithRelations } from "~/db/schema";
 
@@ -33,6 +33,7 @@ import {
   formatEpoch,
   formatSeconds,
 } from "~/utils/number";
+import { Pressable } from "~/components/Base/Pressable";
 import { Divider } from "~/components/Divider";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { Marquee } from "~/components/Marquee";

--- a/mobile/src/navigation/sheets/SortSheet.tsx
+++ b/mobile/src/navigation/sheets/SortSheet.tsx
@@ -1,5 +1,3 @@
-import { Pressable } from "react-native";
-
 import { useViewPreferenceStore } from "~/stores/ViewPreference/store";
 import {
   ViewPreferenceSetters,
@@ -7,6 +5,7 @@ import {
 } from "~/stores/ViewPreference/actions";
 
 import { FlatList } from "~/components/Base/List";
+import { Pressable } from "~/components/Base/Pressable";
 import { RadioField } from "~/components/Form/Radio";
 import { DetachedSheet } from "~/components/Sheet";
 import type { TrueSheetRef } from "~/components/Sheet/useSheetRef";


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

One issue I noticed reappear recently was that sometimes, the `onPress` event on some elements were not firing, even though the animations get triggered (so `onPressIn`/`onPressOut` consistently works but `onPress` & `onLongPress` doessn't). I noticed this early on when switching over to the New Architecture, so it's potentially related to that. In addition, it seems to only happen when the Pressable is in some sort of list component.

### Potential Solution

Using the Pressable exported from RNGH fixes the issue, but has the trade off of not being able to assign `active:*` and `disabled:*` classes due to `withUniwind` not knowing what type of component is being passed.
- This requires patching Uniwind to export a `RNGHPressable` component that follows along [the Uniwind's implementation of getting Tailwind to work with React Native's `Pressable`](https://github.com/uni-stack/uniwind/blob/b6f3aef1eaa8f53514773f096fc85d129163f6ee/packages/uniwind/src/components/native/Pressable.tsx).
- I initially tried to use a fork and install it via a GitHub repository link, but encountered a lot of annoying issues since the repository uses Bun and its features while the package is built by GitHub using Yarn.

### Tradeoff

We initially replaced all of React Native's Pressables with ones from RNGH, but the UX wasn't that great as the components are really heavy, resulting in a noticeable delay in some situations and potentially block the JS thread.

As a tradeoff, we only use it where we know the issue can occur reliably, which is on the `RemoveableItem` component when used on the "Upcoming" screen. We also encountered the issue on the `MediaCard` component on the home screen, so we also use it there as well.

### Better Solutions

A better solution would be for [this PR on the React Native repository](https://redirect.github.com/facebook/react-native/pull/51835) getting merged, which would potentially fix the issue and allow us to switch back to using React Native's Pressables for better performance.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
