### PR TITLE
🧪feat: Experimental support for Android Auto

### DIFF
--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -5,6 +5,7 @@
 
 Android Auto support will stay as an experimental feature for the foreseeable future. As such, there are some caveats you need to be aware of:
 
+0. Only "structured" lists are supported (Albums & Playlists).
 1. Artwork will not get rendered (Android Auto doesn't work with embedded artwork).
 2. Search & voice commands aren't implemented.
 3. Shuffle & Repeat state can only be controlled via the app.

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -6,8 +6,6 @@
 Android Auto support will stay as an experimental feature for the foreseeable future. As such, there are some caveats you need to be aware of:
 
 1. Artwork will not get rendered (Android Auto doesn't work with embedded artwork).
-2. The "Queue" feature is "useless".
-   - This is due to our strategy of keeping only a single item in the queue to allow for flexibility. This probably won't change.
 
 > [!NOTE]
 > This app should work with Android Auto without any additional configurations. If it doesn't show up, you may need to [enable Developer Mode and allow "Unknown Sources"](https://developer.android.com/training/cars/testing#developer-mode).

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -1,0 +1,25 @@
+# [🧪 Experimental] Android Auto
+
+> [!IMPORTANT]
+> I do not use Android Auto, so any bugs that occur will have a lower priority. In addition, we're not responsible for any jankiness that occurs when using this app with Android Auto.
+
+Android Auto support will stay as an experimental feature for the foreseeable future. As such, there are some caveats you need to be aware of:
+
+1. Artwork will not get rendered (Android Auto doesn't work with embedded artwork).
+2. The "Queue" feature is "useless".
+   - This is due to our strategy of keeping only a single item in the queue to allow for flexibility. This probably won't change.
+
+> [!NOTE]
+> This app should work with Android Auto without any additional configurations. If it doesn't show up, you may need to [enable Developer Mode and allow "Unknown Sources"](https://developer.android.com/training/cars/testing#developer-mode).
+
+## Developer Notes
+
+Testing the app in Android Auto requires using the Desktop Head Unit (DHU) available in Android Studio.
+
+0. [Enable Android Auto developer mode](https://developer.android.com/training/cars/testing#developer-mode).
+1. [Installing the DHU](https://developer.android.com/training/cars/testing/dhu#install).
+2. [Connecting to the DHU with device via USB](https://developer.android.com/training/cars/testing/dhu#connection-adb).
+
+### Additional Notes For Adding Android Auto Support
+
+- https://github.com/lovegaoshi/react-native-track-player/blob/APM/docs/docs/guides/android-auto.md#necessary-declarations

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -6,6 +6,8 @@
 Android Auto support will stay as an experimental feature for the foreseeable future. As such, there are some caveats you need to be aware of:
 
 1. Artwork will not get rendered (Android Auto doesn't work with embedded artwork).
+2. Search & voice commands aren't implemented.
+3. Shuffle & Repeat state can only be controlled via the app.
 
 > [!NOTE]
 > This app should work with Android Auto without any additional configurations. If it doesn't show up, you may need to [enable Developer Mode and allow "Unknown Sources"](https://developer.android.com/training/cars/testing#developer-mode).

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -94,5 +94,8 @@
 
     <!-- Disable Sentry's ANR feature. -->
     <meta-data android:name="io.sentry.anr.enable" android:value="false" />
+
+    <!-- Add Android Auto support. -->
+    <meta-data android:name="com.google.android.gms.car.application" android:resource="@xml/automotive_app_desc" />
   </application>
 </manifest>

--- a/mobile/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/mobile/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,3 @@
+<automotiveApp>
+  <uses name="media"/>
+</automotiveApp>

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -61,7 +61,7 @@
     "react-i18next": "16.6.6",
     "react-native": "0.83.4",
     "react-native-android-widget": "0.20.1",
-    "react-native-audio-browser": "github:MissingCore/react-native-audio-browser#b48be198efbf1b31ad556b0d6b742ecde480e9bf",
+    "react-native-audio-browser": "github:MissingCore/react-native-audio-browser#df7cbc9abace2a4c0e8c4de3c8cb4a9e3e7fac2b",
     "react-native-bootsplash": "7.1.0",
     "react-native-gesture-handler": "2.30.0",
     "react-native-keyboard-controller": "1.21.2",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -61,7 +61,7 @@
     "react-i18next": "16.6.6",
     "react-native": "0.83.4",
     "react-native-android-widget": "0.20.1",
-    "react-native-audio-browser": "github:MissingCore/react-native-audio-browser#9927e718e68c55dc0c5ef57030ed340b63ba96f3",
+    "react-native-audio-browser": "github:MissingCore/react-native-audio-browser#b48be198efbf1b31ad556b0d6b742ecde480e9bf",
     "react-native-bootsplash": "7.1.0",
     "react-native-gesture-handler": "2.30.0",
     "react-native-keyboard-controller": "1.21.2",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: 0.20.1
         version: 0.20.1(patch_hash=700a44715e685edefbbcca4d1c8a1a80c90ea32f567b124241138d01b981b064)(expo@55.0.8)(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-audio-browser:
-        specifier: github:MissingCore/react-native-audio-browser#b48be198efbf1b31ad556b0d6b742ecde480e9bf
-        version: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+        specifier: github:MissingCore/react-native-audio-browser#df7cbc9abace2a4c0e8c4de3c8cb4a9e3e7fac2b
+        version: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/df7cbc9abace2a4c0e8c4de3c8cb4a9e3e7fac2b(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-bootsplash:
         specifier: 7.1.0
         version: 7.1.0(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -4934,8 +4934,8 @@ packages:
       expo:
         optional: true
 
-  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf:
-    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf}
+  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/df7cbc9abace2a4c0e8c4de3c8cb4a9e3e7fac2b:
+    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/df7cbc9abace2a4c0e8c4de3c8cb4a9e3e7fac2b}
     version: 0.1.0
     peerDependencies:
       react: '*'
@@ -10960,7 +10960,7 @@ snapshots:
     optionalDependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@6.0.2)
 
-  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/df7cbc9abace2a4c0e8c4de3c8cb4a9e3e7fac2b(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-native: 0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: 0.20.1
         version: 0.20.1(patch_hash=700a44715e685edefbbcca4d1c8a1a80c90ea32f567b124241138d01b981b064)(expo@55.0.8)(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-audio-browser:
-        specifier: github:MissingCore/react-native-audio-browser#9927e718e68c55dc0c5ef57030ed340b63ba96f3
-        version: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/9927e718e68c55dc0c5ef57030ed340b63ba96f3(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+        specifier: github:MissingCore/react-native-audio-browser#b48be198efbf1b31ad556b0d6b742ecde480e9bf
+        version: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-bootsplash:
         specifier: 7.1.0
         version: 7.1.0(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -4934,8 +4934,8 @@ packages:
       expo:
         optional: true
 
-  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/9927e718e68c55dc0c5ef57030ed340b63ba96f3:
-    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/9927e718e68c55dc0c5ef57030ed340b63ba96f3}
+  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf:
+    resolution: {tarball: https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf}
     version: 0.1.0
     peerDependencies:
       react: '*'
@@ -10960,7 +10960,7 @@ snapshots:
     optionalDependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@6.0.2)
 
-  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/9927e718e68c55dc0c5ef57030ed340b63ba96f3(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+  react-native-audio-browser@https://codeload.github.com/MissingCore/react-native-audio-browser/tar.gz/b48be198efbf1b31ad556b0d6b742ecde480e9bf(react-native-nitro-modules@0.35.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-native: 0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -82,6 +82,7 @@ export async function getAlbumTracks<
             duration: tracks.duration,
             disc: tracks.disc,
             track: tracks.track,
+            uri: tracks.uri,
             /** We need to unencode these fields. */
             artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
           },

--- a/mobile/src/data/album/types.ts
+++ b/mobile/src/data/album/types.ts
@@ -4,6 +4,7 @@ export type AlbumTrack = {
   duration: number;
   disc: number | null;
   track: number | null;
+  uri: string;
   artists: string[] | null;
 };
 

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -254,15 +254,25 @@ export async function initServices() {
   /** Generate route containing all lists of a given category. */
   async function getMediaCategoryRoute(
     category: MediaType,
-    loader: () => Promise<Array<{ name: string; id: string }>>,
+    loader: () => Promise<
+      Array<{
+        name: string;
+        id: string;
+        artistName?: string;
+        trackCount: number;
+      }>
+    >,
   ): Promise<ResolvedTrack> {
     const data = await loader();
     return {
       url: `/${category}`,
       title: `${capitalize(category)}s`,
       children: data.map((item) => ({
-        title: item.name,
         url: `/${category}/${item.id}`,
+        title: item.name,
+        description:
+          item.artistName ||
+          i18next.t("plural.track", { count: item.trackCount }),
       })),
     };
   }
@@ -284,6 +294,9 @@ export async function initServices() {
         ? data.artwork[0]
         : data.artwork;
 
+      // Only available for tracks in "Album" entry.
+      const hasDiscLabel = data.tracks.at(-1)?.disc > 1;
+
       return {
         url: `/${category}/${id}`,
         title: data.name,
@@ -295,6 +308,10 @@ export async function initServices() {
             (useListArtwork ? listArtwork : track.artwork) ||
             PlaceholderImageFile,
           duration: track.duration,
+          groupTitle:
+            hasDiscLabel && typeof track.disc === "number"
+              ? `Disc ${track.disc}`
+              : undefined,
         })),
       };
     };

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -32,10 +32,10 @@ import { PlaceholderImageFile } from "~/lib/file-system";
 import { getAudioBrowserOptions } from "~/lib/react-native-audio-browser";
 import { clearAllQueries } from "~/lib/react-query";
 import { bgWait } from "~/utils/promise";
-import { getSafeUri } from "~/utils/string";
+import { capitalize, getSafeUri } from "~/utils/string";
 import { revalidateWidgets } from "~/modules/widget/utils";
 import { RepeatModes } from "~/stores/Playback/constants";
-import type { PlayFromSource } from "~/stores/Playback/types";
+import type { MediaType, PlayFromSource } from "~/stores/Playback/types";
 
 //#region "Smooth Playback Transition" Constants
 type PlaybackStoreFrame = Awaited<
@@ -249,77 +249,60 @@ export async function initServices() {
   //#endregion
 
   //#region Android Auto
-  async function fetchAlbums(): Promise<ResolvedTrack> {
-    const allAlbums = await getAlbumsSummary(true);
+  /** Generate route containing all lists of a given category. */
+  async function getMediaCategoryRoute(
+    category: MediaType,
+    loader: () => Promise<Array<{ name: string; id: string }>>,
+  ): Promise<ResolvedTrack> {
+    const data = await loader();
     return {
-      url: "/album",
-      title: "Albums",
-      children: allAlbums.map((album) => ({
-        title: album.name,
-        url: `/album/${album.id}`,
-        artwork: album.artwork || PlaceholderImageFile,
-        style: "grid" as const,
+      url: `/${category}`,
+      title: `${capitalize(category)}s`,
+      children: data.map((item) => ({
+        title: item.name,
+        url: `/${category}/${item.id}`,
       })),
     };
   }
 
-  async function fetchAlbum(id: string): Promise<ResolvedTrack> {
-    const album = await getAlbum(id);
-    return {
-      url: `/album/${id}`,
-      title: album.name,
-      artwork: album.artwork || PlaceholderImageFile,
-      children: album.tracks.map((track) => ({
-        src: getSafeUri(track.uri),
-        title: track.name,
-        artist: getArtistsString(track.artists),
-        artwork: album.artwork || PlaceholderImageFile,
-        duration: track.duration,
-      })),
+  /** Generate route for list in a given category. */
+  function getMediaCategoryEntryRoute(
+    category: MediaType,
+    loader: (id: string) => Promise<{
+      name: string;
+      artwork: string | null | Array<string | null>;
+      tracks: Array<Record<string, any>>;
+    }>,
+    useListArtwork = false,
+  ): BrowserSource {
+    return async ({ routeParams }): Promise<ResolvedTrack> => {
+      const id = routeParams!.id!;
+      const data = await loader(id);
+      const listArtwork = Array.isArray(data.artwork)
+        ? data.artwork[0]
+        : data.artwork;
+
+      return {
+        url: `/${category}/${id}`,
+        title: data.name,
+        children: data.tracks.map((track) => ({
+          src: getSafeUri(track.uri),
+          title: track.name,
+          artist: getArtistsString(track.artists),
+          artwork:
+            (useListArtwork ? listArtwork : track.artwork) ||
+            PlaceholderImageFile,
+          duration: track.duration,
+        })),
+      };
     };
   }
 
-  async function fetchPlaylists(): Promise<ResolvedTrack> {
-    const allPlaylists = await getPlaylistsSummary(true);
-    return {
-      url: "/playlist",
-      title: "Playlists",
-      children: allPlaylists.map((playlist) => ({
-        title: playlist.name,
-        url: `/playlist/${playlist.id}`,
-        artwork:
-          (Array.isArray(playlist.artwork)
-            ? playlist.artwork[0]
-            : playlist.artwork) || PlaceholderImageFile,
-        style: "grid" as const,
-      })),
-    };
-  }
-
-  async function fetchPlaylist(id: string): Promise<ResolvedTrack> {
-    const playlist = await getPlaylist(id);
-    return {
-      url: `/playlist/${id}`,
-      title: playlist.name,
-      artwork:
-        (Array.isArray(playlist.artwork)
-          ? playlist.artwork[0]
-          : playlist.artwork) || PlaceholderImageFile,
-      children: playlist.tracks.map((track) => ({
-        src: getSafeUri(track.uri),
-        title: track.name,
-        artist: getArtistsString(track.artists),
-        artwork: track.artwork || PlaceholderImageFile,
-        duration: track.duration,
-      })),
-    };
-  }
-
-  const listRoutes: Record<string, BrowserSource> = {
-    "/album": () => fetchAlbums(),
-    "/album/{id}": ({ routeParams }) => fetchAlbum(routeParams!.id!),
-    "/playlist": () => fetchPlaylists(),
-    "/playlist/{id}": ({ routeParams }) => fetchPlaylist(routeParams!.id!),
+  const mediaListRoutes: Record<string, BrowserSource> = {
+    "/album": () => getMediaCategoryRoute("album", getAlbumsSummary),
+    "/album/{id}": getMediaCategoryEntryRoute("album", getAlbum, true),
+    "/playlist": () => getMediaCategoryRoute("playlist", getPlaylistsSummary),
+    "/playlist/{id}": getMediaCategoryEntryRoute("playlist", getPlaylist),
   };
 
   const configuration: BrowserConfiguration = {
@@ -330,7 +313,7 @@ export async function initServices() {
       },
     ],
     routes: {
-      ...listRoutes,
+      ...mediaListRoutes,
       "/library": {
         url: "/library",
         title: "Your Library",

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -15,6 +15,7 @@ import AudioBrowser from "react-native-audio-browser";
 import { db } from "~/db";
 
 import i18next from "~/modules/i18n";
+import { getAlbum, getAlbumsSummary } from "~/data/album/api";
 import { getArtistsString } from "~/data/artist/utils";
 import { getPlaylist, getPlaylistsSummary } from "~/data/playlist/api";
 import { addPlayedTrack } from "~/data/recent/api";
@@ -247,6 +248,36 @@ export async function initServices() {
   //#endregion
 
   //#region Android Auto
+  async function fetchAlbums(): Promise<ResolvedTrack> {
+    const allAlbums = await getAlbumsSummary(true);
+    return {
+      url: "/album",
+      title: "Albums",
+      children: allAlbums.map((album) => ({
+        title: album.name,
+        url: `/album/${album.id}`,
+        artwork: album.artwork || PlaceholderImageFile,
+        style: "grid" as const,
+      })),
+    };
+  }
+
+  async function fetchAlbum(id: string): Promise<ResolvedTrack> {
+    const album = await getAlbum(id);
+    return {
+      url: `/album/${id}`,
+      title: album.name,
+      artwork: album.artwork || PlaceholderImageFile,
+      children: album.tracks.map((track) => ({
+        src: getSafeUri(track.uri),
+        title: track.name,
+        artist: getArtistsString(track.artists),
+        artwork: album.artwork || PlaceholderImageFile,
+        duration: track.duration,
+      })),
+    };
+  }
+
   async function fetchPlaylists(): Promise<ResolvedTrack> {
     const allPlaylists = await getPlaylistsSummary(true);
     return {
@@ -283,7 +314,9 @@ export async function initServices() {
     };
   }
 
-  const playlistRoutes: Record<string, BrowserSource> = {
+  const listRoutes: Record<string, BrowserSource> = {
+    "/album": () => fetchAlbums(),
+    "/album/{id}": ({ routeParams }) => fetchAlbum(routeParams!.id!),
     "/playlist": () => fetchPlaylists(),
     "/playlist/{id}": ({ routeParams }) => fetchPlaylist(routeParams!.id!),
   };
@@ -296,11 +329,15 @@ export async function initServices() {
       },
     ],
     routes: {
-      ...playlistRoutes,
+      ...listRoutes,
       "/library": {
         url: "/library",
         title: "Your Library",
         children: [
+          {
+            url: "/album",
+            title: "Albums",
+          },
           {
             url: "/playlist",
             title: "Playlists",

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -35,6 +35,8 @@ import { bgWait } from "~/utils/promise";
 import { getSafeUri } from "~/utils/string";
 import { revalidateWidgets } from "~/modules/widget/utils";
 import { RepeatModes } from "~/stores/Playback/constants";
+import type { PlayFromSource } from "~/stores/Playback/types";
+import { arePlaybackSourceEqual } from "~/stores/Playback/utils";
 
 //#region "Smooth Playback Transition" Constants
 type PlaybackStoreFrame = Awaited<
@@ -147,6 +149,31 @@ export async function initServices() {
   AudioBrowser.onActiveTrackChanged.addListener(async (e) => {
     if (e.index === undefined || e.track === undefined) return;
     const activeTrackUri = e.track.src;
+
+    //* 🧪 Android Auto
+    const androidAutoURL = e.track.url; // ie: `/album/srzxiew5ihjsxe6u706siqfq?__trackId=......`
+    if (androidAutoURL !== undefined) {
+      const parentListSrc = androidAutoURL.split("?__trackId")[0];
+      const [_, listType, listId] = parentListSrc!.split("/");
+      if (listType && listId) {
+        const androidAutoSource = {
+          type: listType,
+          id: listId,
+        } as PlayFromSource;
+        const { playingFrom } = playbackStore.getState();
+        if (!arePlaybackSourceEqual(playingFrom, androidAutoSource)) {
+          const activeTrack = await db.query.tracks.findFirst({
+            where: (fields, { eq }) => eq(fields.uri, activeTrackUri!),
+          });
+          //? Simplist way of updating the playback store when we change
+          //? lists via Android Auto.
+          await PlaybackControls.playFromList({
+            source: androidAutoSource,
+            trackId: activeTrack?.id,
+          });
+        }
+      }
+    }
 
     //* 🧪 Smooth Playback Transition
     try {

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -5,11 +5,18 @@ import {
   MatrixAction,
 } from "@missingcore/music-glyph-toys";
 import { toast } from "@missingcore/toast";
+import type {
+  BrowserConfiguration,
+  BrowserSource,
+  ResolvedTrack,
+} from "react-native-audio-browser";
 import AudioBrowser from "react-native-audio-browser";
 
 import { db } from "~/db";
 
 import i18next from "~/modules/i18n";
+import { getArtistsString } from "~/data/artist/utils";
+import { getPlaylist, getPlaylistsSummary } from "~/data/playlist/api";
 import { addPlayedTrack } from "~/data/recent/api";
 import { deleteTracks } from "~/data/track/api";
 import { formatTrackforPlayer } from "~/data/track/utils";
@@ -20,9 +27,11 @@ import { sessionStore } from "~/stores/Session/store";
 import { AppCleanUp } from "~/modules/scanning/helpers/cleanup";
 import { router } from "~/navigation/utils/router";
 
+import { PlaceholderImageFile } from "~/lib/file-system";
 import { getAudioBrowserOptions } from "~/lib/react-native-audio-browser";
 import { clearAllQueries } from "~/lib/react-query";
 import { bgWait } from "~/utils/promise";
+import { getSafeUri } from "~/utils/string";
 import { revalidateWidgets } from "~/modules/widget/utils";
 import { RepeatModes } from "~/stores/Playback/constants";
 
@@ -235,5 +244,72 @@ export async function initServices() {
       await playbackStore.getState().reset();
     }
   });
+  //#endregion
+
+  //#region Android Auto
+  async function fetchPlaylists(): Promise<ResolvedTrack> {
+    const allPlaylists = await getPlaylistsSummary(true);
+    return {
+      url: "/playlist",
+      title: "Playlists",
+      children: allPlaylists.map((playlist) => ({
+        title: playlist.name,
+        url: `/playlist/${playlist.id}`,
+        artwork:
+          (Array.isArray(playlist.artwork)
+            ? playlist.artwork[0]
+            : playlist.artwork) || PlaceholderImageFile,
+        style: "grid" as const,
+      })),
+    };
+  }
+
+  async function fetchPlaylist(id: string): Promise<ResolvedTrack> {
+    const playlist = await getPlaylist(id);
+    return {
+      url: `/playlist/${id}`,
+      title: playlist.name,
+      artwork:
+        (Array.isArray(playlist.artwork)
+          ? playlist.artwork[0]
+          : playlist.artwork) || PlaceholderImageFile,
+      children: playlist.tracks.map((track) => ({
+        src: getSafeUri(track.uri),
+        title: track.name,
+        artist: getArtistsString(track.artists),
+        artwork: track.artwork || PlaceholderImageFile,
+        duration: track.duration,
+      })),
+    };
+  }
+
+  const playlistRoutes: Record<string, BrowserSource> = {
+    "/playlist": () => fetchPlaylists(),
+    "/playlist/{id}": ({ routeParams }) => fetchPlaylist(routeParams!.id!),
+  };
+
+  const configuration: BrowserConfiguration = {
+    tabs: [
+      {
+        title: "Your Library",
+        url: "/library",
+      },
+    ],
+    routes: {
+      ...playlistRoutes,
+      "/library": {
+        url: "/library",
+        title: "Your Library",
+        children: [
+          {
+            url: "/playlist",
+            title: "Playlists",
+          },
+        ],
+      },
+    },
+  };
+
+  AudioBrowser.configureBrowser(configuration);
   //#endregion
 }

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -249,6 +249,8 @@ export async function initServices() {
   //#endregion
 
   //#region Android Auto
+  const experimentalLabel = "🧪 This is an Experimental Feature. 🧪";
+
   /** Generate route containing all lists of a given category. */
   async function getMediaCategoryRoute(
     category: MediaType,
@@ -321,10 +323,12 @@ export async function initServices() {
           {
             url: "/album",
             title: "Albums",
+            groupTitle: experimentalLabel,
           },
           {
             url: "/playlist",
             title: "Playlists",
+            groupTitle: experimentalLabel,
           },
         ],
       },

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -36,7 +36,6 @@ import { getSafeUri } from "~/utils/string";
 import { revalidateWidgets } from "~/modules/widget/utils";
 import { RepeatModes } from "~/stores/Playback/constants";
 import type { PlayFromSource } from "~/stores/Playback/types";
-import { arePlaybackSourceEqual } from "~/stores/Playback/utils";
 
 //#region "Smooth Playback Transition" Constants
 type PlaybackStoreFrame = Awaited<
@@ -149,31 +148,6 @@ export async function initServices() {
   AudioBrowser.onActiveTrackChanged.addListener(async (e) => {
     if (e.index === undefined || e.track === undefined) return;
     const activeTrackUri = e.track.src;
-
-    //* 🧪 Android Auto
-    const androidAutoURL = e.track.url; // ie: `/album/srzxiew5ihjsxe6u706siqfq?__trackId=......`
-    if (androidAutoURL !== undefined) {
-      const parentListSrc = androidAutoURL.split("?__trackId")[0];
-      const [_, listType, listId] = parentListSrc!.split("/");
-      if (listType && listId) {
-        const androidAutoSource = {
-          type: listType,
-          id: listId,
-        } as PlayFromSource;
-        const { playingFrom } = playbackStore.getState();
-        if (!arePlaybackSourceEqual(playingFrom, androidAutoSource)) {
-          const activeTrack = await db.query.tracks.findFirst({
-            where: (fields, { eq }) => eq(fields.uri, activeTrackUri!),
-          });
-          //? Simplist way of updating the playback store when we change
-          //? lists via Android Auto.
-          await PlaybackControls.playFromList({
-            source: androidAutoSource,
-            trackId: activeTrack?.id,
-          });
-        }
-      }
-    }
 
     //* 🧪 Smooth Playback Transition
     try {
@@ -371,6 +345,34 @@ export async function initServices() {
           },
         ],
       },
+    },
+    //* Only load a single track to be consistent with our playback strategy.
+    singleTrack: true,
+    //* Triggered when we select a track in Android Auto.
+    handleTrackLoad: async (e) => {
+      const trackUri = e.track.src;
+      const androidAutoURL = e.track.url; // ie: `/album/srzxiew5ihjsxe6u706siqfq?__trackId=......`
+
+      //? Fallback to playing the track in the Playback store if we don't
+      //? have context on the selected track & list.
+      if (!trackUri || !androidAutoURL) return PlaybackControls.play();
+
+      //? Derive the `PlayFromSource` from the url.
+      const [_, lType, lId] = androidAutoURL.split("?__trackId")[0]!.split("/");
+      if (!lType || !lId) return PlaybackControls.play();
+      const listSource = { type: lType, id: lId } as PlayFromSource;
+
+      //? Get the id of the selected track since we can't pass it down.
+      const activeTrack = await db.query.tracks.findFirst({
+        where: (fields, { eq }) => eq(fields.uri, trackUri),
+      });
+
+      //? Simplist way of updating the Playback store when we change
+      //? lists via Android Auto.
+      return PlaybackControls.playFromList({
+        source: listSource,
+        trackId: activeTrack?.id,
+      });
     },
   };
 

--- a/mobile/src/lib/web-browser.ts
+++ b/mobile/src/lib/web-browser.ts
@@ -19,6 +19,7 @@ export const Links = {
   License: `${GITHUB}?tab=readme-ov-file#legal`,
   PrivacyPolicy: "https://missingcore.vercel.app/music/privacy-policy",
   Translations: "https://crowdin.com/project/missingcore-music",
+  AndroidAuto: `${GITHUB}/blob/blob/dev/docs/android-auto.md`,
 };
 //#endregion
 

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -286,6 +286,9 @@
     "experimental": {
       "title": "Experimental Features"
     },
+    "androidAuto": {
+      "title": "Android Auto"
+    },
     "ignoreInterrupt": {
       "title": "Ignore Interruptions",
       "brief": "Continue playing audio when an interruption such as a notification or a call occurs. You will need to manually pause and unpause the music during these situations."

--- a/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from "react-i18next";
 import { db } from "~/db";
 import { waveformSamples } from "~/db/schema";
 
+import { OpenInNew } from "~/resources/icons/OpenInNew";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { PreferenceTogglers } from "~/stores/Preference/actions";
 import { sessionStore } from "~/stores/Session/store";
 
 import { ListLayout } from "~/navigation/layouts/ListLayout";
 
+import { Links, openLink } from "~/lib/web-browser";
 import { SegmentedList } from "~/components/List/Segmented";
 import { Switch } from "~/components/UI/Switch";
 
@@ -30,6 +32,12 @@ export default function ExperimentalSettings() {
         labelTextKey="feat.waveformSlider.extra.purgeCache"
         supportingText={t("feat.waveformSlider.extra.purgeCacheBrief")}
         onPress={purgeWaveformCache}
+      />
+
+      <SegmentedList.Item
+        labelTextKey="feat.androidAuto.title"
+        onPress={() => openLink(Links.AndroidAuto)}
+        RightElement={<OpenInNew />}
       />
     </ListLayout>
   );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds (basic) experimental support for Android Auto. There are some caveats with our implementation:

0. We only support "structured lists" currently (Albums & Playlists).
   - Though, you can play other lists via the app and the controls in Android Auto will work fine, you just can't select them.
1. Artwork doesn't get rendered (since Android Auto doesn't support embedded artwork and the package doesn't handle `content://` uri for artwork).
2. Search & voice commands aren't implemented (so they don't work).
3. Shuffle & repeat state can only be changed in the Android app.

From testing on the Desktop Head Unit (DHU), media gets displayed and the Album & Playlist structure/navigation is there.
- The [Android Auto docs](https://github.com/MissingCore/Music/blob/dev/docs/android-auto.md) should go more into detail on how we can test things.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
