### PR TITLE
refactor: Make data more "consistent"

### DIFF
--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -19,7 +19,7 @@ import { omitKeys } from "~/utils/object";
 import type { AlbumSummary, AlbumTrack } from "./types";
 import { AlbumArtistsKey } from "./utils";
 import type { CommonTrack, DrizzleFilter } from "../types";
-import { fromJSONArrayString } from "../utils";
+import { commonTracksOrIds, fromJSONArrayString } from "../utils";
 import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedAlbum = typeof albums.$inferInsert;
@@ -70,7 +70,7 @@ export async function getAlbumDetails(id: string) {
 export async function getAlbumTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
-  const results: Array<Record<string, unknown>> = await db
+  const results = await db
     .select(
       onlyIds
         ? { id: structuredTracksView.id }
@@ -84,14 +84,7 @@ export async function getAlbumTracks<
     .where(eq(structuredTracksView.albumId, id))
     .orderBy(iAsc(structuredTracksView.disc), iAsc(structuredTracksView.track));
 
-  return (
-    onlyIds
-      ? results
-      : results.map(({ artists, ...rest }) => ({
-          ...rest,
-          artists: fromJSONArrayString(artists),
-        }))
-  ) as TOnlyIds extends true ? Array<{ id: string }> : AlbumTrack[];
+  return commonTracksOrIds<AlbumTrack, TOnlyIds>(results, onlyIds);
 }
 
 /** Get information summarizing each album (sorted by names). */
@@ -141,9 +134,7 @@ export async function getAlbumsSummary<
       artistsKey,
       artistName: AlbumArtistsKey.toString(artistsKey),
       duration: Number(album.duration) || 0,
-      ...(withTracks
-        ? { tracks: parseAlbumTracks(album.artwork, tracks) }
-        : {}),
+      ...(withTracks ? { tracks: parseAlbumTracks(tracks) } : {}),
     }))
     .sort((a, b) => a.name.localeCompare(b.name)) as TWithTracks extends true
     ? Array<AlbumSummary & { tracks: CommonTrack[] }>
@@ -199,18 +190,14 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
 //#endregion
 
 //#region Internal Utils
