### PR TITLE
refactor: Utilize latest Sentry version

### DIFF
--- a/.github/workflows/privacy-build.yml
+++ b/.github/workflows/privacy-build.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Setup Node.js & pnpm
         uses: ./.github/actions/setup
 
+      - name: Uninstall `@sentry/react-native` dependency
+        run: pnpm uninstall @sentry/react-native
+        shell: bash
+
       - name: Setup JDK 18
         uses: actions/setup-java@v4
         with:

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -252,5 +252,7 @@ if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
         autoInstallation {
             enabled = false
         }
+        // https://docs.sentry.io/platforms/android/configuration/gradle/#configure
+        telemetry = false
     }
 }

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -63,83 +63,6 @@ react {
     autolinkLibrariesWithApp()
 }
 
-
-if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
-    apply plugin: "io.sentry.android.gradle"
-
-    /**
-    * Sentry gradle from React Native (@sentry/react-native) that handles uploads Sentry source maps.
-    *  - It seems like source maps aren't automatically uploaded with `expo run:android --variant release`.
-    *    - https://github.com/getsentry/sentry-react-native/issues/3907
-    *    - We're going to trust that it works in the production variants which are built with
-    *    `./gradlew assembleRelease`.
-    */
-    apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
-
-    /**
-    * View default settings at: https://docs.sentry.io/platforms/android/configuration/gradle/
-    *
-    * Code partially based off of: https://github.com/getsentry/sentry-react-native/blob/main/samples/react-native/android/app/build.gradle
-    */ 
-    sentry {
-        // Whether the plugin should attempt to auto-upload the mapping file to Sentry or not.
-        // If disabled the plugin will run a dry-run and just generate a UUID.
-        // The mapping file has to be uploaded manually via sentry-cli in this case.
-        // Default is enabled.
-        autoUploadProguardMapping = shouldSentryAutoUpload()
-
-        // Disables or enables the automatic configuration of Native Symbols
-        // for Sentry. This executes sentry-cli automatically so
-        // you don't need to do it manually.
-        // Default is disabled.
-        uploadNativeSymbols = shouldSentryAutoUpload()
-
-        // Does or doesn't include the source code of native code for Sentry.
-        // This executes sentry-cli with the --include-sources param. automatically so
-        // you don't need to do it manually.
-        // This option has an effect only when [uploadNativeSymbols] is enabled.
-        // Default is disabled.
-        includeNativeSources = true
-
-        // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
-        // This enables source context, allowing you to see your source
-        // code as part of your stack traces in Sentry.
-        //
-        // Default is disabled.
-        includeSourceContext = shouldSentryAutoUpload()
-
-        // Enable or disable the tracing instrumentation.
-        // Does auto instrumentation for specified features through bytecode manipulation.
-        // Default is enabled.
-        tracingInstrumentation {
-            enabled = false
-        }
-
-        // `@sentry/react-native` ships with compatible `sentry-android`
-        // This option would install the latest version that ships with the SDK or SAGP (Sentry Android Gradle Plugin)
-        // which might be incompatible with the React Native SDK
-        // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
-        // Default is enabled.
-        autoInstallation {
-            enabled = false
-        }
-
-        // Disables or enables dependencies metadata reporting for Sentry.
-        // If enabled, the plugin will collect external dependencies and
-        // upload them to Sentry as part of events. If disabled, all the logic
-        // related to the dependencies metadata report will be excluded.
-        //
-        // Default is enabled.
-        includeDependenciesReport = false
-
-        // Whether the plugin should send telemetry data to Sentry.
-        // If disabled the plugin won't send telemetry data.
-        // This is auto disabled if running against a self hosted instance of Sentry.
-        // Default is enabled.
-        telemetry = false
-    }
-}
-
 /**
  * Set this to true in release builds to optimize the app using [R8](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization).
  */
@@ -295,5 +218,39 @@ dependencies {
         implementation("com.facebook.react:hermes-android")
     } else {
         implementation jscFlavor
+    }
+}
+
+if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
+    apply plugin: "io.sentry.android.gradle"
+
+    /**
+    * Sentry gradle from React Native (@sentry/react-native) that handles uploads Sentry source maps.
+    *  - It seems like source maps aren't automatically uploaded with `expo run:android --variant release`.
+    *    - https://github.com/getsentry/sentry-react-native/issues/3907
+    *    - We're going to trust that it works in the production variants which are built with
+    *    `./gradlew assembleRelease`.
+    */
+    apply from: new File(["node", "--print", "require('path').dirname(require.resolve('@sentry/react-native/package.json'))"].execute().text.trim(), "sentry.gradle")
+
+    /**
+    * View default settings at: https://docs.sentry.io/platforms/android/configuration/gradle/
+    *
+    * Code partially based off of: https://github.com/getsentry/sentry-react-native/blob/main/samples/react-native/android/app/build.gradle
+    */
+    sentry {
+        autoUploadProguardMapping = shouldSentryAutoUpload()
+        includeProguardMapping = true
+        dexguardEnabled = false
+        uploadNativeSymbols = shouldSentryAutoUpload()
+        autoUploadNativeSymbols = shouldSentryAutoUpload()
+        includeNativeSources = true
+        includeSourceContext = shouldSentryAutoUpload()
+        tracingInstrumentation {
+            enabled = false
+        }
+        autoInstallation {
+            enabled = false
+        }
     }
 }

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -6,13 +6,12 @@ buildscript {
     mavenCentral()
   }
   dependencies {
+    if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
+      classpath("io.sentry:sentry-android-gradle-plugin:5.12.1")
+    }
     classpath('com.android.tools.build:gradle')
     classpath('com.facebook.react:react-native-gradle-plugin')
     classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
-
-    if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
-      classpath('io.sentry:sentry-android-gradle-plugin:5.9.0')
-    }
   }
 }
 

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
   dependencies {
     if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
-      classpath("io.sentry:sentry-android-gradle-plugin:5.12.1")
+      classpath("io.sentry:sentry-android-gradle-plugin:6.1.0")
     }
     classpath('com.android.tools.build:gradle')
     classpath('com.facebook.react:react-native-gradle-plugin')
