### PR TITLE
refactor: Replace `@lukemorales/query-key-factory` with `QueryOptions` API

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -3,7 +3,6 @@
 | @boterop/react-native-background-timer | MIT | https://github.com/boterop/react-native-background-timer |
 | @legendapp/list | MIT | https://github.com/LegendApp/legend-list |
 | @lodev09/react-native-true-sheet | MIT | https://github.com/lodev09/react-native-true-sheet |
-| @lukemorales/query-key-factory | MIT | https://github.com/lukemorales/query-key-factory |
 | @missingcore/music-glyph-toys | AGPL-3.0-only | https://github.com/MissingCore/music-glyph-toys |
 | @missingcore/react-native-actual-path | MIT | https://github.com/MissingCore/react-native-actual-path |
 | @missingcore/react-native-audio-analyzer | MIT | https://github.com/exzos28/react-native-audio-analyzer |

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -26,7 +26,6 @@
     "@boterop/react-native-background-timer": "2.6.0",
     "@legendapp/list": "2.0.19",
     "@lodev09/react-native-true-sheet": "3.4.2",
-    "@lukemorales/query-key-factory": "1.3.4",
     "@missingcore/music-glyph-toys": "github:MissingCore/music-glyph-toys#bbd70768ca76dff4a585905f02ea6f60c9cd2f38",
     "@missingcore/react-native-actual-path": "0.1.0",
     "@missingcore/react-native-audio-analyzer": "3.2.0-beta.4",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -28,9 +28,6 @@ importers:
       '@lodev09/react-native-true-sheet':
         specifier: 3.4.2
         version: 3.4.2(patch_hash=e629511ec9a360ce64c6f2cbcb19d75a7b9b47d7dd1d172d57695cb35845ebce)(dd0d0e54249de7d450dfd37eca1f4a37)
-      '@lukemorales/query-key-factory':
-        specifier: 1.3.4
-        version: 1.3.4(@tanstack/query-core@5.97.0)(@tanstack/react-query@5.97.0(react@19.2.0))
       '@missingcore/music-glyph-toys':
         specifier: github:MissingCore/music-glyph-toys#bbd70768ca76dff4a585905f02ea6f60c9cd2f38
         version: https://codeload.github.com/MissingCore/music-glyph-toys/tar.gz/bbd70768ca76dff4a585905f02ea6f60c9cd2f38(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1664,13 +1661,6 @@ packages:
         optional: true
       react-native-worklets:
         optional: true