-function parseAlbumTracks(albumArtwork: string | null, tracks?: string) {
+function parseAlbumTracks(tracks?: string) {
   if (!tracks) return [];
   let results: CommonTrack[] = [];
   try {
     const asArray: any[] = JSON.parse(tracks);
     results = asArray
       .filter((i) => i.id !== null)
-      .map((i) => ({
-        ...i,
-        artwork: i.artwork ?? albumArtwork,
-        artists: fromJSONArrayString(i.artists),
-      }));
+      .map((i) => ({ ...i, artists: fromJSONArrayString(i.artists) }));
   } catch {}
   return results;
 }

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -19,8 +19,8 @@ import { omitKeys } from "~/utils/object";
 import type { AlbumSummary, AlbumTrack } from "./types";
 import { AlbumArtistsKey } from "./utils";
 import type { CommonTrack, DrizzleFilter } from "../types";
-import { unencodeJSONArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import { fromJSONArrayString } from "../utils";
+import { commonTrackColumns, getStructuredTracksView } from "../views";
 
 type InsertedAlbum = typeof albums.$inferInsert;
 
@@ -70,35 +70,28 @@ export async function getAlbumDetails(id: string) {
 export async function getAlbumTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
+  const structuredTracks = getStructuredTracksView();
 
-  const results = await db
+  const results: Array<Record<string, unknown>> = await db
     .select(
       onlyIds
-        ? { id: tracks.id }
+        ? { id: structuredTracks.id }
         : {
-            id: tracks.id,
-            name: tracks.name,
-            duration: tracks.duration,
-            disc: tracks.disc,
-            track: tracks.track,
-            uri: tracks.uri,
-            /** We need to unencode these fields. */
-            artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
+            ...commonTrackColumns,
+            disc: structuredTracks.disc,
+            track: structuredTracks.track,
           },
     )
-    .from(tracks)
-    .where(eq(tracks.albumId, id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracks.id)
-    .orderBy(iAsc(tracks.disc), iAsc(tracks.track));
+    .from(structuredTracks)
+    .where(eq(structuredTracks.albumId, id))
+    .orderBy(iAsc(structuredTracks.disc), iAsc(structuredTracks.track));
 
   return (
     onlyIds
       ? results
       : results.map(({ artists, ...rest }) => ({
           ...rest,
-          artists: unencodeJSONArray(artists as string),
+          artists: fromJSONArrayString(artists),
         }))
   ) as TOnlyIds extends true ? Array<{ id: string }> : AlbumTrack[];
 }
@@ -107,7 +100,13 @@ export async function getAlbumTracks<
 export async function getAlbumsSummary<
   TWithTracks extends boolean | undefined = false,
 >(withTracks?: TWithTracks, conditions?: DrizzleFilter) {
-  const orderedAlbumTracks = getOrderedAlbumTracksView();
+  const structuredTracks = getStructuredTracksView();
+  const orderedAlbumTracks = db
+    .select()
+    .from(structuredTracks)
+    .where(isNotNull(structuredTracks.albumId))
+    .orderBy(iAsc(structuredTracks.disc), iAsc(structuredTracks.track))
+    .as("ordered_album_tracks_view");
 
   const results = await db
     .select({
@@ -124,7 +123,10 @@ export async function getAlbumsSummary<
                   'id', ${orderedAlbumTracks.id},
                   'name', ${orderedAlbumTracks.name},
                   'artwork', ${orderedAlbumTracks.artwork},
-                  'artists', ${orderedAlbumTracks.artists}
+                  'artists', ${orderedAlbumTracks.artists},
+                  'albumName', ${orderedAlbumTracks.albumName},
+                  'uri', ${orderedAlbumTracks.uri},
+                  'duration', ${orderedAlbumTracks.duration}
                 )
               )`.as("grouped_tracks"),
           }
@@ -200,33 +202,6 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
 //#endregion
 
 //#region Internal Utils
-function getOrderedAlbumTracksView() {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
-  return db
-    .select({
-      id: tracks.id,
-      name: tracks.name,
-      albumId: tracks.albumId,
-      disc: tracks.disc,
-      track: tracks.track,
-      duration: tracks.duration,
-      artwork: tracks.artwork,
-      year: tracks.year,
-      /** We need to unencode these fields. */
-      artists:
-        sql<string>`json_group_array(${orderedTrackArtists.artistName})`.as(
-          "grouped_artists",
-        ),
-    })
-    .from(tracks)
-    .where(isNotNull(tracks.albumId))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracks.id)
-    .orderBy(iAsc(tracks.disc), iAsc(tracks.track))
-    .as("ordered_album_tracks_view");
-}
-
 function parseAlbumTracks(albumArtwork: string | null, tracks?: string) {
   if (!tracks) return [];
   let results: CommonTrack[] = [];
@@ -237,7 +212,7 @@ function parseAlbumTracks(albumArtwork: string | null, tracks?: string) {
       .map((i) => ({
         ...i,
         artwork: i.artwork ?? albumArtwork,
-        artists: unencodeJSONArray(i.artists),
+        artists: fromJSONArrayString(i.artists),
       }));
   } catch {}
   return results;

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -20,7 +20,7 @@ import type { AlbumSummary, AlbumTrack } from "./types";
 import { AlbumArtistsKey } from "./utils";
 import type { CommonTrack, DrizzleFilter } from "../types";
 import { fromJSONArrayString } from "../utils";
-import { commonTrackColumns, getStructuredTracksView } from "../views";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedAlbum = typeof albums.$inferInsert;
 
@@ -70,21 +70,19 @@ export async function getAlbumDetails(id: string) {
 export async function getAlbumTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
-  const structuredTracks = getStructuredTracksView();
-
   const results: Array<Record<string, unknown>> = await db
     .select(
       onlyIds
-        ? { id: structuredTracks.id }
+        ? { id: structuredTracksView.id }
         : {
             ...commonTrackColumns,
-            disc: structuredTracks.disc,
-            track: structuredTracks.track,
+            disc: structuredTracksView.disc,
+            track: structuredTracksView.track,
           },
     )
-    .from(structuredTracks)
-    .where(eq(structuredTracks.albumId, id))
-    .orderBy(iAsc(structuredTracks.disc), iAsc(structuredTracks.track));
+    .from(structuredTracksView)
+    .where(eq(structuredTracksView.albumId, id))
+    .orderBy(iAsc(structuredTracksView.disc), iAsc(structuredTracksView.track));
 
   return (
     onlyIds
@@ -100,12 +98,11 @@ export async function getAlbumTracks<
 export async function getAlbumsSummary<
   TWithTracks extends boolean | undefined = false,
 >(withTracks?: TWithTracks, conditions?: DrizzleFilter) {
-  const structuredTracks = getStructuredTracksView();
   const orderedAlbumTracks = db
     .select()
-    .from(structuredTracks)
-    .where(isNotNull(structuredTracks.albumId))
-    .orderBy(iAsc(structuredTracks.disc), iAsc(structuredTracks.track))
+    .from(structuredTracksView)
+    .where(isNotNull(structuredTracksView.albumId))
+    .orderBy(iAsc(structuredTracksView.disc), iAsc(structuredTracksView.track))
     .as("ordered_album_tracks_view");
 
   const results = await db

--- a/mobile/src/data/album/queries.ts
+++ b/mobile/src/data/album/queries.ts
@@ -31,13 +31,14 @@ export function useAlbumForScreen(albumId: string) {
             tracks.reduce((total, curr) => total + curr.duration, 0),
           ),
         ],
-        tracks: tracks.map(({ name: title, duration, artists, ...rest }) => {
+        tracks: tracks.map(({ name: title, duration, artists, ...other }) => {
           let description = formatSeconds(duration);
           if (Array.isArray(artists)) {
             const diff = artists.filter((name) => !albumArtists.includes(name));
             if (diff.length > 0) description += ` • ${diff.join(", ")}`;
           }
 
+          const { artwork: _, albumName: _1, ...rest } = other;
           return { ...rest, title, description, imageSource: null };
         }),
 

--- a/mobile/src/data/album/types.ts
+++ b/mobile/src/data/album/types.ts
@@ -1,11 +1,8 @@
-export type AlbumTrack = {
-  id: string;
-  name: string;
-  duration: number;
+import type { CommonTrack } from "../types";
+
+export type AlbumTrack = CommonTrack & {
   disc: number | null;
   track: number | null;
-  uri: string;
-  artists: string[] | null;
 };
 
 export type AlbumSummary = {

--- a/mobile/src/data/artist/api.ts
+++ b/mobile/src/data/artist/api.ts
@@ -13,7 +13,7 @@ import { iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { formatSeconds } from "~/utils/number";
 import type { ArtistAlbum } from "./types";
 import type { CommonTrack } from "../types";
-import { fromJSONArrayString } from "../utils";
+import { commonTracksOrIds } from "../utils";
 import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedArtist = typeof artists.$inferInsert;
@@ -89,7 +89,7 @@ export async function getArtistAlbums(id: string): Promise<ArtistAlbum[]> {
 export async function getArtistTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
-  const results: Array<Record<string, unknown>> = await db
+  const results = await db
     .select(onlyIds ? { id: structuredTracksView.id } : commonTrackColumns)
     .from(tracksToArtists)
     .where(eq(tracksToArtists.artistName, id))
@@ -99,14 +99,7 @@ export async function getArtistTracks<
     )
     .orderBy(iAsc(structuredTracksView.name));
 
-  return (
-    onlyIds
-      ? results
-      : results.map(({ artists, ...rest }) => ({
-          ...rest,
-          artists: fromJSONArrayString(artists),
-        }))
-  ) as TOnlyIds extends true ? Array<{ id: string }> : CommonTrack[];
+  return commonTracksOrIds<CommonTrack, TOnlyIds>(results, onlyIds);
 }
 
 /** Get information summarizing each artist (sorted by names). */

--- a/mobile/src/data/artist/api.ts
+++ b/mobile/src/data/artist/api.ts
@@ -11,7 +11,10 @@ import {
 
 import { iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { formatSeconds } from "~/utils/number";
-import type { ArtistAlbum, ArtistTrack } from "./types";
+import type { ArtistAlbum } from "./types";
+import type { CommonTrack } from "../types";
+import { fromJSONArrayString } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedArtist = typeof artists.$inferInsert;
 
@@ -86,31 +89,24 @@ export async function getArtistAlbums(id: string): Promise<ArtistAlbum[]> {
 export async function getArtistTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
-  const results = await db
-    .select(
-      onlyIds
-        ? { id: tracks.id }
-        : {
-            id: tracks.id,
-            name: tracks.name,
-            artwork: sql<
-              string | null
-            >`coalesce(${tracks.artwork}, ${albums.artwork})`.as(
-              "derived_artwork",
-            ),
-            duration: tracks.duration,
-            album: albums.name,
-          },
-    )
+  const results: Array<Record<string, unknown>> = await db
+    .select(onlyIds ? { id: structuredTracksView.id } : commonTrackColumns)
     .from(tracksToArtists)
     .where(eq(tracksToArtists.artistName, id))
-    .innerJoin(tracks, eq(tracksToArtists.trackId, tracks.id))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .orderBy(iAsc(tracks.name));
+    .innerJoin(
+      structuredTracksView,
+      eq(tracksToArtists.trackId, structuredTracksView.id),
+    )
+    .orderBy(iAsc(structuredTracksView.name));
 
-  return results as TOnlyIds extends true
-    ? Array<{ id: string }>
-    : ArtistTrack[];
+  return (
+    onlyIds
+      ? results
+      : results.map(({ artists, ...rest }) => ({
+          ...rest,
+          artists: fromJSONArrayString(artists),
+        }))
+  ) as TOnlyIds extends true ? Array<{ id: string }> : CommonTrack[];
 }
 
 /** Get information summarizing each artist (sorted by names). */

--- a/mobile/src/data/artist/queries.ts
+++ b/mobile/src/data/artist/queries.ts
@@ -24,7 +24,7 @@ export function useArtistForScreen(artistName: string) {
       tracks: tracks.map((track) => ({
         id: track.id,
         title: track.name,
-        description: track.album ?? "—",
+        description: track.albumName ?? "—",
         imageSource: track.artwork,
       })),
     }),

--- a/mobile/src/data/artist/types.ts
+++ b/mobile/src/data/artist/types.ts
@@ -1,10 +1,3 @@
-export type ArtistTrack = {
-  id: string;
-  name: string;
-  artwork: string | null;
-  album: string | null;
-};
-
 export type ArtistAlbum = {
   id: string;
   name: string;

--- a/mobile/src/data/folder/api.ts
+++ b/mobile/src/data/folder/api.ts
@@ -8,7 +8,7 @@ import { iAsc } from "~/lib/drizzle";
 import { addTrailingSlash } from "~/utils/string";
 import type { Maybe } from "~/utils/types";
 import type { CommonTrack } from "../types";
-import { fromJSONArrayString } from "../utils";
+import { commonTracksOrIds } from "../utils";
 import { commonTrackColumns, structuredTracksView } from "../views";
 
 //#region GET Methods
@@ -73,7 +73,7 @@ export async function getFolderTracks<
       : CommonTrack[];
   }
 
-  const results: Array<Record<string, unknown>> = await db
+  const results = await db
     .select(onlyIds ? { id: structuredTracksView.id } : commonTrackColumns)
     .from(structuredTracksView)
     .where(
@@ -84,14 +84,7 @@ export async function getFolderTracks<
     )
     .orderBy(iAsc(structuredTracksView.name));
 
-  return (
-    onlyIds
-      ? results
-      : results.map(({ artists, ...rest }) => ({
-          ...rest,
-          artists: fromJSONArrayString(artists as string),
-        }))
-  ) as TOnlyIds extends true ? Array<{ id: string }> : CommonTrack[];
+  return commonTracksOrIds<CommonTrack, TOnlyIds>(results, onlyIds);
 }
 //#endregion
 

--- a/mobile/src/data/folder/api.ts
+++ b/mobile/src/data/folder/api.ts
@@ -2,14 +2,14 @@ import { and, eq, exists, isNull, like, sql } from "drizzle-orm";
 
 import { db } from "~/db";
 import type { FileNode } from "~/db/schema";
-import { albums, fileNodes, tracks } from "~/db/schema";
+import { fileNodes, tracks } from "~/db/schema";
 
 import { iAsc } from "~/lib/drizzle";
 import { addTrailingSlash } from "~/utils/string";
 import type { Maybe } from "~/utils/types";
 import type { CommonTrack } from "../types";
-import { unencodeJSONArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import { fromJSONArrayString } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 //#region GET Methods
 /** Get all data associated with a folder. `path` doesn't include `file:///`. */
@@ -73,37 +73,23 @@ export async function getFolderTracks<
       : CommonTrack[];
   }
 
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
-  const results = await db
-    .select(
-      onlyIds
-        ? { id: tracks.id }
-        : {
-            id: tracks.id,
-            name: tracks.name,
-            artwork: sql<
-              string | null
-            >`coalesce(${tracks.artwork}, ${albums.artwork})`.as(
-              "derived_artwork",
-            ),
-            /** We need to unencode these fields. */
-            artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
-          },
+  const results: Array<Record<string, unknown>> = await db
+    .select(onlyIds ? { id: structuredTracksView.id } : commonTrackColumns)
+    .from(structuredTracksView)
+    .where(
+      eq(
+        structuredTracksView.parentFolder,
+        `file:///${addTrailingSlash(path)}`,
+      ),
     )
-    .from(tracks)
-    .where(eq(tracks.parentFolder, `file:///${addTrailingSlash(path)}`))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracks.id)
-    .orderBy(iAsc(tracks.name));
+    .orderBy(iAsc(structuredTracksView.name));
 
   return (
     onlyIds
       ? results
       : results.map(({ artists, ...rest }) => ({
           ...rest,
-          artists: unencodeJSONArray(artists as string),
+          artists: fromJSONArrayString(artists as string),
         }))
   ) as TOnlyIds extends true ? Array<{ id: string }> : CommonTrack[];
 }

--- a/mobile/src/data/genre/api.ts
+++ b/mobile/src/data/genre/api.ts
@@ -1,13 +1,13 @@
-import { count, eq, getTableColumns, sql, sum } from "drizzle-orm";
+import { count, eq, getTableColumns, sum } from "drizzle-orm";
 
 import { db } from "~/db";
-import { albums, genres, tracks, tracksToGenres } from "~/db/schema";
+import { genres, tracks, tracksToGenres } from "~/db/schema";
 
 import { iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { formatSeconds } from "~/utils/number";
 import type { CommonTrack } from "../types";
-import { unencodeJSONArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import { commonTracksOrIds } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedGenre = typeof genres.$inferInsert;
 
@@ -51,40 +51,17 @@ export async function getGenreDetails(id: string) {
 export async function getGenreTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
   const results = await db
-    .select(
-      onlyIds
-        ? { id: tracks.id }
-        : {
-            id: tracks.id,
-            name: tracks.name,
-            artwork: sql<
-              string | null
-            >`coalesce(${tracks.artwork}, ${albums.artwork})`.as(
-              "derived_artwork",
-            ),
-            /** We need to unencode these fields. */
-            artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
-          },
-    )
+    .select(onlyIds ? { id: tracks.id } : commonTrackColumns)
     .from(tracksToGenres)
     .where(eq(tracksToGenres.genreName, id))
-    .innerJoin(tracks, eq(tracksToGenres.trackId, tracks.id))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracksToGenres.trackId)
-    .orderBy(iAsc(tracks.name));
+    .innerJoin(
+      structuredTracksView,
+      eq(tracksToGenres.trackId, structuredTracksView.id),
+    )
+    .orderBy(iAsc(structuredTracksView.name));
 
-  return (
-    onlyIds
-      ? results
-      : results.map(({ artists, ...rest }) => ({
-          ...rest,
-          artists: unencodeJSONArray(artists as string),
-        }))
-  ) as TOnlyIds extends true ? Array<{ id: string }> : CommonTrack[];
+  return commonTracksOrIds<CommonTrack, TOnlyIds>(results, onlyIds);
 }
 
 /** Get information summarizing each genre (sorted by names). */

--- a/mobile/src/data/genre/api.ts
+++ b/mobile/src/data/genre/api.ts
@@ -52,7 +52,7 @@ export async function getGenreTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds) {
   const results = await db
-    .select(onlyIds ? { id: tracks.id } : commonTrackColumns)
+    .select(onlyIds ? { id: structuredTracksView.id } : commonTrackColumns)
     .from(tracksToGenres)
     .where(eq(tracksToGenres.genreName, id))
     .innerJoin(

--- a/mobile/src/data/lyric/api.ts
+++ b/mobile/src/data/lyric/api.ts
@@ -1,11 +1,12 @@
-import { count, eq, getTableColumns, sql } from "drizzle-orm";
+import { count, eq, getTableColumns } from "drizzle-orm";
 
 import { db } from "~/db";
-import { albums, lyrics, tracks, tracksToLyrics } from "~/db/schema";
+import { lyrics, tracks, tracksToLyrics } from "~/db/schema";
 
 import { iAsc, throwIfNoResults } from "~/lib/drizzle";
-import { unencodeJSONArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import type { CommonTrack } from "../types";
+import { commonTracksOrIds } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedLyric = typeof lyrics.$inferInsert;
 
@@ -25,28 +26,17 @@ export async function getLyric(id: string) {
  * the lyric exists.
  */
 export async function getLyricTracks(id: string) {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
   const results = await db
-    .select({
-      id: tracks.id,
-      name: tracks.name,
-      album: albums.name,
-      /** We need to unencode these fields. */
-      artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
-    })
+    .select(commonTrackColumns)
     .from(tracksToLyrics)
     .where(eq(tracksToLyrics.lyricId, id))
-    .innerJoin(tracks, eq(tracksToLyrics.trackId, tracks.id))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracksToLyrics.trackId)
-    .orderBy(iAsc(tracks.name));
+    .innerJoin(
+      structuredTracksView,
+      eq(tracksToLyrics.trackId, structuredTracksView.id),
+    )
+    .orderBy(iAsc(structuredTracksView.name));
 
-  return results.map(({ artists, ...rest }) => ({
-    ...rest,
-    artists: unencodeJSONArray(artists as string),
-  }));
+  return commonTracksOrIds<CommonTrack>(results, false);
 }
 
 /** Get information summarizing each lyric (sorted by names). */

--- a/mobile/src/data/playlist/api.ts
+++ b/mobile/src/data/playlist/api.ts
@@ -1,22 +1,18 @@
 import { and, count, eq, getTableColumns, sql, sum } from "drizzle-orm";
 
 import { db } from "~/db";
-import { albums, playlists, tracks, tracksToPlaylists } from "~/db/schema";
+import { playlists, tracks, tracksToPlaylists } from "~/db/schema";
 
 import i18next from "~/modules/i18n";
 
 import { iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { formatSeconds } from "~/utils/number";
 import { FavoritesPlaylistKey } from "~/modules/media/constants";
-import type {
-  PlaylistSummary,
-  PlaylistSummaryTrack,
-  PlaylistTrack,
-} from "./types";
+import type { PlaylistSummary, PlaylistSummaryTrack } from "./types";
 import { sanitizePlaylistName } from "./utils";
-import type { DrizzleFilter } from "../types";
-import { unencodeJSONArray, unencodeJSONArtworkArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import type { CommonTrack, DrizzleFilter } from "../types";
+import { commonTracksOrIds, unencodeJSONArtworkArray } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedPlaylist = typeof playlists.$inferInsert;
 
@@ -65,51 +61,46 @@ export async function getPlaylistDetails(id: string) {
 export async function getPlaylistTracks<
   TOnlyIds extends boolean | undefined = false,
 >(id: string, onlyIds?: TOnlyIds, limit?: number) {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
   const query = db
-    .select(
-      onlyIds
-        ? { id: tracks.id }
-        : {
-            id: tracks.id,
-            name: tracks.name,
-            artwork: sql<
-              string | null
-            >`coalesce(${tracks.artwork}, ${albums.artwork})`.as(
-              "derived_artwork",
-            ),
-            duration: tracks.duration,
-            uri: tracks.uri,
-            /** We need to unencode these fields. */
-            artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
-          },
-    )
+    .select(onlyIds ? { id: structuredTracksView.id } : commonTrackColumns)
     .from(tracksToPlaylists)
     .where(eq(tracksToPlaylists.playlistName, id))
-    .innerJoin(tracks, eq(tracksToPlaylists.trackId, tracks.id))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracksToPlaylists.trackId)
+    .innerJoin(
+      structuredTracksView,
+      eq(tracksToPlaylists.trackId, structuredTracksView.id),
+    )
     .orderBy(iAsc(tracksToPlaylists.position));
 
   const results = await (limit !== undefined ? query.limit(limit) : query);
 
-  return (
-    onlyIds
-      ? results
-      : results.map(({ artists, ...rest }) => ({
-          ...rest,
-          artists: unencodeJSONArray(artists as string),
-        }))
-  ) as TOnlyIds extends true ? Array<{ id: string }> : PlaylistTrack[];
+  return commonTracksOrIds<CommonTrack, TOnlyIds>(results, onlyIds);
 }
 
 /** Get information summarizing each playlist (sorted by names). */
 export async function getPlaylistsSummary<
   TWithTracks extends boolean | undefined = false,
 >(withTracks?: TWithTracks, conditions?: DrizzleFilter) {
-  const orderedPlaylistTracks = getOrderedPlaylistTracksView();
+  const orderedPlaylistTracks = db
+    .select({
+      playlistName: tracksToPlaylists.playlistName,
+      position: tracksToPlaylists.position, //? To preserve order.
+      id: structuredTracksView.id,
+      name: structuredTracksView.name,
+      rawArtistName: structuredTracksView.rawArtistName,
+      albumName: structuredTracksView.albumName,
+      duration: structuredTracksView.duration,
+      artwork: structuredTracksView.artwork,
+    })
+    .from(tracksToPlaylists)
+    .innerJoin(
+      structuredTracksView,
+      eq(tracksToPlaylists.trackId, structuredTracksView.id),
+    )
+    .orderBy(
+      iAsc(tracksToPlaylists.playlistName),
+      iAsc(tracksToPlaylists.position),
+    )
+    .as("ordered_playlist_tracks_view");
 
   const results = await db
     .select({
@@ -117,7 +108,9 @@ export async function getPlaylistsSummary<
       duration: sum(orderedPlaylistTracks.duration),
       trackCount: count(orderedPlaylistTracks.id),
       /** We need to unencode these strings. */
-      collageArtwork: sql<string>`json_group_array(${orderedPlaylistTracks.derivedArtwork})`,
+      collageArtwork: sql<
+        string | null
+      >`NULLIF(json_group_array(${orderedPlaylistTracks.artwork}), '[null]')`,
       //! This field is "hacked" in, with the main use for the "JSON Backup" feature.
       ...(withTracks
         ? {
@@ -127,7 +120,7 @@ export async function getPlaylistsSummary<
                   'id', ${orderedPlaylistTracks.id},
                   'name', ${orderedPlaylistTracks.name},
                   'rawArtistName', ${orderedPlaylistTracks.rawArtistName},
-                  'album', ${orderedPlaylistTracks.album}
+                  'albumName', ${orderedPlaylistTracks.albumName}
                 )
               )`.as("grouped_tracks"),
           }
@@ -148,9 +141,7 @@ export async function getPlaylistsSummary<
       ...playlist,
       id: name,
       name: parsePlaylistName(name),
-      artwork:
-        playlist.artwork ??
-        unencodeJSONArtworkArray(collageArtwork, playlist.trackCount === 0),
+      artwork: playlist.artwork ?? unencodeJSONArtworkArray(collageArtwork),
       duration: Number(playlist.duration) || 0,
       ...(withTracks ? { tracks: parsePlaylistTracks(tracks) } : {}),
     }))
@@ -237,31 +228,6 @@ export async function deletePlaylist(id: string) {
 //#endregion
 
 //#region Internal Utils
-function getOrderedPlaylistTracksView() {
-  return db
-    .select({
-      playlistName: tracksToPlaylists.playlistName,
-      position: tracksToPlaylists.position, //? To preserve order.
-      id: tracks.id,
-      name: tracks.name,
-      rawArtistName: tracks.rawArtistName,
-      //? For some weird reason, using `albums.name` directly returns `tracks.name`.
-      album: sql<string | null>`${albums.name}`.as("album"),
-      duration: tracks.duration,
-      derivedArtwork: sql<
-        string | null
-      >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
-    })
-    .from(tracksToPlaylists)
-    .innerJoin(tracks, eq(tracksToPlaylists.trackId, tracks.id))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .orderBy(
-      iAsc(tracksToPlaylists.playlistName),
-      iAsc(tracksToPlaylists.position),
-    )
-    .as("ordered_playlist_tracks_view");
-}
-
 /** Checks to see if the playlist name needs to be translated for `FavoritesPlaylistKey`. */
 function parsePlaylistName(name: string) {
   return name === FavoritesPlaylistKey
@@ -274,9 +240,7 @@ function parsePlaylistTracks(tracks?: string) {
   let results: PlaylistSummaryTrack[] = [];
   try {
     const asArray: any[] = JSON.parse(tracks);
-    results = asArray.filter(
-      (i) => i.name !== null || i.rawArtistName !== null || i.album !== null,
-    );
+    results = asArray.filter((i) => i.name !== null);
   } catch {}
   return results;
 }

--- a/mobile/src/data/playlist/types.ts
+++ b/mobile/src/data/playlist/types.ts
@@ -1,11 +1,3 @@
-import type { CommonTrack } from "../types";
-
-export type PlaylistTrack = CommonTrack & {
-  //? Used by "Export M3U" feature:
-  duration: number;
-  uri: string;
-};
-
 export type PlaylistSummary = {
   /** The raw `name` field stored in the `Playlists` schema. */
   id: string;
@@ -22,5 +14,5 @@ export type PlaylistSummaryTrack = {
   name: string;
   /** @deprecated */
   rawArtistName: string | null;
-  album: string | null;
+  albumName: string | null;
 };

--- a/mobile/src/data/recent/api.ts
+++ b/mobile/src/data/recent/api.ts
@@ -2,7 +2,7 @@ import { and, eq, gt, sql } from "drizzle-orm";
 
 import { db } from "~/db";
 import type { PlayedMediaList } from "~/db/schema";
-import { albums, playedMediaLists, tracks } from "~/db/schema";
+import { playedMediaLists, tracks } from "~/db/schema";
 
 import i18next from "~/modules/i18n";
 import type { PlayFromSource } from "~/stores/Playback/types";
@@ -17,8 +17,8 @@ import { getPlaylist } from "../playlist/api";
 import { iDesc } from "~/lib/drizzle";
 import { ReservedPlaylists } from "~/modules/media/constants";
 import type { MediaCardContent } from "~/modules/media/components/MediaCard.type";
-import { unencodeJSONArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import { fromJSONArrayString } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 export const RECENT_DAY_RANGE = 7;
 export const RECENT_RANGE_MS = RECENT_DAY_RANGE * 24 * 60 * 60 * 1000;
@@ -55,29 +55,16 @@ export async function getRecentLists() {
 }
 
 export async function getRecentTracks() {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
   const results = await db
-    .select({
-      id: tracks.id,
-      name: tracks.name,
-      artwork: sql<
-        string | null
-      >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
-      /** We need to unencode these fields. */
-      artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
-    })
-    .from(tracks)
-    .where(gt(tracks.lastPlayedAt, Date.now() - RECENT_RANGE_MS))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracks.id)
-    .orderBy(iDesc(tracks.lastPlayedAt));
+    .select(commonTrackColumns)
+    .from(structuredTracksView)
+    .where(gt(structuredTracksView.lastPlayedAt, Date.now() - RECENT_RANGE_MS))
+    .orderBy(iDesc(structuredTracksView.lastPlayedAt));
 
   return results.map((track) => ({
     id: track.id,
     title: track.name,
-    description: getArtistsString(unencodeJSONArray(track.artists as string)),
+    description: getArtistsString(fromJSONArrayString(track.artists)),
     imageSource: track.artwork,
   }));
 }

--- a/mobile/src/data/track/api.ts
+++ b/mobile/src/data/track/api.ts
@@ -1,20 +1,15 @@
-import { and, eq, getTableColumns, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { db } from "~/db";
 import type { InvalidTrack } from "~/db/schema";
-import {
-  albums,
-  invalidTracks,
-  tracks,
-  tracksToArtists,
-  tracksToPlaylists,
-} from "~/db/schema";
+import { invalidTracks, tracks, tracksToPlaylists } from "~/db/schema";
 
 import { viewPreferenceStore } from "~/stores/ViewPreference/store";
 import type { ScreenSortOptions } from "~/stores/ViewPreference/constants";
 
 import {
   getExcludedColumns,
+  getSubqueryFields,
   iAsc,
   iDesc,
   throwIfNoResults,
@@ -24,46 +19,28 @@ import { FavoritesPlaylistKey } from "~/modules/media/constants";
 import { TrackRelationTables } from "./constants";
 import type { BulkQueriedTrack, SortedTrack, Track } from "./types";
 import type { DrizzleFilter } from "../types";
-import { unencodeJSONArray } from "../utils";
-import { getOrderedTrackArtistsView } from "../views";
+import { commonTracksOrIds, fromJSONArrayString } from "../utils";
+import { commonTrackColumns, structuredTracksView } from "../views";
 
 type InsertedTrack = typeof tracks.$inferInsert;
 type InsertedTrackPlaylistRelation = typeof tracksToPlaylists.$inferInsert;
 
-const trackFields = omitKeys(getTableColumns(tracks), [
+const trackFields = omitKeys(getSubqueryFields(structuredTracksView), [
   "rawArtistName",
   "isFavorite",
   "hiddenAt",
-  "artwork",
 ]);
 
 //#region GET Methods
 export async function getTrack(id: string): Promise<Track> {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
   const [result] = await throwIfNoResults(
     db
-      .select({
-        ...trackFields,
-        artwork: sql<
-          string | null
-        >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
-        album: sql<string | null>`${albums.name}`.as("album"),
-        albumArtistsKey: sql<string | null>`${albums.artistsKey}`.as(
-          "album_artists_key",
-        ),
-        /** We need to unencode these fields. */
-        artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
-      })
-      .from(tracks)
-      .where(eq(tracks.id, id))
-      .leftJoin(albums, eq(tracks.albumId, albums.id))
-      .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-      .groupBy(tracks.id),
+      .select(trackFields)
+      .from(structuredTracksView)
+      .where(eq(structuredTracksView.id, id)),
     "err.msg.noTracks",
   );
-
-  return { ...result!, artists: unencodeJSONArray(result!.artists) };
+  return { ...result!, artists: fromJSONArrayString(result!.artists) };
 }
 
 //#region Get Relations
@@ -115,48 +92,28 @@ export async function getSortedTracks<
   const isAsc = sortOptions?.isAsc ?? trackIsAsc;
   const order = sortOptions?.order ?? trackOrder;
 
-  //? Subquery to order the track artists before we use `GROUP_CONCAT` on them.
-  const orderedTrackArtists = db
-    .select({
-      trackId: tracksToArtists.trackId,
-      artistName:
-        sql<string>`GROUP_CONCAT(${tracksToArtists.artistName}, ', ')`.as(
-          "joined_artistname",
-        ),
-    })
-    .from(tracksToArtists)
-    .orderBy(iAsc(tracksToArtists.trackId), iAsc(tracksToArtists.artistName))
-    .groupBy(tracksToArtists.trackId)
-    .as("ordered_track_artists");
   //? Determine field we'll sort by.
   const sortField =
-    order === "albumName"
-      ? albums.name
-      : order === "artistName"
-        ? orderedTrackArtists.artistName
-        : tracks[order];
+    order === "artistName"
+      ? structuredTracksView.artistsName
+      : structuredTracksView[order];
 
   const results = await db
     .select(
       onlyIds
-        ? { id: tracks.id }
+        ? { id: structuredTracksView.id }
         : {
-            id: tracks.id,
-            name: tracks.name,
-            artistName: orderedTrackArtists.artistName,
-            albumName: albums.name,
-            duration: tracks.duration,
-            discoverTime: tracks.discoverTime,
-            modificationTime: tracks.modificationTime,
-            artwork: sql<
-              string | null
-            >`coalesce(${tracks.artwork}, ${albums.artwork})`,
+            id: structuredTracksView.id,
+            name: structuredTracksView.name,
+            artistName: structuredTracksView.artistsName,
+            albumName: structuredTracksView.albumName,
+            duration: structuredTracksView.duration,
+            discoverTime: structuredTracksView.discoverTime,
+            modificationTime: structuredTracksView.modificationTime,
+            artwork: structuredTracksView.artwork,
           },
     )
-    .from(tracks)
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .groupBy(tracks.id)
+    .from(structuredTracksView)
     .orderBy(isAsc ? iAsc(sortField) : iDesc(sortField));
 
   return results as TOnlyIds extends true
@@ -164,37 +121,19 @@ export async function getSortedTracks<
     : SortedTrack[];
 }
 
-export async function getTracks(
-  conditions?: DrizzleFilter,
-): Promise<BulkQueriedTrack[]> {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-
+export async function getTracks(conditions?: DrizzleFilter) {
   const results = await db
     .select({
-      id: tracks.id,
-      name: tracks.name,
-      rawArtistName: tracks.rawArtistName,
-      artwork: sql<
-        string | null
-      >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
-      albumId: tracks.albumId,
-      album: sql<string | null>`${albums.name}`.as("album"),
-      uri: tracks.uri,
-      parentFolder: tracks.parentFolder,
-      /** We need to unencode these fields. */
-      artists: sql<string>`json_group_array(${orderedTrackArtists.artistName})`,
+      ...commonTrackColumns,
+      rawArtistName: structuredTracksView.rawArtistName,
+      albumId: structuredTracksView.albumId,
+      parentFolder: structuredTracksView.parentFolder,
     })
-    .from(tracks)
+    .from(structuredTracksView)
     .where(and(...(conditions ?? [])))
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracks.id)
-    .orderBy(iAsc(tracks.name));
+    .orderBy(iAsc(structuredTracksView.name));
 
-  return results.map(({ artists, ...track }) => ({
-    ...track,
-    artists: unencodeJSONArray(artists),
-  }));
+  return commonTracksOrIds<BulkQueriedTrack, false>(results, false);
 }
 //#endregion
 

--- a/mobile/src/data/track/types.ts
+++ b/mobile/src/data/track/types.ts
@@ -10,7 +10,7 @@ type TRACK_INTERNAL = Omit<
 
 export type Track = Prettify<
   TRACK_INTERNAL & {
-    album: string | null;
+    albumName: string | null;
     albumArtistsKey: string | null;
     artists: string[] | null;
   }
@@ -29,9 +29,8 @@ export type SortedTrack = {
 };
 
 export type BulkQueriedTrack = CommonTrack & {
+  /** @deprecated */
   rawArtistName: string | null;
   albumId: string | null;
-  album: string | null;
-  uri: string;
   parentFolder: string | null;
 };

--- a/mobile/src/data/track/utils.ts
+++ b/mobile/src/data/track/utils.ts
@@ -26,7 +26,7 @@ export function formatTrackforPlayer(track: Track) {
     artwork: track.artwork || PlaceholderImageFile,
     title: track.name,
     artist: getArtistsString(track.artists, "No Artist"),
-    album: track.album || undefined,
+    album: track.albumName || undefined,
     duration: track.duration,
   } satisfies AddTrack;
 }

--- a/mobile/src/data/types.ts
+++ b/mobile/src/data/types.ts
@@ -9,4 +9,7 @@ export type CommonTrack = {
   name: string;
   artwork: string | null;
   artists: string[] | null;
+  albumName: string | null;
+  uri: string;
+  duration: number;
 };

--- a/mobile/src/data/utils.ts
+++ b/mobile/src/data/utils.ts
@@ -1,3 +1,17 @@
+export function commonTracksOrIds<
+  TResult extends Record<string, any>,
+  TOnlyIds extends boolean | undefined = false,
+>(data: Array<Record<string, unknown>>, onlyIds?: TOnlyIds) {
+  return (
+    onlyIds
+      ? data
+      : data.map(({ artists, ...rest }) => ({
+          ...rest,
+          artists: fromJSONArrayString(artists as string),
+        }))
+  ) as TOnlyIds extends true ? Array<{ id: string }> : TResult[];
+}
+
 export function fromJSONArrayString(rawJSONString: string | null | unknown) {
   let results: string[] = [];
   // `rawJSONString` returns `string[]` or `null` as we use `NULLIF` to

--- a/mobile/src/data/utils.ts
+++ b/mobile/src/data/utils.ts
@@ -24,17 +24,14 @@ export function fromJSONArrayString(rawJSONString: string | null | unknown) {
   return results.length > 0 ? results : null;
 }
 
-export function unencodeJSONArtworkArray(
-  rawJSONString: string,
-  isEmpty: boolean,
-) {
+export function unencodeJSONArtworkArray(rawJSONString: string | null) {
   let results: Array<string | null> = [];
-  try {
-    // `rawJSONString` can be `[null]` or `string[]`.
-    const asArr: Array<string | null> = JSON.parse(rawJSONString);
-    results = asArr.slice(0, 4);
-  } catch {}
-  //? `rawJSONString` will default to `[null]` if the array is supposed to be empty.
-  if (isEmpty && results.length === 1 && results[0] === null) return null;
+  // `rawJSONString` returns `string[]` or `null` as we use `NULLIF` to
+  // prevent returning `[null]`.
+  if (typeof rawJSONString === "string") {
+    try {
+      results = JSON.parse(rawJSONString).slice(0, 4);
+    } catch {}
+  }
   return results.length > 0 ? results : null;
 }

--- a/mobile/src/data/utils.ts
+++ b/mobile/src/data/utils.ts
@@ -1,10 +1,12 @@
-export function unencodeJSONArray(rawJSONString: string) {
+export function fromJSONArrayString(rawJSONString: string | null | unknown) {
   let results: string[] = [];
-  try {
-    // `rawJSONString` can be `[null]` or `string[]`.
-    const asArr: Array<string | null> = JSON.parse(rawJSONString);
-    results = asArr.filter((name) => name !== null);
-  } catch {}
+  // `rawJSONString` returns `string[]` or `null` as we use `NULLIF` to
+  // prevent returning `[null]`.
+  if (typeof rawJSONString === "string") {
+    try {
+      results = JSON.parse(rawJSONString);
+    } catch {}
+  }
   return results.length > 0 ? results : null;
 }
 

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -35,7 +35,8 @@ export const structuredTracksView = db
     artwork: sql<
       string | null
     >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
-    albumName: albums.name,
+    //? For some weird reason, using `albums.name` directly returns `tracks.name`.
+    albumName: sql<string | null>`${albums.name}`.as("album_name"),
     albumArtistsKey: albums.artistsKey,
     artistsName: sql<
       string | null

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -9,6 +9,8 @@ import { pickKeys } from "~/utils/object";
 /**
  * Order the `tracksToArtists` table by artist names. Used for ensuring
  * artist name order when generating the `artists` field on tracks.
+ *
+ * @deprecated Use `orderedTrackArtistsView`.
  */
 export function getOrderedTrackArtistsView() {
   return db
@@ -18,6 +20,8 @@ export function getOrderedTrackArtistsView() {
     .as("ordered_track_artists_view");
 }
 
+export const orderedTrackArtistsView = getOrderedTrackArtistsView();
+
 const { artwork: _, ...trackColumns } = getTableColumns(tracks);
 
 /**
@@ -25,36 +29,36 @@ const { artwork: _, ...trackColumns } = getTableColumns(tracks);
  *  - `artwork` contains the appropriate artwork (from track or album).
  *  - `artists` contains a JSON-stringified array (`string[]` or `[null]`).
  */
-export function getStructuredTracksView() {
-  const orderedTrackArtists = getOrderedTrackArtistsView();
-  return db
-    .select({
-      ...trackColumns,
-      artwork: sql<
-        string | null
-      >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
-      albumName: albums.name,
-      albumArtistsKey: albums.artistsKey,
-      artistsName: sql<
-        string | null
-      >`GROUP_CONCAT(${orderedTrackArtists.artistName}, ', ')`.as(
-        "joined_artists_name",
-      ),
-      /** We need to unencode these fields. */
-      artists: sql<
-        string | null
-      >`NULLIF(json_group_array(${orderedTrackArtists.artistName}), '[null]')`.as(
-        "derived_artists",
-      ),
-    })
-    .from(tracks)
-    .leftJoin(albums, eq(tracks.albumId, albums.id))
-    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
-    .groupBy(tracks.id)
-    .as("structured_tracks_view");
-}
+export const structuredTracksView = db
+  .select({
+    ...trackColumns,
+    artwork: sql<
+      string | null
+    >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
+    albumName: albums.name,
+    albumArtistsKey: albums.artistsKey,
+    artistsName: sql<
+      string | null
+    >`GROUP_CONCAT(${orderedTrackArtistsView.artistName}, ', ')`.as(
+      "joined_artists_name",
+    ),
+    /** We need to unencode these fields. */
+    artists: sql<
+      string | null
+    >`NULLIF(json_group_array(${orderedTrackArtistsView.artistName}), '[null]')`.as(
+      "derived_artists",
+    ),
+  })
+  .from(tracks)
+  .leftJoin(albums, eq(tracks.albumId, albums.id))
+  .leftJoin(
+    orderedTrackArtistsView,
+    eq(tracks.id, orderedTrackArtistsView.trackId),
+  )
+  .groupBy(tracks.id)
+  .as("structured_tracks_view");
 
 export const commonTrackColumns = pickKeys(
-  getSubqueryFields(getStructuredTracksView()),
+  getSubqueryFields(structuredTracksView),
   ["id", "name", "artwork", "artists", "albumName", "uri", "duration"],
 );

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -40,7 +40,7 @@ export function getStructuredTracksView() {
         ),
       /** We need to unencode these fields. */
       artists:
-        sql<string>`json_group_array(${orderedTrackArtists.artistName})`.as(
+        sql<string>`NULLIF(json_group_array(${orderedTrackArtists.artistName}), '[null]')`.as(
           "derived_artists",
         ),
     })

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -1,5 +1,7 @@
+import { eq, getTableColumns, sql } from "drizzle-orm";
+
 import { db } from "~/db";
-import { tracksToArtists } from "~/db/schema";
+import { albums, tracks, tracksToArtists } from "~/db/schema";
 
 import { iAsc } from "~/lib/drizzle";
 
@@ -13,4 +15,38 @@ export function getOrderedTrackArtistsView() {
     .from(tracksToArtists)
     .orderBy(iAsc(tracksToArtists.artistName))
     .as("ordered_track_artists_view");
+}
+
+const { artwork: _, ...trackColumns } = getTableColumns(tracks);
+
+/**
+ * Join main relations (album & artists) onto `tracks` table.
+ *  - `artwork` contains the appropriate artwork (from track or album).
+ *  - `artists` contains a JSON-stringified array (`string[]` or `[null]`).
+ */
+export function getStructuredTracksView() {
+  const orderedTrackArtists = getOrderedTrackArtistsView();
+  return db
+    .select({
+      ...trackColumns,
+      artwork: sql<
+        string | null
+      >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
+      albumName: albums.name,
+      albumArtistsKey: albums.artistsKey,
+      artistsName:
+        sql<string>`GROUP_CONCAT(${orderedTrackArtists.artistName}, ', ')`.as(
+          "joined_artists_name",
+        ),
+      /** We need to unencode these fields. */
+      artists:
+        sql<string>`json_group_array(${orderedTrackArtists.artistName})`.as(
+          "derived_artists",
+        ),
+    })
+    .from(tracks)
+    .leftJoin(albums, eq(tracks.albumId, albums.id))
+    .leftJoin(orderedTrackArtists, eq(tracks.id, orderedTrackArtists.trackId))
+    .groupBy(tracks.id)
+    .as("structured_tracks_view");
 }

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -3,7 +3,8 @@ import { eq, getTableColumns, sql } from "drizzle-orm";
 import { db } from "~/db";
 import { albums, tracks, tracksToArtists } from "~/db/schema";
 
-import { iAsc } from "~/lib/drizzle";
+import { getSubqueryFields, iAsc } from "~/lib/drizzle";
+import { pickKeys } from "~/utils/object";
 
 /**
  * Order the `tracksToArtists` table by artist names. Used for ensuring
@@ -34,15 +35,17 @@ export function getStructuredTracksView() {
       >`coalesce(${tracks.artwork}, ${albums.artwork})`.as("derived_artwork"),
       albumName: albums.name,
       albumArtistsKey: albums.artistsKey,
-      artistsName:
-        sql<string>`GROUP_CONCAT(${orderedTrackArtists.artistName}, ', ')`.as(
-          "joined_artists_name",
-        ),
+      artistsName: sql<
+        string | null
+      >`GROUP_CONCAT(${orderedTrackArtists.artistName}, ', ')`.as(
+        "joined_artists_name",
+      ),
       /** We need to unencode these fields. */
-      artists:
-        sql<string>`NULLIF(json_group_array(${orderedTrackArtists.artistName}), '[null]')`.as(
-          "derived_artists",
-        ),
+      artists: sql<
+        string | null
+      >`NULLIF(json_group_array(${orderedTrackArtists.artistName}), '[null]')`.as(
+        "derived_artists",
+      ),
     })
     .from(tracks)
     .leftJoin(albums, eq(tracks.albumId, albums.id))
@@ -50,3 +53,8 @@ export function getStructuredTracksView() {
     .groupBy(tracks.id)
     .as("structured_tracks_view");
 }
+
+export const commonTrackColumns = pickKeys(
+  getSubqueryFields(getStructuredTracksView()),
+  ["id", "name", "artwork", "artists", "albumName", "uri", "duration"],
+);

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -9,18 +9,12 @@ import { pickKeys } from "~/utils/object";
 /**
  * Order the `tracksToArtists` table by artist names. Used for ensuring
  * artist name order when generating the `artists` field on tracks.
- *
- * @deprecated Use `orderedTrackArtistsView`.
  */
-export function getOrderedTrackArtistsView() {
-  return db
-    .select()
-    .from(tracksToArtists)
-    .orderBy(iAsc(tracksToArtists.artistName))
-    .as("ordered_track_artists_view");
-}
-
-export const orderedTrackArtistsView = getOrderedTrackArtistsView();
+export const orderedTrackArtistsView = db
+  .select()
+  .from(tracksToArtists)
+  .orderBy(iAsc(tracksToArtists.artistName))
+  .as("ordered_track_artists_view");
 
 const { artwork: _, ...trackColumns } = getTableColumns(tracks);
 

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -21,6 +21,7 @@ import { getPlaylist, getPlaylistsSummary } from "~/data/playlist/api";
 import { addPlayedTrack } from "~/data/recent/api";
 import { deleteTracks } from "~/data/track/api";
 import { formatTrackforPlayer } from "~/data/track/utils";
+import type { CommonTrack } from "~/data/types";
 import { playbackStore } from "~/stores/Playback/store";
 import { PlaybackControls, Queue } from "~/stores/Playback/actions";
 import { preferenceStore } from "~/stores/Preference/store";
@@ -287,20 +288,14 @@ export async function initServices() {
     category: MediaType,
     loader: (id: string) => Promise<{
       name: string;
-      artwork: string | null | Array<string | null>;
-      tracks: Array<Record<string, any>>;
+      tracks: Array<CommonTrack & { disc?: number | null }>;
     }>,
-    useListArtwork = false,
   ): BrowserSource {
     return async ({ routeParams }): Promise<ResolvedTrack> => {
       const id = routeParams!.id!;
       const data = await loader(id);
-      const listArtwork = Array.isArray(data.artwork)
-        ? data.artwork[0]
-        : data.artwork;
-
       // Only available for tracks in "Album" entry.
-      const hasDiscLabel = data.tracks.at(-1)?.disc > 1;
+      const hasDiscLabel = (data.tracks.at(-1)?.disc || -1) > 1;
 
       return {
         url: `/${category}/${id}`,
@@ -309,9 +304,7 @@ export async function initServices() {
           src: getSafeUri(track.uri),
           title: track.name,
           artist: getArtistsString(track.artists),
-          artwork:
-            (useListArtwork ? listArtwork : track.artwork) ||
-            PlaceholderImageFile,
+          artwork: track.artwork || PlaceholderImageFile,
           duration: track.duration,
           groupTitle:
             hasDiscLabel && typeof track.disc === "number"
@@ -324,7 +317,7 @@ export async function initServices() {
 
   const mediaListRoutes: Record<string, BrowserSource> = {
     "/album": () => getMediaCategoryRoute("album", getAlbumsSummary),
-    "/album/{id}": getMediaCategoryEntryRoute("album", getAlbum, true),
+    "/album/{id}": getMediaCategoryEntryRoute("album", getAlbum),
     "/playlist": () => getMediaCategoryRoute("playlist", getPlaylistsSummary),
     "/playlist/{id}": getMediaCategoryEntryRoute("playlist", getPlaylist),
   };

--- a/mobile/src/lib/drizzle.ts
+++ b/mobile/src/lib/drizzle.ts
@@ -1,7 +1,12 @@
-import type { SQLWrapper } from "drizzle-orm";
+import type { ColumnsSelection, SQLWrapper } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import { toSnakeCase } from "drizzle-orm/casing";
-import type { AnySQLiteColumn, SQLiteColumn } from "drizzle-orm/sqlite-core";
+import type {
+  AnySQLiteColumn,
+  SQLiteColumn,
+  SubqueryWithSelection,
+  WithSubqueryWithSelection,
+} from "drizzle-orm/sqlite-core";
 import type { ParseKeys } from "i18next";
 
 import i18next from "~/modules/i18n";
@@ -42,4 +47,17 @@ export async function throwIfNoResults<TData>(
     throw new Error(i18next.t(errMsg));
   }
   return result;
+}
+
+/**
+ * Get columns on subquery.
+ *  - Ref: https://github.com/drizzle-team/drizzle-orm/issues/1459
+ *
+ * Shouldn't be needed in v1 of Drizzle based on:
+ *  - https://github.com/drizzle-team/drizzle-orm/pull/1789
+ */
+export function getSubqueryFields<S extends ColumnsSelection, A extends string>(
+  query: WithSubqueryWithSelection<S, A> | SubqueryWithSelection<S, A>,
+) {
+  return query._.selectedFields;
 }

--- a/mobile/src/modules/backup/JSON.ts
+++ b/mobile/src/modules/backup/JSON.ts
@@ -127,7 +127,7 @@ async function exportBackup() {
         tracks: tracks.map((t) => ({
           name: t.name,
           artistName: t.rawArtistName,
-          albumName: t.album,
+          albumName: t.albumName,
         })),
       })),
     }),

--- a/mobile/src/modules/backup/JSON.ts
+++ b/mobile/src/modules/backup/JSON.ts
@@ -85,7 +85,7 @@ async function findExistingTracksFactory() {
           (t) =>
             t.name === entry.name &&
             t.rawArtistName === entry.artistName &&
-            t.album === (entry.albumName || null),
+            t.albumName === (entry.albumName || null),
         ),
       )
       .filter((entry) => entry !== undefined);

--- a/mobile/src/modules/backup/M3U.ts
+++ b/mobile/src/modules/backup/M3U.ts
@@ -3,12 +3,11 @@ import { inArray } from "drizzle-orm";
 import { Paths } from "expo-file-system";
 
 import { db } from "~/db";
-import { tracks } from "~/db/schema";
-
-import { getPlaylist } from "~/data/playlist/api";
-import { getTracks } from "~/data/track/api";
 
 import i18next from "~/modules/i18n";
+import { getPlaylist } from "~/data/playlist/api";
+import { getTracks } from "~/data/track/api";
+import { structuredTracksView } from "~/data/views";
 
 import { joinPaths, pickDirectory, pickFile } from "~/lib/file-system";
 
@@ -58,7 +57,9 @@ export async function readM3UPlaylist() {
         ? trackPaths.map((path) => joinPaths(fileDirectory, path))
         : trackPaths;
 
-  const playlistTracks = await getTracks([inArray(tracks.uri, trackUris)]);
+  const playlistTracks = await getTracks([
+    inArray(structuredTracksView.uri, trackUris),
+  ]);
 
   // Ensure found values are in order.
   const playlistTrackMap = Object.fromEntries(

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -10,6 +10,7 @@ import { albums, tracks } from "~/db/schema";
 
 import { getAlbumsSummary, updateAlbum } from "~/data/album/api";
 import { getTracks, updateTrack } from "~/data/track/api";
+import { structuredTracksView } from "~/data/views";
 import { scanningProgressStore } from "../ScanningProgress";
 
 import { ImageDirectory } from "~/lib/file-system";
@@ -39,7 +40,9 @@ export async function findAndSaveArtwork() {
       or(inArray(tracks.albumId, idsWithCover), isNotNull(tracks.artwork)),
     );
 
-  const uncheckedTracks = await getTracks([eq(tracks.fetchedArt, false)]);
+  const uncheckedTracks = await getTracks([
+    eq(structuredTracksView.fetchedArt, false),
+  ]);
   // Sort tracks to optimize SQL queries.
   const singles: PartialTrack[] = [];
   const albumTracks: Record<string, PartialTrack[]> = {};

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -68,12 +68,12 @@ export function useSearch<TScope extends SearchCategories>(
             );
           } else if (mediaType === "track") {
             results = data[mediaType].filter(
-              ({ name, artists, album }) =>
+              ({ name, artists, albumName }) =>
                 lowerHas(name, q) ||
                 // One of track's artist names starts with the query.
                 artists?.some((i) => lowerStart(i, q)) ||
                 // Track's album starts with the query.
-                lowerStart(album || undefined, q),
+                lowerStart(albumName || undefined, q),
             );
           } else {
             results = data[mediaType].filter((i) => lowerHas(i.name, q));

--- a/mobile/src/navigation/screens/lyrics/CurrentView.tsx
+++ b/mobile/src/navigation/screens/lyrics/CurrentView.tsx
@@ -81,7 +81,7 @@ export default function Lyric({
           </SegmentedList.CustomItem>
           {data.tracks.length > 0 ? (
             <SegmentedList.CustomItem>
-              {data.tracks.map(({ id, name, album, artists }, index) => (
+              {data.tracks.map(({ id, name, albumName, artists }, index) => (
                 <Fragment key={id}>
                   {index > 0 ? <Divider className="mx-4" /> : null}
                   <View className="flex-row gap-2 p-4 pr-2">
@@ -92,7 +92,9 @@ export default function Lyric({
                           {getArtistsString(artists)}
                         </StyledText>
                       ) : null}
-                      {album ? <StyledText dim>{album}</StyledText> : null}
+                      {albumName ? (
+                        <StyledText dim>{albumName}</StyledText>
+                      ) : null}
                     </View>
                     <IconButton
                       Icon={LinkOff}

--- a/mobile/src/navigation/screens/now-playing/UpcomingView.tsx
+++ b/mobile/src/navigation/screens/now-playing/UpcomingView.tsx
@@ -3,12 +3,11 @@ import { inArray } from "drizzle-orm";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { tracks } from "~/db/schema";
-
 import { Cached } from "~/resources/icons/Cached";
 import { DragHandle } from "~/resources/icons/DragHandle";
 import { getArtistsString } from "~/data/artist/utils";
 import { getTracks } from "~/data/track/api";
+import { structuredTracksView } from "~/data/views";
 import { playbackStore, usePlaybackStore } from "~/stores/Playback/store";
 import { PlaybackControls, Queue } from "~/stores/Playback/actions";
 
@@ -203,7 +202,9 @@ async function getQueueTracks() {
   // Since there's potentially duplicate tracks.
   const queueTrackIds = queue.map(extractTrackId);
   const queueSet = new Set(queueTrackIds);
-  const unorderedTracks = await getTracks([inArray(tracks.id, [...queueSet])]);
+  const unorderedTracks = await getTracks([
+    inArray(structuredTracksView.id, [...queueSet]),
+  ]);
 
   // Structure as a map for faster searching.
   const trackMap = Object.fromEntries(

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -78,13 +78,13 @@ function Metadata({ track }: { track: Track }) {
           popStrategy="popScreen"
           className="text-sm/[1.125]"
         />
-        {track.album ? (
+        {track.albumName ? (
           <Marquee>
             <Pressable
               onPress={() => navigation.popTo("Album", { id: track.albumId })}
             >
               <StyledText dim className="text-sm/[1.125]">
-                {track.album}
+                {track.albumName}
               </StyledText>
             </Pressable>
           </Marquee>

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -83,7 +83,7 @@ export default function ModifyTrack({
         uri: trackQuery.data.uri,
         name: trackQuery.data.name,
         artists: trackQuery.data.artists ?? [],
-        album: trackQuery.data.album ?? null,
+        album: trackQuery.data.albumName ?? null,
         albumArtists: trackQuery.data.albumArtistsKey
           ? AlbumArtistsKey.deconstruct(trackQuery.data.albumArtistsKey)
           : [],

--- a/mobile/src/navigation/screens/tracks/sheets/TrackSheet.tsx
+++ b/mobile/src/navigation/screens/tracks/sheets/TrackSheet.tsx
@@ -100,7 +100,7 @@ function TrackIntro({ data }: { data: Track }) {
           popStrategy={onNowPlaying ? "popScreen" : undefined}
           marqueeShadowColor="surfaceBright"
         />
-        {data.album ? (
+        {data.albumName ? (
           <Marquee color="surfaceBright">
             <Pressable
               onPress={sheetAction(() => {
@@ -108,7 +108,7 @@ function TrackIntro({ data }: { data: Track }) {
                 navigation.navigate("Album", { id: data.albumId! });
               })}
             >
-              <StyledText dim>{data.album}</StyledText>
+              <StyledText dim>{data.albumName}</StyledText>
             </Pressable>
           </Marquee>
         ) : null}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR aims to make the track data returned by our "API" functions more consistent by having all of them extend the `CommonTrack` type (which now also has `albumName`, `uri`, and `duration` fields). To facilitate this, we created a new `structuredTracksView` "view" which returns formatted tracks to remove redundancy (ie: derives the `artwork` field, returns the album & artist name fields).

This does make it a bit easier to support more lists if we want to in Android Auto as we return a similar enough structure across all of our data.

### Some Notes

- We don't need to return our subqueries via functions, they can just be defined in a variable.
- [If we join a table with a column name that's present in the original table, returning that field in `select` may result in the wrong value](https://redirect.github.com/drizzle-team/drizzle-orm/issues/555).
- Any conditions passed to `getTracks()` will need to reference from the `structuredTracksView` subquery instead of the `tracks` table.
- SQL's `NULLIF` is really useful if we want to convert `'[null]'` from `json_group_array()` to `null`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