@@ -22,14 +22,6 @@ allprojects {
     maven { url 'https://jitpack.io' }
     maven {
       url "$rootDir/../node_modules/@missingcore/music-glyph-toys/android/glyph-matrix-sdk"
-    }
-  }
-}
-
-subprojects {
-  configurations.all {
-    if (findProperty('music.WITH_SENTRY')?.toBoolean()) {
-      exclude group: 'io.sentry', module: 'sentry-android-replay'
     }
   }
 }

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -107,6 +107,8 @@ export default (): ExpoConfig => ({
 
 //#region Sentry Plugin Configs
 const sentryPluginConfig = {
+  project: "music",
+  organization: "missingcore",
   experimental_android: {
     enableAndroidGradlePlugin: true,
     autoUploadProguardMapping: true,

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -100,9 +100,22 @@ export default (): ExpoConfig => ({
       { android: { enforceNavigationBarContrast: false } },
     ],
     ["react-native-android-widget", widgetPluginConfig],
+    ["@sentry/react-native/expo", sentryPluginConfig],
   ],
   newArchEnabled: true,
 });
+
+//#region Sentry Plugin Configs
+const sentryPluginConfig = {
+  experimental_android: {
+    enableAndroidGradlePlugin: true,
+    autoUploadProguardMapping: true,
+    uploadNativeSymbols: true,
+    includeNativeSources: true,
+    includeSourceContext: true,
+  },
+};
+//#endregion
 
 //#region Widget Plugin Configs
 const widgetPluginConfig: WithAndroidWidgetsParams = {

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,43 +1,6 @@
 import type { ExpoConfig } from "expo/config";
 import type { WithAndroidWidgetsParams } from "react-native-android-widget";
 
-const widgetConfig: WithAndroidWidgetsParams = {
-  widgets: [
-    {
-      name: "ArtworkPlayer",
-      label: "🧪 Artwork Player",
-      minWidth: "110dp",
-      minHeight: "110dp",
-      targetCellWidth: 2,
-      targetCellHeight: 2,
-      description:
-        "[Experimental] Displays track artwork and allows for play/pause.",
-      previewImage: "./assets/widget/artwork-player.png",
-    },
-    {
-      name: "NowPlaying",
-      label: "🧪 Now Playing",
-      minWidth: "110dp",
-      minHeight: "110dp",
-      targetCellWidth: 2,
-      targetCellHeight: 2,
-      description: "[Experimental] Quick access to your media controls.",
-      previewImage: "./assets/widget/now-playing.png",
-    },
-    {
-      name: "ResizableNowPlaying",
-      label: "🧪 Now Playing",
-      minWidth: "250dp",
-      minHeight: "110dp",
-      targetCellWidth: 4,
-      targetCellHeight: 2,
-      description: "[Experimental] Quick access to your media controls.",
-      previewImage: "./assets/widget/resizable-now-playing.png",
-      resizeMode: "horizontal",
-    },
-  ],
-};
-
 const BUILD_THEME: "light" | "dark" = "light";
 const BACKGROUND_COLOR = BUILD_THEME === "light" ? "#F2F2F2" : "#000000";
 const ICON_BACKGROUND_COLOR = BUILD_THEME === "light" ? "#FFFFFF" : "#000000";
@@ -136,7 +99,46 @@ export default (): ExpoConfig => ({
       "@zoontek/react-native-navigation-bar",
       { android: { enforceNavigationBarContrast: false } },
     ],
-    ["react-native-android-widget", widgetConfig],
+    ["react-native-android-widget", widgetPluginConfig],
   ],
   newArchEnabled: true,
 });
+
+//#region Widget Plugin Configs
+const widgetPluginConfig: WithAndroidWidgetsParams = {
+  widgets: [
+    {
+      name: "ArtworkPlayer",
+      label: "🧪 Artwork Player",
+      minWidth: "110dp",
+      minHeight: "110dp",
+      targetCellWidth: 2,
+      targetCellHeight: 2,
+      description:
+        "[Experimental] Displays track artwork and allows for play/pause.",
+      previewImage: "./assets/widget/artwork-player.png",
+    },
+    {
+      name: "NowPlaying",
+      label: "🧪 Now Playing",
+      minWidth: "110dp",
+      minHeight: "110dp",
+      targetCellWidth: 2,
+      targetCellHeight: 2,
+      description: "[Experimental] Quick access to your media controls.",
+      previewImage: "./assets/widget/now-playing.png",
+    },
+    {
+      name: "ResizableNowPlaying",
+      label: "🧪 Now Playing",
+      minWidth: "250dp",
+      minHeight: "110dp",
+      targetCellWidth: 4,
+      targetCellHeight: 2,
+      description: "[Experimental] Quick access to your media controls.",
+      previewImage: "./assets/widget/resizable-now-playing.png",
+      resizeMode: "horizontal",
+    },
+  ],
+};
+//#endregion

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -5,109 +5,115 @@ const BUILD_THEME: "light" | "dark" = "light";
 const BACKGROUND_COLOR = BUILD_THEME === "light" ? "#F2F2F2" : "#000000";
 const ICON_BACKGROUND_COLOR = BUILD_THEME === "light" ? "#FFFFFF" : "#000000";
 
-export default (): ExpoConfig => ({
-  name: "Music",
-  slug: "Music",
-  description: "A Nothing inspired music player.",
-  version: "2.9.0",
-  platforms: ["android"],
-  githubUrl: "https://github.com/MissingCore/Music",
-  orientation: "portrait",
-  primaryColor: "#C8102E",
-  icon: `./assets/${BUILD_THEME}/icon.png`,
-  scheme: ["com.cyanchill.missingcore.music"],
-  backgroundColor: BACKGROUND_COLOR,
-  userInterfaceStyle: "automatic",
-  assetBundlePatterns: ["**/*"],
-  android: {
-    package: "com.cyanchill.missingcore.music",
-    versionCode: 1057,
-    adaptiveIcon: {
-      foregroundImage: `./assets/${BUILD_THEME}/adaptive-icon.png`,
-      monochromeImage: `./assets/${BUILD_THEME}/adaptive-icon-monochrome.png`,
-      backgroundColor: ICON_BACKGROUND_COLOR,
-    },
-    blockedPermissions: [
-      // Optional permissions that Expo adds.
-      "android.permission.VIBRATE",
-      // From `expo-image-picker`.
-      "android.permission.CAMERA",
-      // From `expo-media-library`.
-      "android.permission.READ_MEDIA_VISUAL_USER_SELECTED",
-    ],
-    intentFilters: [
-      // Whenever we rebuild the `AndroidManifest.xml` file, we should delete
-      // the generated "MAIN" intent filter.
-      {
-        action: "MAIN",
-        category: ["DEFAULT", "LAUNCHER", "APP_MUSIC"],
+export default (): ExpoConfig => {
+  const optionalPlugins: ExpoConfig["plugins"] = [];
+
+  //? Even if we uninstall `@sentry/react-native`, the build will fail
+  //? due to it being referenced in the plugin.
+  if (process.env.EXPO_PUBLIC_WITH_SENTRY === "true") {
+    optionalPlugins.push(["@sentry/react-native/expo", sentryPluginConfig]);
+  }
+
+  return {
+    name: "Music",
+    slug: "Music",
+    description: "A Nothing inspired music player.",
+    version: "2.9.0",
+    platforms: ["android"],
+    githubUrl: "https://github.com/MissingCore/Music",
+    orientation: "portrait",
+    primaryColor: "#C8102E",
+    icon: `./assets/${BUILD_THEME}/icon.png`,
+    scheme: ["com.cyanchill.missingcore.music"],
+    backgroundColor: BACKGROUND_COLOR,
+    userInterfaceStyle: "automatic",
+    assetBundlePatterns: ["**/*"],
+    android: {
+      package: "com.cyanchill.missingcore.music",
+      versionCode: 1057,
+      adaptiveIcon: {
+        foregroundImage: `./assets/${BUILD_THEME}/adaptive-icon.png`,
+        monochromeImage: `./assets/${BUILD_THEME}/adaptive-icon-monochrome.png`,
+        backgroundColor: ICON_BACKGROUND_COLOR,
       },
-      // Allows us to "Open With" on music files.
-      {
-        action: "VIEW",
-        category: ["DEFAULT", "BROWSABLE"],
-        data: [
-          // Recieve intent from `file://` & `content://` URIs.
-          { scheme: "content" },
-          { scheme: "file" },
-          // Normal audio mime types + weird mime types we can "Open With".
-          { mimeType: "audio/*" },
-          { mimeType: "application/ogg" },
-          { mimeType: "application/x-ogg" },
-          { mimeType: "application/itunes" },
-        ],
-      },
-    ],
-  },
-  plugins: [
-    [
-      "expo-build-properties",
-      {
-        android: {
-          enableBundleCompression: true,
-          enableMinifyInReleaseBuilds: true,
-          enableShrinkResourcesInReleaseBuilds: true,
+      blockedPermissions: [
+        // Optional permissions that Expo adds.
+        "android.permission.VIBRATE",
+        // From `expo-image-picker`.
+        "android.permission.CAMERA",
+        // From `expo-media-library`.
+        "android.permission.READ_MEDIA_VISUAL_USER_SELECTED",
+      ],
+      intentFilters: [
+        // Whenever we rebuild the `AndroidManifest.xml` file, we should delete
+        // the generated "MAIN" intent filter.
+        {
+          action: "MAIN",
+          category: ["DEFAULT", "LAUNCHER", "APP_MUSIC"],
         },
-      },
+        // Allows us to "Open With" on music files.
+        {
+          action: "VIEW",
+          category: ["DEFAULT", "BROWSABLE"],
+          data: [
+            // Recieve intent from `file://` & `content://` URIs.
+            { scheme: "content" },
+            { scheme: "file" },
+            // Normal audio mime types + weird mime types we can "Open With".
+            { mimeType: "audio/*" },
+            { mimeType: "application/ogg" },
+            { mimeType: "application/x-ogg" },
+            { mimeType: "application/itunes" },
+          ],
+        },
+      ],
+    },
+    plugins: [
+      [
+        "expo-build-properties",
+        {
+          android: {
+            enableBundleCompression: true,
+            enableMinifyInReleaseBuilds: true,
+            enableShrinkResourcesInReleaseBuilds: true,
+          },
+        },
+      ],
+      [
+        "expo-font",
+        {
+          fonts: [
+            "assets/fonts/Roboto-Regular.ttf",
+            "assets/fonts/Roboto-Medium.ttf",
+            "assets/fonts/Inter-Regular.ttf",
+            "assets/fonts/Inter-Medium.ttf",
+            "assets/fonts/GeistMono-Regular.ttf",
+            "assets/fonts/GeistMono-Medium.ttf",
+            "assets/fonts/Ndot-77_JP_Extended.ttf",
+            "assets/fonts/NType82-Headline.otf",
+          ],
+        },
+      ],
+      ["expo-image-picker", { microphonePermission: false }],
+      ["expo-media-library", { granularPermissions: ["audio"] }],
+      [
+        "react-native-bootsplash",
+        {
+          logo: `./assets/${BUILD_THEME}/splash-icon.png`,
+          background: BACKGROUND_COLOR,
+          assetsOutput: `./assets/${BUILD_THEME}/bootsplash`,
+        },
+      ],
+      [
+        "@zoontek/react-native-navigation-bar",
+        { android: { enforceNavigationBarContrast: false } },
+      ],
+      ["react-native-android-widget", widgetPluginConfig],
+      ...optionalPlugins,
     ],
-    [
-      "expo-font",
-      {
-        fonts: [
-          "assets/fonts/Roboto-Regular.ttf",
-          "assets/fonts/Roboto-Medium.ttf",
-          "assets/fonts/Inter-Regular.ttf",
-          "assets/fonts/Inter-Medium.ttf",
-          "assets/fonts/GeistMono-Regular.ttf",
-          "assets/fonts/GeistMono-Medium.ttf",
-          "assets/fonts/Ndot-77_JP_Extended.ttf",
-          "assets/fonts/NType82-Headline.otf",
-        ],
-      },
-    ],
-    ["expo-image-picker", { microphonePermission: false }],
-    ["expo-media-library", { granularPermissions: ["audio"] }],
-    [
-      "react-native-bootsplash",
-      {
-        logo: `./assets/${BUILD_THEME}/splash-icon.png`,
-        background: BACKGROUND_COLOR,
-        assetsOutput: `./assets/${BUILD_THEME}/bootsplash`,
-      },
-    ],
-    [
-      "@zoontek/react-native-navigation-bar",
-      { android: { enforceNavigationBarContrast: false } },
-    ],
-    ["react-native-android-widget", widgetPluginConfig],
-    //? Even if we uninstall `@sentry/react-native`, the build will fail
-    //? due to it being referenced in the plugin.
-    process.env.EXPO_PUBLIC_WITH_SENTRY === "true"
-      ? ["@sentry/react-native/expo", sentryPluginConfig]
-      : [],
-  ],
-  newArchEnabled: true,
-});
+    newArchEnabled: true,
+  };
+};
 
 //#region Sentry Plugin Configs
 const sentryPluginConfig = {

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -100,7 +100,11 @@ export default (): ExpoConfig => ({
       { android: { enforceNavigationBarContrast: false } },
     ],
     ["react-native-android-widget", widgetPluginConfig],
-    ["@sentry/react-native/expo", sentryPluginConfig],
+    //? Even if we uninstall `@sentry/react-native`, the build will fail
+    //? due to it being referenced in the plugin.
+    process.env.EXPO_PUBLIC_WITH_SENTRY === "true"
+      ? ["@sentry/react-native/expo", sentryPluginConfig]
+      : [],
   ],
   newArchEnabled: true,
 });

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -5,7 +5,9 @@ const { withUniwindConfig } = require("uniwind/metro");
 let config = null;
 
 if (process.env.EXPO_PUBLIC_WITH_SENTRY === "true") {
-  const { getSentryExpoConfig } = require("@sentry/react-native/metro");
+  const { getSentryExpoConfig } = require("@sentry/react-native/metro", {
+    includeWebReplay: false,
+  });
   config = getSentryExpoConfig(__dirname);
 } else {
   const { getDefaultConfig } = require("expo/metro-config");

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -36,7 +36,7 @@
     "@react-navigation/material-top-tabs": "7.4.16",
     "@react-navigation/native": "7.1.31",
     "@react-navigation/native-stack": "7.14.2",
-    "@sentry/react-native": "7.3.0",
+    "@sentry/react-native": "7.4.0",
     "@tanstack/react-query": "5.90.21",
     "@weights-ai/react-native-track-player": "github:MissingCore/react-native-track-player#74325fcbff1af92006d31791bcca493985f94550",
     "@zoontek/react-native-navigation-bar": "1.1.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -36,7 +36,7 @@
     "@react-navigation/material-top-tabs": "7.4.16",
     "@react-navigation/native": "7.1.31",
     "@react-navigation/native-stack": "7.14.2",
-    "@sentry/react-native": "7.4.0",
+    "@sentry/react-native": "8.2.0",
     "@tanstack/react-query": "5.90.21",
     "@weights-ai/react-native-track-player": "github:MissingCore/react-native-track-player#74325fcbff1af92006d31791bcca493985f94550",
     "@zoontek/react-native-navigation-bar": "1.1.0",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: 7.14.2
         version: 7.14.2(@react-navigation/native@7.1.31(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-safe-area-context@5.7.0(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-screens@4.24.0(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
       '@sentry/react-native':
-        specifier: 7.3.0
-        version: 7.3.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
+        specifier: 7.4.0
+        version: 7.4.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
       '@tanstack/react-query':
         specifier: 5.90.21
         version: 5.90.21(react@19.1.4)
@@ -1734,88 +1734,88 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@sentry-internal/browser-utils@10.18.0':
-    resolution: {integrity: sha512-6Y5VkNcj5ecIFsKdL8/7hrLt7pCuWR4BRLsKOHAmhdCnXtobf7v6DeBow2Hk5yEYO0AwjP5mqvoBAewbS+h3GA==}
+  '@sentry-internal/browser-utils@10.20.0':
+    resolution: {integrity: sha512-9+NybrYs+dEM2iW5uRAYEhKkNK0XhDea5jovtDUXEvdSCMJFcdR88uztkftnCur45/hpvbgSULsGPUdHPb5ITw==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.18.0':
-    resolution: {integrity: sha512-uuupIivGPCpRStMU1I3sYPgD+pl8PqNV1DSVgVS5LF99h8tqjmRGS1xkCrUaUhVhVmsnxzbnvXb1hsOaCXX7DA==}
+  '@sentry-internal/feedback@10.20.0':
+    resolution: {integrity: sha512-R/eGLKl7WDccLKBorEbyTsy5b99w/k4v80SntE8HL2rsO7DCDXma8TGmtHd+iZnw8dUci+EVrw7LbeGSgf3QzA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.18.0':
-    resolution: {integrity: sha512-asp1biXA+F5HAKl7RvPbf5s087bg1bpxMB9E69xWc1ECUfFMPrFRNS7mAJ5A8DTd1K74E9cFsLl6zO29HpH4+w==}
+  '@sentry-internal/replay-canvas@10.20.0':
+    resolution: {integrity: sha512-8DBawFi4F4e2Cu2ToiitCnYsK8idrDOv66Vq+N6c8e3qFitTTuoPQwOihb2+HY4CB06ABPW3WvfZntJJmsf91w==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.18.0':
-    resolution: {integrity: sha512-ixr3K19q4oTRgM0xANi+8ThDUbxV5iixUIgvJrT7c1L6yyidovIwO0D82ZY3phUfMkgE+mX3cxX46gXTRTglKQ==}
+  '@sentry-internal/replay@10.20.0':
+    resolution: {integrity: sha512-+XPYp0CuJnf+c36/c+hHrY6wAPHCdnqllZeyU7+9LAiKsdhN8Oo4eF1v5zd097qDZBg1NrKhU44ScJIzz+vygw==}
     engines: {node: '>=18'}
 
-  '@sentry/babel-plugin-component-annotate@4.3.0':
-    resolution: {integrity: sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==}
+  '@sentry/babel-plugin-component-annotate@4.4.0':
+    resolution: {integrity: sha512-Pzjpn9MZg6yR61ThJgOoD28dLNCj457O0/t8d276K+Bzf8iOZKbrNO4sltp1vUB1yqhV+ulvIZO8xu8ABohtsg==}
     engines: {node: '>= 14'}
 
-  '@sentry/browser@10.18.0':
-    resolution: {integrity: sha512-JrPfxjCsuVYUe16U4fo4W2Fn0f9BwRev3G28a4ZIkwKwJo+qSnIk1mT8Eam8nwNCU8MZjB4KNE9w2p0kaoQxvQ==}
+  '@sentry/browser@10.20.0':
+    resolution: {integrity: sha512-zcf8HwFiRbzjZL9KbLev44eEOf+yl+3svQbs2BlR2KAYGaB10swV5abij0UTTGO7ClnqUZdcGpwiyyfPS6mjHg==}
     engines: {node: '>=18'}
 
-  '@sentry/cli-darwin@2.56.0':
-    resolution: {integrity: sha512-CzXFWbv3GrjU0gFlUM9jt0fvJmyo5ktty4HGxRFfS/eMC6xW58Gg/sEeMVEkdvk5osKooX/YEgfLBdo4zvuWDA==}
+  '@sentry/cli-darwin@2.56.1':
+    resolution: {integrity: sha512-zfhT8MrvB5x/xRdIVGwg+sG0Cx3i0G6RH2zCrdQ/moWn8TfkwsM0O1k/AxpwbpcRfAHCkVb04CU/yKciKwg2KA==}
     engines: {node: '>=10'}
     os: [darwin]
 
-  '@sentry/cli-linux-arm64@2.56.0':
-    resolution: {integrity: sha512-91d5ZlC989j/t+TXor/glPyx6SnLFS/SlJ9fIrHIQohdGKyWWSFb4VKUan8Ok3GYu9SUzKTMByryIOoYEmeGVw==}
+  '@sentry/cli-linux-arm64@2.56.1':
+    resolution: {integrity: sha512-AypXIwZvOMJb9RgjI/98hTAd06FcOjqjIm6G9IR0OI4pJCOcaAXz9NKXdJqxpZd7phSMJnD+Bx/8iYOUPeY73A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm@2.56.0':
-    resolution: {integrity: sha512-vQCCMhZLugPmr25XBoP94dpQsFa110qK5SBUVJcRpJKyzMZd+6ueeHNslq2mB0OF4BwL1qd/ZDIa4nxa1+0rjQ==}
+  '@sentry/cli-linux-arm@2.56.1':
+    resolution: {integrity: sha512-fNB/Ng11HrkGOSEIDg+fc3zfTCV7q6kJddp6ndK3QlYFsCffRSnclaX1SMp+mqxdWkHqe1kkp85OY8G/x5uAWw==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-i686@2.56.0':
-    resolution: {integrity: sha512-MZzXuq1Q/TktN81DUs6XSBU752pG3XWSJdZR+NCStIg3l8s3O/Pwh6OcDHTYqgwsYJaGBpA0fP2Afl5XeSAUNg==}
+  '@sentry/cli-linux-i686@2.56.1':
+    resolution: {integrity: sha512-vnH+WJEsUq7Lf7xc9udzE/M4hoDXXsniFFYr/7BvdnXtCQlNNaWFMXHbEDYAql3baIlHkWoG8cEHWuB/YKyniw==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-x64@2.56.0':
-    resolution: {integrity: sha512-INOO2OQ90Y3UzYgHRdrHdKC/0es3YSHLv0iNNgQwllL0YZihSVNYSSrZqcPq8oSDllEy9Vt9oOm/7qEnUP2Kfw==}
+  '@sentry/cli-linux-x64@2.56.1':
+    resolution: {integrity: sha512-3/BlKe5Vdnia36MeovghHJD8lbcum5TFIxLp+PSfH2sVb09+5Jo0L95oRTI2JkD8Fs+QNssvTqTxJj5eIo/n+A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-win32-arm64@2.56.0':
-    resolution: {integrity: sha512-eUvkVk9KK01q6/qyugQPh7dAxqFPbgOa62QAoSwo11WQFYc3NPgJLilFWLQo+nahHGYKh6PKuCJ5tcqnQq5Hkg==}
+  '@sentry/cli-win32-arm64@2.56.1':
+    resolution: {integrity: sha512-Gg8RV7CV7Tz4fiR1EN1Af5AVhJsnEXiZvfvfQXI4lp51MKAhcxZIMtEfg9HaWsn3Dm/wgwYBinyeywfWbTXYDg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@sentry/cli-win32-i686@2.56.0':
-    resolution: {integrity: sha512-mpCA8hKXuvT17bl1H/54KOa5i+02VBBHVlOiP3ltyBuQUqfvX/30Zl/86Spy+ikodovZWAHv5e5FpyXbY1/mPw==}
+  '@sentry/cli-win32-i686@2.56.1':
+    resolution: {integrity: sha512-6u6a060yC3i76Ze1apqgWr5luQSyhuD5ND84eWfh/UbddsEa42UHjoVHOiBwmpZqf/hvNZAtzLnE4NCvU4zOMg==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [win32]
 
-  '@sentry/cli-win32-x64@2.56.0':
-    resolution: {integrity: sha512-UV0pXNls+/ViAU/3XsHLLNEHCsRYaGEwJdY3HyGIufSlglxrX6BVApkV9ziGi4WAxcJWLjQdfcEs6V5B+wBy0A==}
+  '@sentry/cli-win32-x64@2.56.1':
+    resolution: {integrity: sha512-11cdflajBrDWlRZqI9MOu7ok2vnPzFjKmbU3YvBYWQapNE+HHAsWdsRL/u/P1RmU62vj7Y42iSUcj6x1SNrdPw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@sentry/cli@2.56.0':
-    resolution: {integrity: sha512-br6+1nTPUV5EG1oaxLzxv31kREFKr49Y1+3jutfMUz9Nl8VyVP7o9YwakB/YWl+0Vi0NXg5vq7qsd/OOuV5j8w==}
+  '@sentry/cli@2.56.1':
+    resolution: {integrity: sha512-VDAIg+gmjNtJS5VUZQMDSK9RaKC9hYQi3PoXpNa+owNfQNk60bCi8z8jkbWRcKbNGn3V51WqvrQAqLoNAdPc9w==}
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@sentry/core@10.18.0':
-    resolution: {integrity: sha512-zlhAlzc/Qpza8f/CMUb7zg/9FOhWouKAm9zyV9jZlx9lL6WceVbUEwQ3rq8ncGgM+LMwlASCOjsz5a728vAhCw==}
+  '@sentry/core@10.20.0':
+    resolution: {integrity: sha512-S291KihnOIB8i7mVJIJBVHBMcCfIoY/KDJBHEfBoHY9M56g2An4FVhM9+/xR85+IoMkTySdXN08k9LEyQz4FpQ==}
     engines: {node: '>=18'}
 
-  '@sentry/react-native@7.3.0':
-    resolution: {integrity: sha512-VrvHK062zq+zuwFffloUjJ2K/+I+IO+tmtgwQMW8t1GkjdtVmrKm3QfZQVzfsXW53sehqkK9CgIHawj4p7DKjQ==}
+  '@sentry/react-native@7.4.0':
+    resolution: {integrity: sha512-dDbFEO4DkDjfGlo+gQ5u1JokMMSglZerAQZbuMJO1cBCt+G/+8GZBFVXSHPk/CZLWiPBxQWP27nHhZ7Y06h5hw==}
     hasBin: true
     peerDependencies:
       expo: '>=49.0.0'
@@ -1825,14 +1825,14 @@ packages:
       expo:
         optional: true
 
-  '@sentry/react@10.18.0':
-    resolution: {integrity: sha512-mLVJzF/+VFTNkqVqApU9QLrTAahASLKLaPreJ5LUXhEbCEiBUTQNZIn8Js+tDisHwbdy9k94XC1/OLxld3Calg==}
+  '@sentry/react@10.20.0':
+    resolution: {integrity: sha512-8W+gMkMxQhqlGHCW7kjLhcLgBJ/YSHbLhVd36s0GRudxjXh61K8rdCaAXToD8akgZ76DtLbx5PPQ5fLfQCOnpw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
-  '@sentry/types@10.18.0':
-    resolution: {integrity: sha512-AVUL63Lotvd7cujtch1A7Rax5syleB7jAP/I5sdCs6UvDc5VqmuTNsrg5DfjBNOOPPoGGfbSBaMBQAimvtNFaA==}
+  '@sentry/types@10.20.0':
+    resolution: {integrity: sha512-9pGtoiYBvw0SpHayBlQ6/9F4wP/KwlS8KZg1iBsZSR8h8WjLRGbER/TjKcAdg07HPd0APVajbT2YyL30+9Oi8Q==}
     engines: {node: '>=18'}
 
   '@sinclair/typebox@0.27.10':
@@ -7479,59 +7479,59 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@sentry-internal/browser-utils@10.18.0':
+  '@sentry-internal/browser-utils@10.20.0':
     dependencies:
-      '@sentry/core': 10.18.0
+      '@sentry/core': 10.20.0
 
-  '@sentry-internal/feedback@10.18.0':
+  '@sentry-internal/feedback@10.20.0':
     dependencies:
-      '@sentry/core': 10.18.0
+      '@sentry/core': 10.20.0
 
-  '@sentry-internal/replay-canvas@10.18.0':
+  '@sentry-internal/replay-canvas@10.20.0':
     dependencies:
-      '@sentry-internal/replay': 10.18.0
-      '@sentry/core': 10.18.0
+      '@sentry-internal/replay': 10.20.0
+      '@sentry/core': 10.20.0
 
-  '@sentry-internal/replay@10.18.0':
+  '@sentry-internal/replay@10.20.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.18.0
-      '@sentry/core': 10.18.0
+      '@sentry-internal/browser-utils': 10.20.0
+      '@sentry/core': 10.20.0
 
-  '@sentry/babel-plugin-component-annotate@4.3.0': {}
+  '@sentry/babel-plugin-component-annotate@4.4.0': {}
 
-  '@sentry/browser@10.18.0':
+  '@sentry/browser@10.20.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.18.0
-      '@sentry-internal/feedback': 10.18.0
-      '@sentry-internal/replay': 10.18.0
-      '@sentry-internal/replay-canvas': 10.18.0
-      '@sentry/core': 10.18.0
+      '@sentry-internal/browser-utils': 10.20.0
+      '@sentry-internal/feedback': 10.20.0
+      '@sentry-internal/replay': 10.20.0
+      '@sentry-internal/replay-canvas': 10.20.0
+      '@sentry/core': 10.20.0
 
-  '@sentry/cli-darwin@2.56.0':
+  '@sentry/cli-darwin@2.56.1':
     optional: true
 
-  '@sentry/cli-linux-arm64@2.56.0':
+  '@sentry/cli-linux-arm64@2.56.1':
     optional: true
 
-  '@sentry/cli-linux-arm@2.56.0':
+  '@sentry/cli-linux-arm@2.56.1':
     optional: true
 
-  '@sentry/cli-linux-i686@2.56.0':
+  '@sentry/cli-linux-i686@2.56.1':
     optional: true
 
-  '@sentry/cli-linux-x64@2.56.0':
+  '@sentry/cli-linux-x64@2.56.1':
     optional: true
 
-  '@sentry/cli-win32-arm64@2.56.0':
+  '@sentry/cli-win32-arm64@2.56.1':
     optional: true
 
-  '@sentry/cli-win32-i686@2.56.0':
+  '@sentry/cli-win32-i686@2.56.1':
     optional: true
 
-  '@sentry/cli-win32-x64@2.56.0':
+  '@sentry/cli-win32-x64@2.56.1':
     optional: true
 
-  '@sentry/cli@2.56.0':
+  '@sentry/cli@2.56.1':
     dependencies:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
@@ -7539,28 +7539,28 @@ snapshots:
       proxy-from-env: 1.1.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 2.56.0
-      '@sentry/cli-linux-arm': 2.56.0
-      '@sentry/cli-linux-arm64': 2.56.0
-      '@sentry/cli-linux-i686': 2.56.0
-      '@sentry/cli-linux-x64': 2.56.0
-      '@sentry/cli-win32-arm64': 2.56.0
-      '@sentry/cli-win32-i686': 2.56.0
-      '@sentry/cli-win32-x64': 2.56.0
+      '@sentry/cli-darwin': 2.56.1
+      '@sentry/cli-linux-arm': 2.56.1
+      '@sentry/cli-linux-arm64': 2.56.1
+      '@sentry/cli-linux-i686': 2.56.1
+      '@sentry/cli-linux-x64': 2.56.1
+      '@sentry/cli-win32-arm64': 2.56.1
+      '@sentry/cli-win32-i686': 2.56.1
+      '@sentry/cli-win32-x64': 2.56.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@sentry/core@10.18.0': {}
+  '@sentry/core@10.20.0': {}
 
-  '@sentry/react-native@7.3.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)':
+  '@sentry/react-native@7.4.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@sentry/babel-plugin-component-annotate': 4.3.0
-      '@sentry/browser': 10.18.0
-      '@sentry/cli': 2.56.0
-      '@sentry/core': 10.18.0
-      '@sentry/react': 10.18.0(react@19.1.4)
-      '@sentry/types': 10.18.0
+      '@sentry/babel-plugin-component-annotate': 4.4.0
+      '@sentry/browser': 10.20.0
+      '@sentry/cli': 2.56.1
+      '@sentry/core': 10.20.0
+      '@sentry/react': 10.20.0(react@19.1.4)
+      '@sentry/types': 10.20.0
       react: 19.1.4
       react-native: 0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4)
     optionalDependencies:
@@ -7569,16 +7569,16 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/react@10.18.0(react@19.1.4)':
+  '@sentry/react@10.20.0(react@19.1.4)':
     dependencies:
-      '@sentry/browser': 10.18.0
-      '@sentry/core': 10.18.0
+      '@sentry/browser': 10.20.0
+      '@sentry/core': 10.20.0
       hoist-non-react-statics: 3.3.2
       react: 19.1.4
 
-  '@sentry/types@10.18.0':
+  '@sentry/types@10.20.0':
     dependencies:
-      '@sentry/core': 10.18.0
+      '@sentry/core': 10.20.0
 
   '@sinclair/typebox@0.27.10': {}
 

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: 7.14.2
         version: 7.14.2(@react-navigation/native@7.1.31(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-safe-area-context@5.7.0(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native-screens@4.24.0(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
       '@sentry/react-native':
-        specifier: 7.4.0
-        version: 7.4.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
+        specifier: 8.2.0
+        version: 8.2.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
       '@tanstack/react-query':
         specifier: 5.90.21
         version: 5.90.21(react@19.1.4)
@@ -1734,88 +1734,88 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@sentry-internal/browser-utils@10.20.0':
-    resolution: {integrity: sha512-9+NybrYs+dEM2iW5uRAYEhKkNK0XhDea5jovtDUXEvdSCMJFcdR88uztkftnCur45/hpvbgSULsGPUdHPb5ITw==}
+  '@sentry-internal/browser-utils@10.39.0':
+    resolution: {integrity: sha512-W6WODonMGiI13Az5P7jd/m2lj/JpIyuVKg7wE4X+YdlMehLspAv6I7gRE4OBSumS14ZjdaYDpD/lwtnBwKAzcA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.20.0':
-    resolution: {integrity: sha512-R/eGLKl7WDccLKBorEbyTsy5b99w/k4v80SntE8HL2rsO7DCDXma8TGmtHd+iZnw8dUci+EVrw7LbeGSgf3QzA==}
+  '@sentry-internal/feedback@10.39.0':
+    resolution: {integrity: sha512-cRXmmDeOr5FzVsBNRLU4WDEuC3fhuD0XV362EWl4DI3XBGao8ukaueKcLIKic5WZx6uXimjWw/UJmDLgxeCqkg==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.20.0':
-    resolution: {integrity: sha512-8DBawFi4F4e2Cu2ToiitCnYsK8idrDOv66Vq+N6c8e3qFitTTuoPQwOihb2+HY4CB06ABPW3WvfZntJJmsf91w==}
+  '@sentry-internal/replay-canvas@10.39.0':
+    resolution: {integrity: sha512-TTiX0XWCcqTqFGJjEZYObk93j/sJmXcqPzcu0cN2mIkKnnaHDY3w74SHZCshKqIr0AOQdt1HDNa36s3TCdt0Jw==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.20.0':
-    resolution: {integrity: sha512-+XPYp0CuJnf+c36/c+hHrY6wAPHCdnqllZeyU7+9LAiKsdhN8Oo4eF1v5zd097qDZBg1NrKhU44ScJIzz+vygw==}
+  '@sentry-internal/replay@10.39.0':
+    resolution: {integrity: sha512-obZoYOrUfxIYBHkmtPpItRdE38VuzF1VIxSgZ8Mbtq/9UvCWh+eOaVWU2stN/cVu1KYuYX0nQwBvdN28L6y/JA==}
     engines: {node: '>=18'}
 
-  '@sentry/babel-plugin-component-annotate@4.4.0':
-    resolution: {integrity: sha512-Pzjpn9MZg6yR61ThJgOoD28dLNCj457O0/t8d276K+Bzf8iOZKbrNO4sltp1vUB1yqhV+ulvIZO8xu8ABohtsg==}
+  '@sentry/babel-plugin-component-annotate@4.9.1':
+    resolution: {integrity: sha512-0gEoi2Lb54MFYPOmdTfxlNKxI7kCOvNV7gP8lxMXJ7nCazF5OqOOZIVshfWjDLrc0QrSV6XdVvwPV9GDn4wBMg==}
     engines: {node: '>= 14'}
 
-  '@sentry/browser@10.20.0':
-    resolution: {integrity: sha512-zcf8HwFiRbzjZL9KbLev44eEOf+yl+3svQbs2BlR2KAYGaB10swV5abij0UTTGO7ClnqUZdcGpwiyyfPS6mjHg==}
+  '@sentry/browser@10.39.0':
+    resolution: {integrity: sha512-I50W/1PDJWyqgNrGufGhBYCmmO3Bb159nx2Ut2bKoVveTfgH/hLEtDyW0kHo8Fu454mW+ukyXfU4L4s+kB9aaw==}
     engines: {node: '>=18'}
 
-  '@sentry/cli-darwin@2.56.1':
-    resolution: {integrity: sha512-zfhT8MrvB5x/xRdIVGwg+sG0Cx3i0G6RH2zCrdQ/moWn8TfkwsM0O1k/AxpwbpcRfAHCkVb04CU/yKciKwg2KA==}
-    engines: {node: '>=10'}
+  '@sentry/cli-darwin@3.2.2':
+    resolution: {integrity: sha512-y1uglMBbo9dYqC92hTQBkuGk7SegLPo1cVwJzX0dhplJoBMuanLMhOMYd1J20qhkDdBhguflCHGf0tOzNTGWhg==}
+    engines: {node: '>=18'}
     os: [darwin]
 
-  '@sentry/cli-linux-arm64@2.56.1':
-    resolution: {integrity: sha512-AypXIwZvOMJb9RgjI/98hTAd06FcOjqjIm6G9IR0OI4pJCOcaAXz9NKXdJqxpZd7phSMJnD+Bx/8iYOUPeY73A==}
-    engines: {node: '>=10'}
+  '@sentry/cli-linux-arm64@3.2.2':
+    resolution: {integrity: sha512-SIGJknEQNDw9S/8QPTl8QLVe2IEiTKH3NeeHQ/Q2XWXig1ZebJfm4iTrdu47ypszIfxHeLvQkkVrr8mRKq16xA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm@2.56.1':
-    resolution: {integrity: sha512-fNB/Ng11HrkGOSEIDg+fc3zfTCV7q6kJddp6ndK3QlYFsCffRSnclaX1SMp+mqxdWkHqe1kkp85OY8G/x5uAWw==}
-    engines: {node: '>=10'}
+  '@sentry/cli-linux-arm@3.2.2':
+    resolution: {integrity: sha512-CC7N3hjOgs3cwrW0T9hqirFVUpKO6ASjdd0JT4DQHaAn34pruv8J+OoSnj1jkrT2DHxDkNNZPOFSK05AnHr8wA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-i686@2.56.1':
-    resolution: {integrity: sha512-vnH+WJEsUq7Lf7xc9udzE/M4hoDXXsniFFYr/7BvdnXtCQlNNaWFMXHbEDYAql3baIlHkWoG8cEHWuB/YKyniw==}
-    engines: {node: '>=10'}
+  '@sentry/cli-linux-i686@3.2.2':
+    resolution: {integrity: sha512-W2hQ2DvIlZI05j2JN/87lfeo51F24zmQOJU6Uz+fZz/mkSvpnjeWxjAvfDNVGlLxp7XSoDbhHfrLBxdIh6jMeg==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-x64@2.56.1':
-    resolution: {integrity: sha512-3/BlKe5Vdnia36MeovghHJD8lbcum5TFIxLp+PSfH2sVb09+5Jo0L95oRTI2JkD8Fs+QNssvTqTxJj5eIo/n+A==}
-    engines: {node: '>=10'}
+  '@sentry/cli-linux-x64@3.2.2':
+    resolution: {integrity: sha512-4mh3yvOUxO63lq3teexRvalD1mWaRVjpgL2cCMKA2wkB69lcL5nK2gkdzDUKx2y/elluVdvGPPZaqOr1bfNI0w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-win32-arm64@2.56.1':
-    resolution: {integrity: sha512-Gg8RV7CV7Tz4fiR1EN1Af5AVhJsnEXiZvfvfQXI4lp51MKAhcxZIMtEfg9HaWsn3Dm/wgwYBinyeywfWbTXYDg==}
-    engines: {node: '>=10'}
+  '@sentry/cli-win32-arm64@3.2.2':
+    resolution: {integrity: sha512-TQgfkdJgd8Y/lPzDibqc5Hamg8Hl5rN1sZwX80n4r9Ly46Yzu8Bv6KUhoNL/ktAvw9Aeko6Bx54rwZnzxFZHwg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@sentry/cli-win32-i686@2.56.1':
-    resolution: {integrity: sha512-6u6a060yC3i76Ze1apqgWr5luQSyhuD5ND84eWfh/UbddsEa42UHjoVHOiBwmpZqf/hvNZAtzLnE4NCvU4zOMg==}
-    engines: {node: '>=10'}
+  '@sentry/cli-win32-i686@3.2.2':
+    resolution: {integrity: sha512-vAcnq0SdYuvwIdREgF5APocjW3d9Z17xLwugpaAz8wpOjCeC1iMEFWqbz5k49i4iDkDVNFRMENiVvWVSu1kEnA==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [win32]
 
-  '@sentry/cli-win32-x64@2.56.1':
-    resolution: {integrity: sha512-11cdflajBrDWlRZqI9MOu7ok2vnPzFjKmbU3YvBYWQapNE+HHAsWdsRL/u/P1RmU62vj7Y42iSUcj6x1SNrdPw==}
-    engines: {node: '>=10'}
+  '@sentry/cli-win32-x64@3.2.2':
+    resolution: {integrity: sha512-xWPTXjSSdmoyG/0ee7A9KSfsScGHCdaXMP6ASt4bMx3yYJO7ziEoZzfJE2M6oglz+woAm0LV9+O/n7g80tixlQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@sentry/cli@2.56.1':
-    resolution: {integrity: sha512-VDAIg+gmjNtJS5VUZQMDSK9RaKC9hYQi3PoXpNa+owNfQNk60bCi8z8jkbWRcKbNGn3V51WqvrQAqLoNAdPc9w==}
-    engines: {node: '>= 10'}
+  '@sentry/cli@3.2.2':
+    resolution: {integrity: sha512-qmjsm9+Bq/3QGTnIfOsJdhq+8LI3imxAPbGNBpRj4R0YFk+b1ry9huRHCLgkMcRFWtPkJmGZwEq2Z7e+02QPLA==}
+    engines: {node: '>= 18'}
     hasBin: true
 
-  '@sentry/core@10.20.0':
-    resolution: {integrity: sha512-S291KihnOIB8i7mVJIJBVHBMcCfIoY/KDJBHEfBoHY9M56g2An4FVhM9+/xR85+IoMkTySdXN08k9LEyQz4FpQ==}
+  '@sentry/core@10.39.0':
+    resolution: {integrity: sha512-xCLip2mBwCdRrvXHtVEULX0NffUTYZZBhEUGht0WFL+GNdNQ7gmBOGOczhZlrf2hgFFtDO0fs1xiP9bqq5orEQ==}
     engines: {node: '>=18'}
 
-  '@sentry/react-native@7.4.0':
-    resolution: {integrity: sha512-dDbFEO4DkDjfGlo+gQ5u1JokMMSglZerAQZbuMJO1cBCt+G/+8GZBFVXSHPk/CZLWiPBxQWP27nHhZ7Y06h5hw==}
+  '@sentry/react-native@8.2.0':
+    resolution: {integrity: sha512-hcYakN9AzEHdaPHYQEHhTAneTqyqJm/MZ6Wb8+UGnXIaCnMjZCTRpu17GvQMBC4qh3lafyF3OwiO16SUDHYJhQ==}
     hasBin: true
     peerDependencies:
       expo: '>=49.0.0'
@@ -1825,14 +1825,14 @@ packages:
       expo:
         optional: true
 
-  '@sentry/react@10.20.0':
-    resolution: {integrity: sha512-8W+gMkMxQhqlGHCW7kjLhcLgBJ/YSHbLhVd36s0GRudxjXh61K8rdCaAXToD8akgZ76DtLbx5PPQ5fLfQCOnpw==}
+  '@sentry/react@10.39.0':
+    resolution: {integrity: sha512-qxReWHFhDcXNGEyAlYzhR7+K70es+vXaSknTZui1q7TfQwCT1rZlLKn/K8GDpNsb35RC5QhiIphU6pKbyYgZqw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
-  '@sentry/types@10.20.0':
-    resolution: {integrity: sha512-9pGtoiYBvw0SpHayBlQ6/9F4wP/KwlS8KZg1iBsZSR8h8WjLRGbER/TjKcAdg07HPd0APVajbT2YyL30+9Oi8Q==}
+  '@sentry/types@10.39.0':
+    resolution: {integrity: sha512-tRPFcjnBoljGYCNXql3aJBCLcHreoqXYv3SMr6bpFGY7JIP5HryXuESkEiDI8r3yggeb3TOCjqJ9GaixzEc71g==}
     engines: {node: '>=18'}
 
   '@sinclair/typebox@0.27.10':
@@ -2214,10 +2214,6 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3557,10 +3553,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -4416,15 +4408,6 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-forge@1.3.3:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
@@ -5414,9 +5397,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   treeify@1.1.0:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
     engines: {node: '>=0.6'}
@@ -5590,9 +5570,6 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
@@ -5603,9 +5580,6 @@ packages:
   whatwg-url-without-unicode@8.0.0-3:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -7479,106 +7453,98 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@sentry-internal/browser-utils@10.20.0':
+  '@sentry-internal/browser-utils@10.39.0':
     dependencies:
-      '@sentry/core': 10.20.0
+      '@sentry/core': 10.39.0
 
-  '@sentry-internal/feedback@10.20.0':
+  '@sentry-internal/feedback@10.39.0':
     dependencies:
-      '@sentry/core': 10.20.0
+      '@sentry/core': 10.39.0
 
-  '@sentry-internal/replay-canvas@10.20.0':
+  '@sentry-internal/replay-canvas@10.39.0':
     dependencies:
-      '@sentry-internal/replay': 10.20.0
-      '@sentry/core': 10.20.0
+      '@sentry-internal/replay': 10.39.0
+      '@sentry/core': 10.39.0
 
-  '@sentry-internal/replay@10.20.0':
+  '@sentry-internal/replay@10.39.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.20.0
-      '@sentry/core': 10.20.0
+      '@sentry-internal/browser-utils': 10.39.0
+      '@sentry/core': 10.39.0
 
-  '@sentry/babel-plugin-component-annotate@4.4.0': {}
+  '@sentry/babel-plugin-component-annotate@4.9.1': {}
 
-  '@sentry/browser@10.20.0':
+  '@sentry/browser@10.39.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.20.0
-      '@sentry-internal/feedback': 10.20.0
-      '@sentry-internal/replay': 10.20.0
-      '@sentry-internal/replay-canvas': 10.20.0
-      '@sentry/core': 10.20.0
+      '@sentry-internal/browser-utils': 10.39.0
+      '@sentry-internal/feedback': 10.39.0
+      '@sentry-internal/replay': 10.39.0
+      '@sentry-internal/replay-canvas': 10.39.0
+      '@sentry/core': 10.39.0
 
-  '@sentry/cli-darwin@2.56.1':
+  '@sentry/cli-darwin@3.2.2':
     optional: true
 
-  '@sentry/cli-linux-arm64@2.56.1':
+  '@sentry/cli-linux-arm64@3.2.2':
     optional: true
 
-  '@sentry/cli-linux-arm@2.56.1':
+  '@sentry/cli-linux-arm@3.2.2':
     optional: true
 
-  '@sentry/cli-linux-i686@2.56.1':
+  '@sentry/cli-linux-i686@3.2.2':
     optional: true
 
-  '@sentry/cli-linux-x64@2.56.1':
+  '@sentry/cli-linux-x64@3.2.2':
     optional: true
 
-  '@sentry/cli-win32-arm64@2.56.1':
+  '@sentry/cli-win32-arm64@3.2.2':
     optional: true
 
-  '@sentry/cli-win32-i686@2.56.1':
+  '@sentry/cli-win32-i686@3.2.2':
     optional: true
 
-  '@sentry/cli-win32-x64@2.56.1':
+  '@sentry/cli-win32-x64@3.2.2':
     optional: true
 
-  '@sentry/cli@2.56.1':
+  '@sentry/cli@3.2.2':
     dependencies:
-      https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0
       progress: 2.0.3
       proxy-from-env: 1.1.0
+      undici: 6.23.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 2.56.1
-      '@sentry/cli-linux-arm': 2.56.1
-      '@sentry/cli-linux-arm64': 2.56.1
-      '@sentry/cli-linux-i686': 2.56.1
-      '@sentry/cli-linux-x64': 2.56.1
-      '@sentry/cli-win32-arm64': 2.56.1
-      '@sentry/cli-win32-i686': 2.56.1
-      '@sentry/cli-win32-x64': 2.56.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      '@sentry/cli-darwin': 3.2.2
+      '@sentry/cli-linux-arm': 3.2.2
+      '@sentry/cli-linux-arm64': 3.2.2
+      '@sentry/cli-linux-i686': 3.2.2
+      '@sentry/cli-linux-x64': 3.2.2
+      '@sentry/cli-win32-arm64': 3.2.2
+      '@sentry/cli-win32-i686': 3.2.2
+      '@sentry/cli-win32-x64': 3.2.2
 
-  '@sentry/core@10.20.0': {}
+  '@sentry/core@10.39.0': {}
 
-  '@sentry/react-native@7.4.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)':
+  '@sentry/react-native@8.2.0(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@sentry/babel-plugin-component-annotate': 4.4.0
-      '@sentry/browser': 10.20.0
-      '@sentry/cli': 2.56.1
-      '@sentry/core': 10.20.0
-      '@sentry/react': 10.20.0(react@19.1.4)
-      '@sentry/types': 10.20.0
+      '@sentry/babel-plugin-component-annotate': 4.9.1
+      '@sentry/browser': 10.39.0
+      '@sentry/cli': 3.2.2
+      '@sentry/core': 10.39.0
+      '@sentry/react': 10.39.0(react@19.1.4)
+      '@sentry/types': 10.39.0
       react: 19.1.4
       react-native: 0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4)
     optionalDependencies:
       expo: 54.0.33(@babel/core@7.29.0)(react-native@0.81.6(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
-  '@sentry/react@10.20.0(react@19.1.4)':
+  '@sentry/react@10.39.0(react@19.1.4)':
     dependencies:
-      '@sentry/browser': 10.20.0
-      '@sentry/core': 10.20.0
-      hoist-non-react-statics: 3.3.2
+      '@sentry/browser': 10.39.0
+      '@sentry/core': 10.39.0
       react: 19.1.4
 
-  '@sentry/types@10.20.0':
+  '@sentry/types@10.39.0':
     dependencies:
-      '@sentry/core': 10.20.0
+      '@sentry/core': 10.39.0
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -7928,12 +7894,6 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -9489,13 +9449,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -10519,10 +10472,6 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-forge@1.3.3: {}
 
@@ -11596,8 +11545,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tr46@0.0.3: {}
-
   treeify@1.1.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
@@ -11786,8 +11733,6 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@5.0.0: {}
 
   whatwg-fetch@3.6.20: {}
@@ -11797,11 +11742,6 @@ snapshots:
       buffer: 5.7.1
       punycode: 2.3.1
       webidl-conversions: 5.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -36,6 +36,10 @@ if (SENTRY_ENABLED) {
       "No matching browser activity found",
       "non-premultiplied bitmap",
     ],
+    //? Disable logging console messages in Sentry introduced in `@sentry/react-native@7.4.0`.
+    integrations(integrations: Array<{ name: string }>) {
+      return integrations.filter((i) => i.name !== "ConsoleLogs");
+    },
   });
 }
 

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -26,6 +26,8 @@ import { SENTRY_ENABLED, Sentry } from "~/lib/sentry";
 import { bgWait } from "~/utils/promise";
 
 if (SENTRY_ENABLED) {
+  const RemovedIntegrations = new Set(["ConsoleLogs", "MobileReplay"]);
+
   Sentry.init({
     dsn: "https://bbd726405356cdfb20b85f5f924fd3e3@o4507687432617984.ingest.us.sentry.io/4507687447101440",
     ignoreErrors: [
@@ -38,7 +40,7 @@ if (SENTRY_ENABLED) {
     ],
     //? Disable logging console messages in Sentry introduced in `@sentry/react-native@7.4.0`.
     integrations(integrations: Array<{ name: string }>) {
-      return integrations.filter((i) => i.name !== "ConsoleLogs");
+      return integrations.filter((i) => !RemovedIntegrations.has(i.name));
     },
   });
 }

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -92,7 +92,7 @@
   },
   "@sentry/react-native": {
     "name": "@sentry/react-native",
-    "version": "7.4.0",
+    "version": "8.2.0",
     "source": "https://github.com/getsentry/sentry-react-native",
     "license": "MIT",
     "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2017-2024 Sentry\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -92,7 +92,7 @@
   },
   "@sentry/react-native": {
     "name": "@sentry/react-native",
-    "version": "7.3.0",
+    "version": "7.4.0",
     "source": "https://github.com/getsentry/sentry-react-native",
     "license": "MIT",
     "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2017-2024 Sentry\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR updates Sentry to v8.2.0 and has us implementing Sentry's Android Gradle Plugin (AGP) via the Expo plugin. This has a side-effect of **increasing the installed app size by around `~1.09 MB`**.
- Upgrading to v7.4.0 had an issue where `console.log` were getting reported, even though they should have been stripped by the babel plugin.
- Upgrading to v7.5.0 required us to remove the code that removed the `sentry-android-replay` module, which reduced the installed app size by `~0.27 MB` because an error being thrown due to it being used elsewhere (ie: that code didn't look at a check to see if `sentry-android-replay` is available).

In addition, we've updated the "Privacy Build" workflow to uninstall `@sentry/react-native` since the code still gets bundled even though it's not used, **reducing the installed app size by around `~3.45 MB`**.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