-
-  '@lukemorales/query-key-factory@1.3.4':
-    resolution: {integrity: sha512-A3frRDdkmaNNQi6mxIshsDk4chRXWoXa05US8fBo4kci/H+lVmujS6QrwQLLGIkNIRFGjMqp2uKjC4XsLdydRw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@tanstack/query-core': '>= 4.0.0'
-      '@tanstack/react-query': '>= 4.0.0'
 
   '@missingcore/music-glyph-toys@https://codeload.github.com/MissingCore/music-glyph-toys/tar.gz/bbd70768ca76dff4a585905f02ea6f60c9cd2f38':
     resolution: {tarball: https://codeload.github.com/MissingCore/music-glyph-toys/tar.gz/bbd70768ca76dff4a585905f02ea6f60c9cd2f38}
@@ -7229,11 +7219,6 @@ snapshots:
       '@react-navigation/native': 7.2.2(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-worklets: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-
-  '@lukemorales/query-key-factory@1.3.4(@tanstack/query-core@5.97.0)(@tanstack/react-query@5.97.0(react@19.2.0))':
-    dependencies:
-      '@tanstack/query-core': 5.97.0
-      '@tanstack/react-query': 5.97.0(react@19.2.0)
 
   '@missingcore/music-glyph-toys@https://codeload.github.com/MissingCore/music-glyph-toys/tar.gz/bbd70768ca76dff4a585905f02ea6f60c9cd2f38(react-native@0.83.4(patch_hash=c87b321d226be5b76bb1dbbbba9de0e0d51d09f2b72a14368c1eb4a1c5f71bec)(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:

--- a/mobile/src/data/folder/queries.ts
+++ b/mobile/src/data/folder/queries.ts
@@ -1,14 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { useViewPreferenceStore } from "~/stores/ViewPreference/store";
-import { queries as q } from "../keyStore";
+import { getFolder } from "./api";
 
 //#region Queries
 export function useFolderContent(folderPath?: string) {
   const isAsc = useViewPreferenceStore((s) => s.folderIsAsc);
   const order = useViewPreferenceStore((s) => s.folderOrder);
+
+  const sortOptions = { isAsc, order };
+
   return useQuery({
-    ...q.folders.detail({ isAsc, order }, folderPath),
+    queryKey: ["folders", "detail", folderPath, sortOptions],
+    queryFn: () => getFolder(folderPath, sortOptions),
     select: ({ directories, tracks }) => ({
       directories,
       tracks: tracks.map((track) => ({

--- a/mobile/src/data/keyStore.ts
+++ b/mobile/src/data/keyStore.ts
@@ -10,11 +10,9 @@ import {
   getSortedArtistTracks,
 } from "./artist/api";
 import { getFavoriteLists } from "./favorite/api";
-import { getFolder } from "./folder/api";
 import { getGenre, getGenresSummary, getSortedGenreTracks } from "./genre/api";
 import { getLyric, getLyricsSummary } from "./lyric/api";
 import { getPlaylist, getPlaylistsSummary } from "./playlist/api";
-import { getRecentMedia } from "./recent/api";
 import {
   getSortedTracks,
   getTrack,
@@ -82,17 +80,6 @@ export const queries = {
       return queryOptions({
         queryKey: [...this._def, "lists"],
         queryFn: getFavoriteLists,
-      });
-    },
-  },
-
-  /** Query keys used in `useQuery` for folders. */
-  folders: {
-    _def: ["folders"] as const,
-    detail(sortOptions: TracksSortOptions<"folder">, folderPath?: string) {
-      return queryOptions({
-        queryKey: [...this._def, "detail", folderPath, sortOptions],
-        queryFn: () => getFolder(folderPath, sortOptions),
       });
     },
   },
@@ -203,17 +190,6 @@ export const queries = {
           }),
         },
       };
-    },
-  },
-
-  /** Query keys used in `useQuery` for recently played media. */
-  recent: {
-    _def: ["recent"] as const,
-    get all() {
-      return queryOptions({
-        queryKey: [...this._def, "all"],
-        queryFn: getRecentMedia,
-      });
     },
   },
 };

--- a/mobile/src/data/keyStore.ts
+++ b/mobile/src/data/keyStore.ts
@@ -1,4 +1,4 @@
-import { createQueryKeyStore } from "@lukemorales/query-key-factory";
+import { queryOptions } from "@tanstack/react-query";
 import { ne } from "drizzle-orm";
 
 import { playlists } from "~/db/schema";
@@ -27,133 +27,168 @@ import type { TracksSortOptions } from "./types";
 
 import { FavoritesPlaylistKey } from "~/modules/media/constants";
 
-/** All of the reusuable query keys. */
-export const queries = createQueryKeyStore({
+/** All of the reusable query keys. */
+export const queries = {
   /** Query keys used in `useQuery` for albums. */
   albums: {
-    all: {
-      queryKey: null,
+    _def: ["albums"] as const,
+    all: queryOptions({
+      queryKey: ["albums", "all"] as const,
       queryFn: () => getAlbumsSummary(),
-    },
-    detail: (albumId: string) => ({
-      queryKey: [albumId],
-      queryFn: () => getAlbum(albumId),
     }),
+    detail: (albumId: string) =>
+      queryOptions({
+        queryKey: ["albums", "detail", albumId] as const,
+        queryFn: () => getAlbum(albumId),
+      }),
   },
+
   /** Query keys used in `useQuery` for artists. */
   artists: {
-    all: {
-      queryKey: null,
+    _def: ["artists"] as const,
+    all: queryOptions({
+      queryKey: ["artists", "all"] as const,
       queryFn: getArtistsSummary,
-    },
+    }),
     detail: (artistName: string) => ({
-      queryKey: [artistName],
-      queryFn: () => getArtist(artistName, true),
-      contextQueries: {
-        // eslint-disable-next-line @tanstack/query/exhaustive-deps
-        tracks: (sortOptions?: TracksSortOptions<"artistTracks">) => ({
-          queryKey: [sortOptions],
-          queryFn: () => getSortedArtistTracks(artistName, false, sortOptions),
-        }),
+      ...queryOptions({
+        queryKey: ["artists", "detail", artistName] as const,
+        queryFn: () => getArtist(artistName, true),
+      }),
+      _ctx: {
+        tracks: (sortOptions?: TracksSortOptions<"artistTracks">) =>
+          queryOptions({
+            queryKey: [
+              "artists",
+              "detail",
+              artistName,
+              "tracks",
+              sortOptions,
+            ] as const,
+            queryFn: () =>
+              getSortedArtistTracks(artistName, false, sortOptions),
+          }),
       },
     }),
   },
+
   /** Query keys used in `useQuery` for favorite media. */
   favorites: {
-    lists: {
-      queryKey: null,
+    _def: ["favorites"] as const,
+    lists: queryOptions({
+      queryKey: ["favorites", "lists"] as const,
       queryFn: getFavoriteLists,
-    },
-  },
-  /** Query keys used in `useQuery` for folders. */
-  folders: {
-    detail: (
-      sortOptions: TracksSortOptions<"folder">,
-      folderPath?: string,
-    ) => ({
-      queryKey: [sortOptions, folderPath],
-      queryFn: () => getFolder(folderPath, sortOptions),
     }),
   },
+
+  /** Query keys used in `useQuery` for folders. */
+  folders: {
+    _def: ["folders"] as const,
+    detail: (sortOptions: TracksSortOptions<"folder">, folderPath?: string) =>
+      queryOptions({
+        queryKey: ["folders", "detail", folderPath, sortOptions] as const,
+        queryFn: () => getFolder(folderPath, sortOptions),
+      }),
+  },
+
   /** Query keys used in `useQuery` for genres. */
   genres: {
-    all: {
-      queryKey: null,
+    _def: ["genres"] as const,
+    all: queryOptions({
+      queryKey: ["genres", "all"] as const,
       queryFn: getGenresSummary,
-    },
+    }),
     detail: (genreName: string) => ({
-      queryKey: [genreName],
-      queryFn: () => getGenre(genreName, true),
-      contextQueries: {
-        // eslint-disable-next-line @tanstack/query/exhaustive-deps
-        tracks: (sortOptions?: TracksSortOptions<"genreTracks">) => ({
-          queryKey: [sortOptions],
-          queryFn: () => getSortedGenreTracks(genreName, false, sortOptions),
-        }),
+      ...queryOptions({
+        queryKey: ["genres", "detail", genreName] as const,
+        queryFn: () => getGenre(genreName, true),
+      }),
+      _ctx: {
+        tracks: (sortOptions?: TracksSortOptions<"genreTracks">) =>
+          queryOptions({
+            queryKey: [
+              "genres",
+              "detail",
+              genreName,
+              "tracks",
+              sortOptions,
+            ] as const,
+            queryFn: () => getSortedGenreTracks(genreName, false, sortOptions),
+          }),
       },
     }),
   },
+
   /** Query keys used in `useQuery` for lyrics. */
   lyrics: {
-    all: {
-      queryKey: null,
+    _def: ["lyrics"] as const,
+    all: queryOptions({
+      queryKey: ["lyrics", "all"] as const,
       queryFn: getLyricsSummary,
-    },
-    detail: (lyricId: string) => ({
-      queryKey: [lyricId],
-      queryFn: () => getLyric(lyricId),
     }),
-    forTrack: (trackId: string) => ({
-      queryKey: [trackId],
-      queryFn: () => getTrackLyrics(trackId),
-    }),
+    detail: (lyricId: string) =>
+      queryOptions({
+        queryKey: ["lyrics", "detail", lyricId] as const,
+        queryFn: () => getLyric(lyricId),
+      }),
+    forTrack: (trackId: string) =>
+      queryOptions({
+        queryKey: ["lyrics", "forTrack", trackId] as const,
+        queryFn: () => getTrackLyrics(trackId),
+      }),
   },
+
   /** Query keys used in `useQuery` for playlists. */
   playlists: {
-    all: {
-      queryKey: null,
+    _def: ["playlists"] as const,
+    all: queryOptions({
+      queryKey: ["playlists", "all"] as const,
       queryFn: () =>
         getPlaylistsSummary(false, [ne(playlists.name, FavoritesPlaylistKey)]),
-    },
-    detail: (playlistName: string) => ({
-      queryKey: [playlistName],
-      queryFn: () => getPlaylist(playlistName),
     }),
+    detail: (playlistName: string) =>
+      queryOptions({
+        queryKey: ["playlists", "detail", playlistName] as const,
+        queryFn: () => getPlaylist(playlistName),
+      }),
   },
+
   /** Query keys used in `useQuery` for tracks. */
   tracks: {
-    sorted: (sortOptions: TracksSortOptions<"track">) => ({
-      queryKey: [sortOptions],
-      queryFn: () => getSortedTracks(false, sortOptions),
-    }),
+    _def: ["tracks"] as const,
+    sorted: (sortOptions: TracksSortOptions<"track">) =>
+      queryOptions({
+        queryKey: ["tracks", "sorted", sortOptions] as const,
+        queryFn: () => getSortedTracks(false, sortOptions),
+      }),
     detail: (trackId: string) => ({
-      queryKey: [trackId],
-      queryFn: () => getTrack(trackId),
-      contextQueries: {
-        // eslint-disable-next-line @tanstack/query/exhaustive-deps
-        isFavorite: {
-          queryKey: null,
+      ...queryOptions({
+        queryKey: ["tracks", "detail", trackId] as const,
+        queryFn: () => getTrack(trackId),
+      }),
+      _ctx: {
+        isFavorite: queryOptions({
+          queryKey: ["tracks", "detail", trackId, "isFavorite"] as const,
           queryFn: () => getTrackFavoriteStatus(trackId),
-        },
-        // eslint-disable-next-line @tanstack/query/exhaustive-deps
-        genres: {
-          queryKey: null,
+        }),
+        genres: queryOptions({
+          queryKey: ["tracks", "detail", trackId, "genres"] as const,
           queryFn: () => getTrackGenres(trackId),
-        },
-        // eslint-disable-next-line @tanstack/query/exhaustive-deps
-        playlists: {
-          queryKey: null,
+        }),
+        playlists: queryOptions({
+          queryKey: ["tracks", "detail", trackId, "playlists"] as const,
           queryFn: () => getTrackPlaylists(trackId),
-        },
+        }),
       },
     }),
   },
 
   /** Query keys used in `useQuery` for recently played media. */
   recent: {
-    all: {
-      queryKey: null,
+    _def: ["recent"] as const,
+    all: queryOptions({
+      queryKey: ["recent", "all"] as const,
       queryFn: getRecentMedia,
-    },
+    }),
   },
-});
+};

--- a/mobile/src/data/keyStore.ts
+++ b/mobile/src/data/keyStore.ts
@@ -31,28 +31,33 @@ import { FavoritesPlaylistKey } from "~/modules/media/constants";
 export const queries = {
   /** Query keys used in `useQuery` for albums. */
   albums: {
-    _def: ["albums"],
-    all: queryOptions({
-      queryKey: ["albums", "all"],
-      queryFn: () => getAlbumsSummary(),
-    }),
-    detail: (albumId: string) =>
-      queryOptions({
-        queryKey: ["albums", "detail", albumId],
+    _def: ["albums"] as const,
+    get all() {
+      return queryOptions({
+        queryKey: [...this._def, "all"],
+        queryFn: () => getAlbumsSummary(),
+      });
+    },
+    detail(albumId: string) {
+      return queryOptions({
+        queryKey: [...this._def, "detail", albumId],
         queryFn: () => getAlbum(albumId),
-      }),
+      });
+    },
   },
 
   /** Query keys used in `useQuery` for artists. */
   artists: {
-    _def: ["artists"],
-    all: queryOptions({
-      queryKey: ["artists", "all"],
-      queryFn: getArtistsSummary,
-    }),
-    detail: (artistName: string) => {
+    _def: ["artists"] as const,
+    get all() {
+      return queryOptions({
+        queryKey: [...this._def, "all"],
+        queryFn: getArtistsSummary,
+      });
+    },
+    detail(artistName: string) {
       const detail = queryOptions({
-        queryKey: ["artists", "detail", artistName],
+        queryKey: [...this._def, "detail", artistName],
         queryFn: () => getArtist(artistName, true),
       });
       return {
@@ -72,33 +77,38 @@ export const queries = {
 
   /** Query keys used in `useQuery` for favorite media. */
   favorites: {
-    _def: ["favorites"],
-    lists: queryOptions({
-      queryKey: ["favorites", "lists"],
-      queryFn: getFavoriteLists,
-    }),
+    _def: ["favorites"] as const,
+    get lists() {
+      return queryOptions({
+        queryKey: [...this._def, "lists"],
+        queryFn: getFavoriteLists,
+      });
+    },
   },
 
   /** Query keys used in `useQuery` for folders. */
   folders: {
-    _def: ["folders"],
-    detail: (sortOptions: TracksSortOptions<"folder">, folderPath?: string) =>
-      queryOptions({
-        queryKey: ["folders", "detail", folderPath, sortOptions],
+    _def: ["folders"] as const,
+    detail(sortOptions: TracksSortOptions<"folder">, folderPath?: string) {
+      return queryOptions({
+        queryKey: [...this._def, "detail", folderPath, sortOptions],
         queryFn: () => getFolder(folderPath, sortOptions),
-      }),
+      });
+    },
   },
 
   /** Query keys used in `useQuery` for genres. */
   genres: {
-    _def: ["genres"],
-    all: queryOptions({
-      queryKey: ["genres", "all"],
-      queryFn: getGenresSummary,
-    }),
-    detail: (genreName: string) => {
+    _def: ["genres"] as const,
+    get all() {
+      return queryOptions({
+        queryKey: [...this._def, "all"],
+        queryFn: getGenresSummary,
+      });
+    },
+    detail(genreName: string) {
       const detail = queryOptions({
-        queryKey: ["genres", "detail", genreName],
+        queryKey: [...this._def, "detail", genreName],
         queryFn: () => getGenre(genreName, true),
       });
       return {
@@ -118,49 +128,59 @@ export const queries = {
 
   /** Query keys used in `useQuery` for lyrics. */
   lyrics: {
-    _def: ["lyrics"],
-    all: queryOptions({
-      queryKey: ["lyrics", "all"],
-      queryFn: getLyricsSummary,
-    }),
-    detail: (lyricId: string) =>
-      queryOptions({
-        queryKey: ["lyrics", "detail", lyricId],
+    _def: ["lyrics"] as const,
+    get all() {
+      return queryOptions({
+        queryKey: [...this._def, "all"],
+        queryFn: getLyricsSummary,
+      });
+    },
+    detail(lyricId: string) {
+      return queryOptions({
+        queryKey: [...this._def, "detail", lyricId],
         queryFn: () => getLyric(lyricId),
-      }),
-    forTrack: (trackId: string) =>
-      queryOptions({
-        queryKey: ["lyrics", "forTrack", trackId],
+      });
+    },
+    forTrack(trackId: string) {
+      return queryOptions({
+        queryKey: [...this._def, "forTrack", trackId],
         queryFn: () => getTrackLyrics(trackId),
-      }),
+      });
+    },
   },
 
   /** Query keys used in `useQuery` for playlists. */
   playlists: {
-    _def: ["playlists"],
-    all: queryOptions({
-      queryKey: ["playlists", "all"],
-      queryFn: () =>
-        getPlaylistsSummary(false, [ne(playlists.name, FavoritesPlaylistKey)]),
-    }),
-    detail: (playlistName: string) =>
-      queryOptions({
-        queryKey: ["playlists", "detail", playlistName],
+    _def: ["playlists"] as const,
+    get all() {
+      return queryOptions({
+        queryKey: [...this._def, "all"],
+        queryFn: () =>
+          getPlaylistsSummary(false, [
+            ne(playlists.name, FavoritesPlaylistKey),
+          ]),
+      });
+    },
+    detail(playlistName: string) {
+      return queryOptions({
+        queryKey: [...this._def, "detail", playlistName],
         queryFn: () => getPlaylist(playlistName),
-      }),
+      });
+    },
   },
 
   /** Query keys used in `useQuery` for tracks. */
   tracks: {
-    _def: ["tracks"],
-    sorted: (sortOptions: TracksSortOptions<"track">) =>
-      queryOptions({
-        queryKey: ["tracks", "sorted", sortOptions],
+    _def: ["tracks"] as const,
+    sorted(sortOptions: TracksSortOptions<"track">) {
+      return queryOptions({
+        queryKey: [...this._def, "sorted", sortOptions],
         queryFn: () => getSortedTracks(false, sortOptions),
-      }),
-    detail: (trackId: string) => {
+      });
+    },
+    detail(trackId: string) {
       const detail = queryOptions({
-        queryKey: ["tracks", "detail", trackId],
+        queryKey: [...this._def, "detail", trackId],
         queryFn: () => getTrack(trackId),
       });
       return {
@@ -188,10 +208,12 @@ export const queries = {
 
   /** Query keys used in `useQuery` for recently played media. */
   recent: {
-    _def: ["recent"],
-    all: queryOptions({
-      queryKey: ["recent", "all"],
-      queryFn: getRecentMedia,
-    }),
+    _def: ["recent"] as const,
+    get all() {
+      return queryOptions({
+        queryKey: [...this._def, "all"],
+        queryFn: getRecentMedia,
+      });
+    },
   },
 };

--- a/mobile/src/data/keyStore.ts
+++ b/mobile/src/data/keyStore.ts
@@ -31,163 +31,166 @@ import { FavoritesPlaylistKey } from "~/modules/media/constants";
 export const queries = {
   /** Query keys used in `useQuery` for albums. */
   albums: {
-    _def: ["albums"] as const,
+    _def: ["albums"],
     all: queryOptions({
-      queryKey: ["albums", "all"] as const,
+      queryKey: ["albums", "all"],
       queryFn: () => getAlbumsSummary(),
     }),
     detail: (albumId: string) =>
       queryOptions({
-        queryKey: ["albums", "detail", albumId] as const,
+        queryKey: ["albums", "detail", albumId],
         queryFn: () => getAlbum(albumId),
       }),
   },
 
   /** Query keys used in `useQuery` for artists. */
   artists: {
-    _def: ["artists"] as const,
+    _def: ["artists"],
     all: queryOptions({
-      queryKey: ["artists", "all"] as const,
+      queryKey: ["artists", "all"],
       queryFn: getArtistsSummary,
     }),
-    detail: (artistName: string) => ({
-      ...queryOptions({
-        queryKey: ["artists", "detail", artistName] as const,
+    detail: (artistName: string) => {
+      const detail = queryOptions({
+        queryKey: ["artists", "detail", artistName],
         queryFn: () => getArtist(artistName, true),
-      }),
-      _ctx: {
-        tracks: (sortOptions?: TracksSortOptions<"artistTracks">) =>
-          queryOptions({
-            queryKey: [
-              "artists",
-              "detail",
-              artistName,
-              "tracks",
-              sortOptions,
-            ] as const,
-            queryFn: () =>
-              getSortedArtistTracks(artistName, false, sortOptions),
-          }),
-      },
-    }),
+      });
+      return {
+        ...detail,
+        _ctx: {
+          tracks: (sortOptions?: TracksSortOptions<"artistTracks">) =>
+            // eslint-disable-next-line @tanstack/query/exhaustive-deps
+            queryOptions({
+              queryKey: [...detail.queryKey, "tracks", sortOptions],
+              queryFn: () =>
+                getSortedArtistTracks(artistName, false, sortOptions),
+            }),
+        },
+      };
+    },
   },
 
   /** Query keys used in `useQuery` for favorite media. */
   favorites: {
-    _def: ["favorites"] as const,
+    _def: ["favorites"],
     lists: queryOptions({
-      queryKey: ["favorites", "lists"] as const,
+      queryKey: ["favorites", "lists"],
       queryFn: getFavoriteLists,
     }),
   },
 
   /** Query keys used in `useQuery` for folders. */
   folders: {
-    _def: ["folders"] as const,
+    _def: ["folders"],
     detail: (sortOptions: TracksSortOptions<"folder">, folderPath?: string) =>
       queryOptions({
-        queryKey: ["folders", "detail", folderPath, sortOptions] as const,
+        queryKey: ["folders", "detail", folderPath, sortOptions],
         queryFn: () => getFolder(folderPath, sortOptions),
       }),
   },
 
   /** Query keys used in `useQuery` for genres. */
   genres: {
-    _def: ["genres"] as const,
+    _def: ["genres"],
     all: queryOptions({
-      queryKey: ["genres", "all"] as const,
+      queryKey: ["genres", "all"],
       queryFn: getGenresSummary,
     }),
-    detail: (genreName: string) => ({
-      ...queryOptions({
-        queryKey: ["genres", "detail", genreName] as const,
+    detail: (genreName: string) => {
+      const detail = queryOptions({
+        queryKey: ["genres", "detail", genreName],
         queryFn: () => getGenre(genreName, true),
-      }),
-      _ctx: {
-        tracks: (sortOptions?: TracksSortOptions<"genreTracks">) =>
-          queryOptions({
-            queryKey: [
-              "genres",
-              "detail",
-              genreName,
-              "tracks",
-              sortOptions,
-            ] as const,
-            queryFn: () => getSortedGenreTracks(genreName, false, sortOptions),
-          }),
-      },
-    }),
+      });
+      return {
+        ...detail,
+        _ctx: {
+          tracks: (sortOptions?: TracksSortOptions<"genreTracks">) =>
+            // eslint-disable-next-line @tanstack/query/exhaustive-deps
+            queryOptions({
+              queryKey: [...detail.queryKey, "tracks", sortOptions],
+              queryFn: () =>
+                getSortedGenreTracks(genreName, false, sortOptions),
+            }),
+        },
+      };
+    },
   },
 
   /** Query keys used in `useQuery` for lyrics. */
   lyrics: {
-    _def: ["lyrics"] as const,
+    _def: ["lyrics"],
     all: queryOptions({
-      queryKey: ["lyrics", "all"] as const,
+      queryKey: ["lyrics", "all"],
       queryFn: getLyricsSummary,
     }),
     detail: (lyricId: string) =>
       queryOptions({
-        queryKey: ["lyrics", "detail", lyricId] as const,
+        queryKey: ["lyrics", "detail", lyricId],
         queryFn: () => getLyric(lyricId),
       }),
     forTrack: (trackId: string) =>
       queryOptions({
-        queryKey: ["lyrics", "forTrack", trackId] as const,
+        queryKey: ["lyrics", "forTrack", trackId],
         queryFn: () => getTrackLyrics(trackId),
       }),
   },
 
   /** Query keys used in `useQuery` for playlists. */
   playlists: {
-    _def: ["playlists"] as const,
+    _def: ["playlists"],
     all: queryOptions({
-      queryKey: ["playlists", "all"] as const,
+      queryKey: ["playlists", "all"],
       queryFn: () =>
         getPlaylistsSummary(false, [ne(playlists.name, FavoritesPlaylistKey)]),
     }),
     detail: (playlistName: string) =>
       queryOptions({
-        queryKey: ["playlists", "detail", playlistName] as const,
+        queryKey: ["playlists", "detail", playlistName],
         queryFn: () => getPlaylist(playlistName),
       }),
   },
 
   /** Query keys used in `useQuery` for tracks. */
   tracks: {
-    _def: ["tracks"] as const,
+    _def: ["tracks"],
     sorted: (sortOptions: TracksSortOptions<"track">) =>
       queryOptions({
-        queryKey: ["tracks", "sorted", sortOptions] as const,
+        queryKey: ["tracks", "sorted", sortOptions],
         queryFn: () => getSortedTracks(false, sortOptions),
       }),
-    detail: (trackId: string) => ({
-      ...queryOptions({
-        queryKey: ["tracks", "detail", trackId] as const,
+    detail: (trackId: string) => {
+      const detail = queryOptions({
+        queryKey: ["tracks", "detail", trackId],
         queryFn: () => getTrack(trackId),
-      }),
-      _ctx: {
-        isFavorite: queryOptions({
-          queryKey: ["tracks", "detail", trackId, "isFavorite"] as const,
-          queryFn: () => getTrackFavoriteStatus(trackId),
-        }),
-        genres: queryOptions({
-          queryKey: ["tracks", "detail", trackId, "genres"] as const,
-          queryFn: () => getTrackGenres(trackId),
-        }),
-        playlists: queryOptions({
-          queryKey: ["tracks", "detail", trackId, "playlists"] as const,
-          queryFn: () => getTrackPlaylists(trackId),
-        }),
-      },
-    }),
+      });
+      return {
+        ...detail,
+        _ctx: {
+          // eslint-disable-next-line @tanstack/query/exhaustive-deps
+          isFavorite: queryOptions({
+            queryKey: [...detail.queryKey, "isFavorite"],
+            queryFn: () => getTrackFavoriteStatus(trackId),
+          }),
+          // eslint-disable-next-line @tanstack/query/exhaustive-deps
+          genres: queryOptions({
+            queryKey: [...detail.queryKey, "genres"],
+            queryFn: () => getTrackGenres(trackId),
+          }),
+          // eslint-disable-next-line @tanstack/query/exhaustive-deps
+          playlists: queryOptions({
+            queryKey: [...detail.queryKey, "playlists"],
+            queryFn: () => getTrackPlaylists(trackId),
+          }),
+        },
+      };
+    },
   },
 
   /** Query keys used in `useQuery` for recently played media. */
   recent: {
-    _def: ["recent"] as const,
+    _def: ["recent"],
     all: queryOptions({
-      queryKey: ["recent", "all"] as const,
+      queryKey: ["recent", "all"],
       queryFn: getRecentMedia,
     }),
   },

--- a/mobile/src/data/recent/queries.ts
+++ b/mobile/src/data/recent/queries.ts
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { queries as q } from "../keyStore";
+import { getRecentMedia } from "./api";
 
 //#region Queries
 export function useRecentlyPlayedMedia() {
-  return useQuery({ ...q.recent.all, gcTime: 0, staleTime: 0 });
+  return useQuery({
+    queryKey: ["recent", "all"],
+    queryFn: getRecentMedia,
+    gcTime: 0,
+    staleTime: 0,
+  });
 }
 //#endregion

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -20,13 +20,6 @@
     "license": "MIT",
     "licenseText": "MIT License\n\nCopyright (c) 2025 lodev09\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
   },
-  "@lukemorales/query-key-factory": {
-    "name": "@lukemorales/query-key-factory",
-    "version": "1.3.4",
-    "source": "https://github.com/lukemorales/query-key-factory",
-    "license": "MIT",
-    "licenseText": "MIT License\n\nCopyright (c) 2022 Luke Morales\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
-  },
   "@missingcore/music-glyph-toys": {
     "name": "@missingcore/music-glyph-toys",
     "version": "0.3.0",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR replaces `@lukemorales/query-key-factory` with the `QueryOptions` API to lessen our use of external dependencies. This rewrite preserves most the original behavior, so we don't need to update any code that uses the exported `queries` object (we have co-located the "folders" & "recent" query key in their respective `queries.ts` file as we don't reference them in the `queries` object for invalidation).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
