### PR TITLE
refactor: Refactored `~/modules` code import & FormState

### DIFF
--- a/mobile/src/modules/backup/JSON.ts
+++ b/mobile/src/modules/backup/JSON.ts
@@ -21,8 +21,8 @@ import { mergeTracks } from "~/data/track/utils";
 
 import { pickDirectory } from "~/lib/file-system";
 import { clearAllQueries } from "~/lib/react-query";
-import { ZSchema } from "../form/utils";
-import { FavoritesPlaylistKey } from "../media/constants";
+import { ZSchema } from "~/modules/form/utils";
+import { FavoritesPlaylistKey } from "~/modules/media/constants";
 
 //#region Schemas
 const NullableNonEmptyStringSchema = z.nullish(ZSchema.NonEmptyString);

--- a/mobile/src/modules/equalizer/screens/View.tsx
+++ b/mobile/src/modules/equalizer/screens/View.tsx
@@ -3,8 +3,8 @@ import { useMemo } from "react";
 import { View } from "react-native";
 import { useEqualizerSettings } from "react-native-audio-browser";
 
-import { useEqualizerStore } from "~/modules/equalizer/core/store";
-import { toggleEQ, setEQPreset } from "~/modules/equalizer/core/actions";
+import { useEqualizerStore } from "../core/store";
+import { toggleEQ, setEQPreset } from "../core/actions";
 
 import { ListLayout } from "~/navigation/layouts/ListLayout";
 import { ScreenOptions } from "~/navigation/components/ScreenOptions";
@@ -15,8 +15,8 @@ import { Pressable } from "~/components/Base/Pressable";
 import { Button } from "~/components/Form/Button";
 import { TStyledText } from "~/components/Typography/StyledText";
 import { Switch } from "~/components/UI/Switch";
-import { EQGraph } from "~/modules/equalizer/components/EQGraph";
-import { FrequencySlider } from "~/modules/equalizer/components/FrequencySlider";
+import { EQGraph } from "../components/EQGraph";
+import { FrequencySlider } from "../components/FrequencySlider";
 
 export default function EqualizerSettings() {
   const eqFreqs = useEqualizerStore((s) => s.defaultFrequencies);

--- a/mobile/src/modules/form/FormState/index.tsx
+++ b/mobile/src/modules/form/FormState/index.tsx
@@ -160,7 +160,7 @@ export function FormStateProvider<TSchema extends ZodMiniObject>(
 }
 //#endregion
 
-//#region
+//#region FAB Workflow
 export type FABWorkflowConfig<TData extends Record<string, any>> = {
   label: ParseKeys;
   action: (

--- a/mobile/src/modules/form/FormState/index.tsx
+++ b/mobile/src/modules/form/FormState/index.tsx
@@ -166,10 +166,8 @@ export type FABWorkflowConfig<TData extends Record<string, any>> = {
   action: (
     context: Pick<FormState<TData>, "data" | "setFields">,
   ) => void | Promise<void>;
-  /** If the action that will be done is dangerous/destructive. */
+  /** If the action that will be done is dangerous/destructive. Will require confirmation to fire `action`. */
   danger?: boolean;
-  /** If the action requires user confirmation before proceeding. */
-  requireConfirmation?: boolean;
 };
 
 /** Additional action that can be displayed in the form. */
@@ -182,7 +180,7 @@ export function FABWorkflow(
     useFormStateContext();
 
   const triggerAction = async () => {
-    if (props.requireConfirmation) setLastChance(false);
+    if (props.danger) setLastChance(false);
     setIsSubmitting(true);
     await props.action({ data, setFields });
     setIsSubmitting(false);
@@ -193,9 +191,7 @@ export function FABWorkflow(
       <View {...props.floatingContentProps}>
         <ExtendedTButton
           textKey={props.label}
-          onPress={() =>
-            props.requireConfirmation ? setLastChance(true) : triggerAction()
-          }
+          onPress={() => (props.danger ? setLastChance(true) : triggerAction())}
           disabled={lastChance || isSubmitting}
           className={
             props.danger
@@ -205,7 +201,7 @@ export function FABWorkflow(
           textClassName={props.danger ? "text-onError" : "text-onSecondary"}
         />
       </View>
-      {props.requireConfirmation ? (
+      {props.danger ? (
         <ModalTemplate
           visible={lastChance}
           titleKey={props.label}

--- a/mobile/src/modules/form/FormState/index.tsx
+++ b/mobile/src/modules/form/FormState/index.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
+import type { ParseKeys } from "i18next";
 import type { Dispatch, SetStateAction } from "react";
 import {
   createContext,
@@ -10,16 +11,18 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { BackHandler } from "react-native";
+import { BackHandler, View } from "react-native";
 import type { ZodMiniObject } from "zod/mini";
 import { z } from "zod/mini";
 
 import { Check } from "~/resources/icons/Check";
 
 import { ScreenOptions } from "~/navigation/components/ScreenOptions";
+import type { useFloatingContent } from "~/navigation/hooks/useFloatingContent";
 
 import { wait } from "~/utils/promise";
 import { isNumber, isString } from "~/utils/validation";
+import { ExtendedTButton } from "~/components/Form/Button";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { ModalTemplate } from "~/components/Modal";
 
@@ -153,6 +156,70 @@ export function FormStateProvider<TSchema extends ZodMiniObject>(
       {props.children}
       <UnsavedChangesPrompt />
     </FormStateContext>
+  );
+}
+//#endregion
+
+//#region
+export type FABWorkflowConfig<TData extends Record<string, any>> = {
+  label: ParseKeys;
+  action: (
+    context: Pick<FormState<TData>, "data" | "setFields">,
+  ) => void | Promise<void>;
+  /** If the action that will be done is dangerous/destructive. */
+  danger?: boolean;
+  /** If the action requires user confirmation before proceeding. */
+  requireConfirmation?: boolean;
+};
+
+/** Additional action that can be displayed in the form. */
+export function FABWorkflow(
+  props: FABWorkflowConfig<any> &
+    Omit<ReturnType<typeof useFloatingContent>, "offset">,
+) {
+  const [lastChance, setLastChance] = useState(false);
+  const { data, setFields, isSubmitting, setIsSubmitting } =
+    useFormStateContext();
+
+  const triggerAction = async () => {
+    if (props.requireConfirmation) setLastChance(false);
+    setIsSubmitting(true);
+    await props.action({ data, setFields });
+    setIsSubmitting(false);
+  };
+
+  return (
+    <>
+      <View {...props.floatingContentProps}>
+        <ExtendedTButton
+          textKey={props.label}
+          onPress={() =>
+            props.requireConfirmation ? setLastChance(true) : triggerAction()
+          }
+          disabled={lastChance || isSubmitting}
+          className={
+            props.danger
+              ? "bg-error active:bg-errorDim"
+              : "bg-secondary active:bg-secondaryDim"
+          }
+          textClassName={props.danger ? "text-onError" : "text-onSecondary"}
+        />
+      </View>
+      {props.requireConfirmation ? (
+        <ModalTemplate
+          visible={lastChance}
+          titleKey={props.label}
+          topAction={{
+            textKey: "form.confirm",
+            onPress: triggerAction,
+          }}
+          bottomAction={{
+            textKey: "form.cancel",
+            onPress: () => setLastChance(false),
+          }}
+        />
+      ) : null}
+    </>
   );
 }
 //#endregion

--- a/mobile/src/modules/form/FormState/index.tsx
+++ b/mobile/src/modules/form/FormState/index.tsx
@@ -164,7 +164,7 @@ export function FormStateProvider<TSchema extends ZodMiniObject>(
 export type FABWorkflowConfig<TData extends Record<string, any>> = {
   label: ParseKeys;
   action: (
-    context: Pick<FormState<TData>, "data" | "setFields">,
+    context: Pick<FormState<TData>, "setFields">,
   ) => void | Promise<void>;
   /** If the action that will be done is dangerous/destructive. Will require confirmation to fire `action`. */
   danger?: boolean;
@@ -176,13 +176,12 @@ export function FABWorkflow(
     Omit<ReturnType<typeof useFloatingContent>, "offset">,
 ) {
   const [lastChance, setLastChance] = useState(false);
-  const { data, setFields, isSubmitting, setIsSubmitting } =
-    useFormStateContext();
+  const { setFields, isSubmitting, setIsSubmitting } = useFormStateContext();
 
   const triggerAction = async () => {
     if (props.danger) setLastChance(false);
     setIsSubmitting(true);
-    await props.action({ data, setFields });
+    await props.action({ setFields });
     setIsSubmitting(false);
   };
 

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -14,6 +14,7 @@ import { FlatList, useFlatListRef } from "~/components/Base/List";
 import { Button } from "~/components/Form/Button";
 import { TopDownGradient } from "~/components/Gradient";
 import { TEm } from "~/components/Typography/StyledText";
+import { TrackAction } from "~/modules/media/components/Track";
 import type { ColorRole } from "~/modules/theme/constants";
 import { SearchBar } from "./SearchBar";
 import { SearchResult } from "./SearchResult";
@@ -23,7 +24,6 @@ import type {
   SearchCategories,
   SearchResults,
 } from "../types";
-import { TrackAction } from "../../media/components/Track";
 
 type SearchTab = SearchCategories[number] | "all";
 

--- a/mobile/src/modules/search/screens/View.tsx
+++ b/mobile/src/modules/search/screens/View.tsx
@@ -8,8 +8,8 @@ import { PlaybackControls } from "~/stores/Playback/actions";
 
 import { AccentText } from "~/components/Typography/AccentText";
 import { ReservedPlaylists } from "~/modules/media/constants";
-import { SearchEngine } from "~/modules/search/components/SearchEngine";
-import type { SearchCallbacks } from "~/modules/search/types";
+import { SearchEngine } from "../components/SearchEngine";
+import type { SearchCallbacks } from "../types";
 
 /** List of media we want to appear in the search. */
 const searchScope = ["album", "artist", "folder", "playlist", "track"] as const;

--- a/mobile/src/modules/theme/components/ModifyViewBase.tsx
+++ b/mobile/src/modules/theme/components/ModifyViewBase.tsx
@@ -1,31 +1,24 @@
-import { toast } from "@missingcore/toast";
-import { useNavigation } from "@react-navigation/native";
-import { Fragment, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { View } from "react-native";
-
-import { usePreferenceStore } from "~/stores/Preference/store";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";
 
-import { wait } from "~/utils/promise";
 import { Pressable } from "~/components/Base/Pressable";
 import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
-import { ExtendedTButton } from "~/components/Form/Button";
-import { ModalTemplate } from "~/components/Modal";
 import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
 import { Switch } from "~/components/UI/Switch";
+import type { FABWorkflowConfig } from "~/modules/form/FormState";
 import {
+  FABWorkflow,
   FormStateProvider,
   useFormStateContext,
 } from "~/modules/form/FormState";
 import { FormInputImpl } from "~/modules/form/FormState/FormInput";
+import { ColorPickerInput } from "./ColorPickerInput";
 import type { ColorRole, HexColor } from "../constants";
 import { ColorRoleOptions, Themes } from "../constants";
-import { readThemeFile } from "../helpers/backup";
 import type { ThemeEntry } from "../helpers/zod";
 import { ThemeEntrySchema } from "../helpers/zod";
-import { deleteCustomTheme, revalidateCustomThemes } from "../queries";
-import { ColorPickerInput } from "./ColorPickerInput";
 
 function useFormState() {
   return useFormStateContext<ThemeEntry>();
@@ -33,15 +26,13 @@ function useFormState() {
 
 export function ModifyThemeBase(props: {
   onSubmit: (data: ThemeEntry) => void | Promise<void>;
-  mode?: "create" | "edit";
   initialData?: Partial<ThemeEntry>;
+  actionConfig?: FABWorkflowConfig<ThemeEntry>;
 }) {
   const { offset, floatingContentProps } = useFloatingContent();
-  const activeCustomThemeId = usePreferenceStore((s) => s.activeCustomThemeId);
 
   const initData = useMemo(
     () => ({
-      _id: props.initialData?._id ?? null,
       _importGen: null,
       name: props.initialData?.name ?? "",
       scheme: props.initialData?.scheme ?? "light",
@@ -55,14 +46,6 @@ export function ModifyThemeBase(props: {
     [props.initialData],
   );
 
-  const RenderedWorkflow = useMemo(() => {
-    if (props.mode === "edit") {
-      if (activeCustomThemeId === props.initialData?._id) return Fragment;
-      return DeleteWorkflow;
-    }
-    return ImportWorkflow;
-  }, [props.mode, activeCustomThemeId, props.initialData?._id]);
-
   return (
     <FormStateProvider
       schema={ThemeEntrySchema}
@@ -70,7 +53,12 @@ export function ModifyThemeBase(props: {
       onSubmit={props.onSubmit}
     >
       <ThemeForm bottomOffset={offset} />
-      <RenderedWorkflow floatingContentProps={floatingContentProps} />
+      {props.actionConfig ? (
+        <FABWorkflow
+          {...props.actionConfig}
+          floatingContentProps={floatingContentProps}
+        />
+      ) : null}
     </FormStateProvider>
   );
 }
@@ -115,91 +103,6 @@ function ThemeForm({ bottomOffset }: { bottomOffset: number }) {
         ))}
       </View>
     </KeyboardAwareScrollView>
-  );
-}
-//#endregion
-
-//#region Import Workflow
-function ImportWorkflow({
-  floatingContentProps,
-}: Omit<ReturnType<typeof useFloatingContent>, "offset">) {
-  const { setFields, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onImport = async () => {
-    setIsSubmitting(true);
-    try {
-      const { name, scheme, colors } = await readThemeFile();
-      toast.t("feat.backup.extra.importSuccess");
-      await wait(100);
-      setFields({ name, scheme, ...colors, _importGen: Date.now() });
-    } catch (err) {
-      toast.error((err as Error).message);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <View {...floatingContentProps}>
-      <ExtendedTButton
-        textKey="feat.backup.extra.import"
-        onPress={onImport}
-        disabled={isSubmitting}
-        className="bg-secondary active:bg-secondaryDim"
-        textClassName="text-onSecondary"
-      />
-    </View>
-  );
-}
-//#endregion
-
-//#region Delete Workflow
-function DeleteWorkflow({
-  floatingContentProps,
-}: Omit<ReturnType<typeof useFloatingContent>, "offset">) {
-  const navigation = useNavigation();
-  const [lastChance, setLastChance] = useState(false);
-  const { data, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onDeletePressed = async () => {
-    if (!data._id) return;
-    setLastChance(false);
-    setIsSubmitting(true);
-    await wait(1);
-    try {
-      await deleteCustomTheme(data._id);
-      revalidateCustomThemes();
-      navigation.goBack();
-    } catch {
-      setLastChance(true);
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <>
-      <View {...floatingContentProps}>
-        <ExtendedTButton
-          textKey="form.delete"
-          onPress={() => setLastChance(true)}
-          disabled={lastChance || isSubmitting}
-          className="bg-error active:bg-errorDim"
-          textClassName="text-onError"
-        />
-      </View>
-      <ModalTemplate
-        visible={lastChance}
-        titleKey="form.delete"
-        topAction={{
-          textKey: "form.confirm",
-          onPress: onDeletePressed,
-        }}
-        bottomAction={{
-          textKey: "form.cancel",
-          onPress: () => setLastChance(false),
-        }}
-      />
-    </>
   );
 }
 //#endregion

--- a/mobile/src/modules/theme/helpers/zod.ts
+++ b/mobile/src/modules/theme/helpers/zod.ts
@@ -28,7 +28,6 @@ const ColorRolesSchema = Object.fromEntries(
 //#region Form Schema
 export const ThemeEntrySchema = z.object({
   // Additional context:
-  _id: z.nullable(z.string()),
   _importGen: z.nullable(z.number()),
   // Actual form fields:
   name: ZSchema.NonEmptyString,

--- a/mobile/src/modules/theme/screens/CreateView.tsx
+++ b/mobile/src/modules/theme/screens/CreateView.tsx
@@ -1,14 +1,29 @@
 import { toast } from "@missingcore/toast";
 import { useNavigation } from "@react-navigation/native";
 
+import { wait } from "~/utils/promise";
 import { ModifyThemeBase } from "../components/ModifyViewBase";
+import { readThemeFile } from "../helpers/backup";
 import { createCustomTheme, revalidateCustomThemes } from "../queries";
 
 export default function CreateTheme() {
   const navigation = useNavigation();
   return (
     <ModifyThemeBase
-      onSubmit={async ({ _id, _importGen, ...entry }) => {
+      actionConfig={{
+        label: "feat.backup.extra.import",
+        action: async ({ setFields }) => {
+          try {
+            const { name, scheme, colors } = await readThemeFile();
+            await wait(100);
+            toast.t("feat.backup.extra.importSuccess");
+            setFields({ name, scheme, ...colors, _importGen: Date.now() });
+          } catch (err) {
+            toast.error((err as Error).message);
+          }
+        },
+      }}
+      onSubmit={async ({ _importGen, ...entry }) => {
         try {
           await createCustomTheme(entry);
           revalidateCustomThemes();

--- a/mobile/src/modules/theme/screens/ModifyView.tsx
+++ b/mobile/src/modules/theme/screens/ModifyView.tsx
@@ -51,7 +51,6 @@ export default function ModifyTheme({
                 } catch {}
               },
               danger: true,
-              requireConfirmation: true,
             }
       }
       onSubmit={async ({ _importGen, ...entry }) => {

--- a/mobile/src/modules/theme/screens/ModifyView.tsx
+++ b/mobile/src/modules/theme/screens/ModifyView.tsx
@@ -48,7 +48,9 @@ export default function ModifyTheme({
                   await deleteCustomTheme(themeId);
                   revalidateCustomThemes();
                   navigation.goBack();
-                } catch {}
+                } catch {
+                  toast.tError("err.flow.generic.title");
+                }
               },
               danger: true,
             }

--- a/mobile/src/modules/theme/screens/ModifyView.tsx
+++ b/mobile/src/modules/theme/screens/ModifyView.tsx
@@ -7,9 +7,11 @@ import { PreferenceSetters } from "~/stores/Preference/actions";
 
 import { PagePlaceholder } from "~/navigation/components/Placeholder";
 
+import { wait } from "~/utils/promise";
 import { ModifyThemeBase } from "../components/ModifyViewBase";
 import type { ThemeEntry } from "../helpers/zod";
 import {
+  deleteCustomTheme,
   revalidateCustomThemes,
   updateCustomTheme,
   useCustomTheme,
@@ -30,15 +32,29 @@ export default function ModifyTheme({
     return <PagePlaceholder isPending={isPending} />;
 
   const isActiveTheme = activeCustomThemeId === themeId;
-
-  const { id, ...rest } = data;
-  const initData = { _id: id, ...rest } as Partial<ThemeEntry>;
+  const { id: _, ...initData } = data;
 
   return (
     <ModifyThemeBase
-      mode="edit"
-      initialData={initData}
-      onSubmit={async ({ _id, _importGen, ...entry }) => {
+      initialData={initData as Partial<ThemeEntry>}
+      actionConfig={
+        isActiveTheme
+          ? undefined
+          : {
+              label: "form.delete",
+              action: async () => {
+                await wait(1);
+                try {
+                  await deleteCustomTheme(themeId);
+                  revalidateCustomThemes();
+                  navigation.goBack();
+                } catch {}
+              },
+              danger: true,
+              requireConfirmation: true,
+            }
+      }
+      onSubmit={async ({ _importGen, ...entry }) => {
         try {
           await updateCustomTheme(themeId, entry);
           revalidateCustomThemes();

--- a/mobile/src/navigation/routes.tsx
+++ b/mobile/src/navigation/routes.tsx
@@ -18,7 +18,6 @@ import { BackHandler } from "react-native";
 
 import Home from "./screens/HomeView";
 import RecentlyPlayed from "./screens/RecentlyPlayedView";
-import Search from "./screens/SearchView";
 import Album from "./screens/albums/CurrentView";
 import Albums from "./screens/albums/View";
 import Artist from "./screens/artists/CurrentView";
@@ -38,7 +37,6 @@ import ModifyPlaylist from "./screens/playlists/ModifyView";
 import Playlists from "./screens/playlists/View";
 import AppearanceSettings from "./screens/settings/AppearanceSettingsView";
 import AppUpdate from "./screens/settings/AppUpdateView";
-import EqualizerSettings from "./screens/settings/EqualizerSettingsView";
 import ExperimentalSettings from "./screens/settings/ExperimentalSettingsView";
 import HiddenTracks from "./screens/settings/HiddenTracksView";
 import Insights from "./screens/settings/InsightsView";
@@ -53,6 +51,8 @@ import ModifyTrack from "./screens/tracks/ModifyView";
 import Tracks from "./screens/tracks/View";
 import { TrackSheet } from "./screens/tracks/sheets/TrackSheet";
 import { ArtistsSheet } from "./sheets/ArtistsSheet";
+import EqualizerSettings from "~/modules/equalizer/screens/View";
+import Search from "~/modules/search/screens/View";
 import ThemeScreenGroup from "~/modules/theme/screens";
 
 import { preferenceStore, usePreferenceStore } from "~/stores/Preference/store";

--- a/mobile/src/navigation/screens/lyrics/CreateView.tsx
+++ b/mobile/src/navigation/screens/lyrics/CreateView.tsx
@@ -7,8 +7,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queries as q } from "~/data/keyStore";
 import { createLyric } from "~/data/lyric/api";
 
+import { wait } from "~/utils/promise";
 import { ModifyLyricBase } from "./components/ModifyViewBase";
 import { linkTrackToLyric } from "./helpers/linkTrackToLyric";
+import { readLyricFile } from "./helpers/readLyricFile";
 
 type Props = StaticScreenProps<{ linkTo?: string }>;
 
@@ -22,7 +24,20 @@ export default function CreateLyric({
 
   return (
     <ModifyLyricBase
-      onSubmit={async ({ id: _, ...entry }) => {
+      actionConfig={{
+        label: "feat.backup.extra.import",
+        action: async ({ setFields }) => {
+          try {
+            const { name, contents } = await readLyricFile();
+            await wait(100);
+            toast.t("feat.backup.extra.importSuccess");
+            setFields({ name, lyrics: contents });
+          } catch (err) {
+            toast.error((err as Error).message);
+          }
+        },
+      }}
+      onSubmit={async (entry) => {
         try {
           const newLyric = await createLyric(entry);
           if (!newLyric) throw new Error("Lyric not returned after insertion.");

--- a/mobile/src/navigation/screens/lyrics/ModifyView.tsx
+++ b/mobile/src/navigation/screens/lyrics/ModifyView.tsx
@@ -4,11 +4,12 @@ import { useNavigation } from "@react-navigation/native";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { queries as q } from "~/data/keyStore";
-import { updateLyric } from "~/data/lyric/api";
+import { deleteLyric, updateLyric } from "~/data/lyric/api";
 import { useLyric } from "~/data/lyric/queries";
 
 import { PagePlaceholder } from "~/navigation/components/Placeholder";
 
+import { wait } from "~/utils/promise";
 import { ModifyLyricBase } from "./components/ModifyViewBase";
 
 type Props = StaticScreenProps<{ id: string }>;
@@ -29,12 +30,24 @@ export default function ModifyLyric({
 
   return (
     <ModifyLyricBase
-      mode="edit"
       initialData={initData}
-      onSubmit={async ({ id: _, ...entry }) => {
+      actionConfig={{
+        label: "form.delete",
+        action: async () => {
+          await wait(1);
+          try {
+            await deleteLyric(lyricId);
+            queryClient.invalidateQueries({ queryKey: q.lyrics._def });
+            navigation.goBack();
+            navigation.goBack();
+          } catch {}
+        },
+        danger: true,
+        requireConfirmation: true,
+      }}
+      onSubmit={async (entry) => {
         try {
           await updateLyric(lyricId, entry);
-
           queryClient.resetQueries({ queryKey: q.lyrics._def });
           navigation.goBack();
         } catch {

--- a/mobile/src/navigation/screens/lyrics/ModifyView.tsx
+++ b/mobile/src/navigation/screens/lyrics/ModifyView.tsx
@@ -43,7 +43,6 @@ export default function ModifyLyric({
           } catch {}
         },
         danger: true,
-        requireConfirmation: true,
       }}
       onSubmit={async (entry) => {
         try {

--- a/mobile/src/navigation/screens/lyrics/ModifyView.tsx
+++ b/mobile/src/navigation/screens/lyrics/ModifyView.tsx
@@ -26,7 +26,7 @@ export default function ModifyLyric({
   if (isPending || error || !data)
     return <PagePlaceholder isPending={isPending} />;
 
-  const initData = { id: lyricId, name: data.name, lyrics: data.lyrics };
+  const initData = { name: data.name, lyrics: data.lyrics };
 
   return (
     <ModifyLyricBase
@@ -40,7 +40,9 @@ export default function ModifyLyric({
             queryClient.invalidateQueries({ queryKey: q.lyrics._def });
             navigation.goBack();
             navigation.goBack();
-          } catch {}
+          } catch {
+            toast.tError("err.flow.generic.title");
+          }
         },
         danger: true,
       }}

--- a/mobile/src/navigation/screens/lyrics/components/ModifyViewBase.tsx
+++ b/mobile/src/navigation/screens/lyrics/components/ModifyViewBase.tsx
@@ -1,54 +1,37 @@
-import { toast } from "@missingcore/toast";
-import { useNavigation } from "@react-navigation/native";
-import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
-import { View } from "react-native";
 import { z } from "zod/mini";
-
-import { queries as q } from "~/data/keyStore";
-import { deleteLyric } from "~/data/lyric/api";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";
 
-import { wait } from "~/utils/promise";
 import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
-import { ExtendedTButton } from "~/components/Form/Button";
-import { ModalTemplate } from "~/components/Modal";
 import { ZSchema } from "~/modules/form/utils";
-import {
-  FormStateProvider,
-  useFormStateContext,
-} from "~/modules/form/FormState";
+import type { FABWorkflowConfig } from "~/modules/form/FormState";
+import { FABWorkflow, FormStateProvider } from "~/modules/form/FormState";
 import {
   FormInputImpl,
   TextareaImpl,
 } from "~/modules/form/FormState/FormInput";
-import { readLyricFile } from "../helpers/readLyricFile";
 
 export function ModifyLyricBase(props: {
+  actionConfig: FABWorkflowConfig<LyricEntry>;
   onSubmit: (data: LyricEntry) => void | Promise<void>;
-  mode?: "create" | "edit";
   initialData?: LyricEntry;
 }) {
   const { offset, floatingContentProps } = useFloatingContent();
-
-  const RenderedWorkflow = useMemo(
-    () => (props.mode === "edit" ? DeleteWorkflow : ImportWorkflow),
-    [props.mode],
-  );
 
   return (
     <FormStateProvider
       schema={LyricEntrySchema}
       initData={{
-        id: props.initialData?.id ?? null,
         name: props.initialData?.name ?? "",
         lyrics: props.initialData?.lyrics ?? "",
       }}
       onSubmit={props.onSubmit}
     >
       <LyricForm bottomOffset={offset} />
-      <RenderedWorkflow floatingContentProps={floatingContentProps} />
+      <FABWorkflow
+        {...props.actionConfig}
+        floatingContentProps={floatingContentProps}
+      />
     </FormStateProvider>
   );
 }
@@ -70,105 +53,12 @@ function LyricForm({ bottomOffset }: { bottomOffset: number }) {
 }
 //#endregion
 
-//#region Import Workflow
-function ImportWorkflow({
-  floatingContentProps,
-}: Omit<ReturnType<typeof useFloatingContent>, "offset">) {
-  const { setFields, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onImport = async () => {
-    setIsSubmitting(true);
-    try {
-      const { name, contents } = await readLyricFile();
-      toast.t("feat.backup.extra.importSuccess");
-      await wait(100);
-      setFields({ name, lyrics: contents });
-    } catch (err) {
-      toast.error((err as Error).message);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <View {...floatingContentProps}>
-      <ExtendedTButton
-        textKey="feat.backup.extra.import"
-        onPress={onImport}
-        disabled={isSubmitting}
-        className="bg-secondary active:bg-secondaryDim"
-        textClassName="text-onSecondary"
-      />
-    </View>
-  );
-}
-//#endregion
-
-//#region Delete Workflow
-function DeleteWorkflow({
-  floatingContentProps,
-}: Omit<ReturnType<typeof useFloatingContent>, "offset">) {
-  const navigation = useNavigation();
-  const queryClient = useQueryClient();
-  const [lastChance, setLastChance] = useState(false);
-  const { data, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onDelete = async () => {
-    if (!data.id) return;
-    setLastChance(false);
-    setIsSubmitting(true);
-    await wait(1);
-    try {
-      await deleteLyric(data.id);
-      queryClient.invalidateQueries({ queryKey: q.lyrics._def });
-      navigation.goBack();
-      navigation.goBack();
-    } catch {
-      setLastChance(true);
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <>
-      <View {...floatingContentProps}>
-        <ExtendedTButton
-          textKey="form.delete"
-          onPress={() => setLastChance(true)}
-          disabled={lastChance || isSubmitting}
-          className="bg-error active:bg-errorDim"
-          textClassName="text-onError"
-        />
-      </View>
-      <ModalTemplate
-        visible={lastChance}
-        titleKey="form.delete"
-        topAction={{
-          textKey: "form.confirm",
-          onPress: onDelete,
-        }}
-        bottomAction={{
-          textKey: "form.cancel",
-          onPress: () => setLastChance(false),
-        }}
-      />
-    </>
-  );
-}
-//#endregion
-
 //#region Schema
 const LyricEntrySchema = z.object({
-  // Additional context:
-  id: z.nullable(z.string()),
   // Actual form fields:
   name: ZSchema.NonEmptyString,
   lyrics: ZSchema.NonEmptyString,
 });
 
 type LyricEntry = z.infer<typeof LyricEntrySchema>;
-
-function useFormState() {
-  return useFormStateContext<LyricEntry>();
-}
 //#endregion

--- a/mobile/src/navigation/screens/lyrics/components/ModifyViewBase.tsx
+++ b/mobile/src/navigation/screens/lyrics/components/ModifyViewBase.tsx
@@ -55,7 +55,6 @@ function LyricForm({ bottomOffset }: { bottomOffset: number }) {
 
 //#region Schema
 const LyricEntrySchema = z.object({
-  // Actual form fields:
   name: ZSchema.NonEmptyString,
   lyrics: ZSchema.NonEmptyString,
 });

--- a/mobile/src/navigation/screens/playlists/CreateView.tsx
+++ b/mobile/src/navigation/screens/playlists/CreateView.tsx
@@ -7,6 +7,9 @@ import { queries as q } from "~/data/keyStore";
 import { createPlaylist } from "~/data/playlist/api";
 
 import { PagePlaceholder } from "~/navigation/components/Placeholder";
+
+import { wait } from "~/utils/promise";
+import { readM3UPlaylist } from "~/modules/backup/M3U";
 import {
   ModifyPlaylistBase,
   usePreloadReferenceData,
@@ -21,6 +24,22 @@ export default function CreatePlaylist() {
   return (
     <ModifyPlaylistBase
       referenceData={data}
+      actionConfig={{
+        label: "feat.playlist.extra.m3uImport",
+        action: async ({ setFields }) => {
+          try {
+            const { name, tracks: playlistTracks } = await readM3UPlaylist();
+            await wait(100);
+            toast.t("feat.backup.extra.importSuccess");
+            setFields((prev) => ({
+              name: name || prev.name,
+              trackIds: playlistTracks.map((t) => t.id),
+            }));
+          } catch (err) {
+            toast.error((err as Error).message);
+          }
+        },
+      }}
       onSubmit={async ({ name, trackIds }) => {
         try {
           await createPlaylist({

--- a/mobile/src/navigation/screens/playlists/ModifyView.tsx
+++ b/mobile/src/navigation/screens/playlists/ModifyView.tsx
@@ -73,7 +73,9 @@ export default function ModifyPlaylist({
 
                   navigation.goBack();
                   navigation.goBack();
-                } catch {}
+                } catch {
+                  toast.tError("err.flow.generic.title");
+                }
               },
               danger: true,
             }

--- a/mobile/src/navigation/screens/playlists/ModifyView.tsx
+++ b/mobile/src/navigation/screens/playlists/ModifyView.tsx
@@ -76,7 +76,6 @@ export default function ModifyPlaylist({
                 } catch {}
               },
               danger: true,
-              requireConfirmation: true,
             }
       }
       onSubmit={async ({ name: playlistName, trackIds }) => {

--- a/mobile/src/navigation/screens/playlists/ModifyView.tsx
+++ b/mobile/src/navigation/screens/playlists/ModifyView.tsx
@@ -5,11 +5,14 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { queries as q } from "~/data/keyStore";
-import { updatePlaylist } from "~/data/playlist/api";
+import { deletePlaylist, updatePlaylist } from "~/data/playlist/api";
 import { usePlaylist } from "~/data/playlist/queries";
 import { Resynchronize } from "~/stores/Playback/actions";
 
 import { PagePlaceholder } from "~/navigation/components/Placeholder";
+
+import { wait } from "~/utils/promise";
+import { FavoritesPlaylistKey } from "~/modules/media/constants";
 import {
   ModifyPlaylistBase,
   usePreloadReferenceData,
@@ -41,6 +44,7 @@ export default function ModifyPlaylist({
     );
   }
 
+  const isFavoritesList = id === FavoritesPlaylistKey;
   const initData = {
     name: id,
     trackIds: playlistQuery.data.tracks.map((t) => t.id),
@@ -48,9 +52,33 @@ export default function ModifyPlaylist({
 
   return (
     <ModifyPlaylistBase
-      mode="edit"
       referenceData={preloadFormDataQuery.data}
       initialData={initData}
+      actionConfig={
+        isFavoritesList
+          ? undefined
+          : {
+              label: "form.delete",
+              action: async () => {
+                await wait(1);
+                try {
+                  await deletePlaylist(id);
+
+                  queryClient.invalidateQueries({ queryKey: q.playlists._def });
+                  queryClient.invalidateQueries({ queryKey: q.tracks._def });
+                  queryClient.invalidateQueries({
+                    queryKey: q.favorites.lists.queryKey,
+                  });
+                  queryClient.invalidateQueries({ queryKey: ["search"] });
+
+                  navigation.goBack();
+                  navigation.goBack();
+                } catch {}
+              },
+              danger: true,
+              requireConfirmation: true,
+            }
+      }
       onSubmit={async ({ name: playlistName, trackIds }) => {
         // Don't update playlist name if it hasn't changed.
         const newName = id === playlistName ? undefined : playlistName;

--- a/mobile/src/navigation/screens/playlists/components/ModifyViewBase.tsx
+++ b/mobile/src/navigation/screens/playlists/components/ModifyViewBase.tsx
@@ -1,14 +1,5 @@
 import { toast } from "@missingcore/toast";
-import { useNavigation } from "@react-navigation/native";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  createContext,
-  memo,
-  use,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import { createContext, memo, use, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 import { z } from "zod/mini";
@@ -17,9 +8,7 @@ import { Add } from "~/resources/icons/Add";
 import { Cancel } from "~/resources/icons/Cancel";
 import { CheckCircle } from "~/resources/icons/CheckCircle";
 import { DragHandle } from "~/resources/icons/DragHandle";
-import { queries as q } from "~/data/keyStore";
 import { getArtistsString } from "~/data/artist/utils";
-import { deletePlaylist } from "~/data/playlist/api";
 import { usePlaylistsNames } from "~/data/playlist/queries";
 import { sanitizePlaylistName } from "~/data/playlist/utils";
 import type { CommonTrack } from "~/data/types";
@@ -30,23 +19,21 @@ import { AddMusicSheet } from "../sheets/AddMusicSheet";
 
 import { cn } from "~/lib/style";
 import { moveArray } from "~/utils/object";
-import { wait } from "~/utils/promise";
 import {
   DragList,
   useDragListState,
   useInitDrag,
 } from "~/components/Base/DragList";
 import type { ListRenderItemInfo } from "~/components/Base/List";
-import { ExtendedTButton } from "~/components/Form/Button";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { RemovableItem } from "~/components/List/RemovableItem";
-import { ModalTemplate } from "~/components/Modal";
 import type { TrueSheetRef } from "~/components/Sheet/useSheetRef";
 import { useSheetRef } from "~/components/Sheet/useSheetRef";
 import { TStyledText } from "~/components/Typography/StyledText";
-import { readM3UPlaylist } from "~/modules/backup/M3U";
 import { ZSchema } from "~/modules/form/utils";
+import type { FABWorkflowConfig } from "~/modules/form/FormState";
 import {
+  FABWorkflow,
   FormStateProvider,
   useFormStateContext,
 } from "~/modules/form/FormState";
@@ -58,18 +45,11 @@ import type { SearchCallbacks } from "~/modules/search/types";
 
 export function ModifyPlaylistBase(props: {
   onSubmit: (data: PlaylistEntry) => void | Promise<void>;
-  mode?: "create" | "edit";
-  initialData?: Omit<PlaylistEntry, "isFavoritesList">;
+  initialData?: PlaylistEntry;
   referenceData: ReturnType<typeof usePreloadReferenceData>["data"];
+  actionConfig?: FABWorkflowConfig<PlaylistEntry>;
 }) {
   const { offset, floatingContentProps } = useFloatingContent();
-
-  const isFavoritesList = props.initialData?.name === FavoritesPlaylistKey;
-
-  const RenderedWorkflow = useMemo(
-    () => (props.mode === "edit" ? DeleteWorkflow : ImportM3UWorkflow),
-    [props.mode],
-  );
 
   // Exclude `FavoritesPlaylistKey` as we don't return it when fetching all
   // playlists & don't check it in `sanitizePlaylistName`.
@@ -89,11 +69,9 @@ export function ModifyPlaylistBase(props: {
       <FormStateProvider
         schema={PlaylistEntrySchema}
         initData={{
-          isFavoritesList,
           name: props.initialData?.name ?? "",
           trackIds: props.initialData?.trackIds ?? [],
         }}
-        omittedFields={["isFavoritesList"]}
         onSubmit={props.onSubmit}
         onConstraints={({ name }) => {
           // Checks to see if playlist name is unique.
@@ -107,9 +85,17 @@ export function ModifyPlaylistBase(props: {
           return isUnique;
         }}
       >
-        <PlaylistForm bottomOffset={offset} />
-        {!isFavoritesList ? (
-          <RenderedWorkflow floatingContentProps={floatingContentProps} />
+        <PlaylistForm
+          bottomOffset={offset}
+          //? `actionConfig` being undefined implies that this is the Favorites
+          //? playlist as we don't want users to delete it.
+          isFavoritesList={props.actionConfig === undefined}
+        />
+        {props.actionConfig ? (
+          <FABWorkflow
+            {...props.actionConfig}
+            floatingContentProps={floatingContentProps}
+          />
         ) : null}
       </FormStateProvider>
     </CachedTracksContext>
@@ -119,7 +105,10 @@ export function ModifyPlaylistBase(props: {
 //#region Playlist Form
 const FormInput = FormInputImpl<PlaylistEntry>();
 
-function PlaylistForm({ bottomOffset }: { bottomOffset: number }) {
+function PlaylistForm(props: {
+  bottomOffset: number;
+  isFavoritesList?: boolean;
+}) {
   const {
     data: { trackIds },
     setFields,
@@ -169,11 +158,12 @@ function PlaylistForm({ bottomOffset }: { bottomOffset: number }) {
         onReorder={reorderTrack}
         ListHeaderComponent={
           <ListHeaderComponent
+            isFavoritesList={props.isFavoritesList}
             showSheet={() => addTracksSheetRef.current?.present()}
           />
         }
         ListEmptyComponent={<ContentPlaceholder errMsgKey="err.msg.noTracks" />}
-        contentContainerStyle={{ paddingBottom: bottomOffset }}
+        contentContainerStyle={{ paddingBottom: props.bottomOffset }}
         contentContainerClassName="px-4"
       />
     </>
@@ -223,11 +213,8 @@ function AddTracksSheet(props: { ref: TrueSheetRef }) {
 //#endregion
 
 //#region Playlist Name Field
-function PlaylistNameField() {
-  const {
-    data: { isFavoritesList },
-    passedConstraints,
-  } = useFormState();
+function PlaylistNameField({ isFavoritesList }: { isFavoritesList?: boolean }) {
+  const { passedConstraints } = useFormState();
 
   const ConstraintIcon = useMemo(
     () => (passedConstraints ? CheckCircle : Cancel),
@@ -260,13 +247,16 @@ function PlaylistNameField() {
 //#endregion
 
 //#region Pre-DragList Fields
-function ListHeaderComponent(props: { showSheet: VoidFunction }) {
+function ListHeaderComponent(props: {
+  isFavoritesList?: boolean;
+  showSheet: VoidFunction;
+}) {
   const { t } = useTranslation();
   const { isSubmitting } = useFormState();
 
   return (
     <View className="gap-6">
-      <PlaylistNameField />
+      <PlaylistNameField isFavoritesList={props.isFavoritesList} />
       <InputLabel
         labelKey="term.tracks"
         RightElement={
@@ -345,102 +335,6 @@ const RenderItem = memo(
 //#endregion
 //#endregion
 
-//#region Import M3U Workflow
-function ImportM3UWorkflow({
-  floatingContentProps,
-}: Omit<ReturnType<typeof useFloatingContent>, "offset">) {
-  const { data, setFields, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onImport = async () => {
-    setIsSubmitting(true);
-    try {
-      const { name, tracks: playlistTracks } = await readM3UPlaylist();
-      toast.t("feat.backup.extra.importSuccess");
-      await wait(100);
-      const updatedFields: Partial<PlaylistEntry> = {
-        trackIds: playlistTracks.map((t) => t.id),
-      };
-      if (!data.name && !!name) updatedFields.name = name;
-      setFields(updatedFields);
-    } catch (err) {
-      toast.error((err as Error).message);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <View {...floatingContentProps}>
-      <ExtendedTButton
-        textKey="feat.playlist.extra.m3uImport"
-        onPress={onImport}
-        disabled={isSubmitting}
-        className="bg-secondary active:bg-secondaryDim"
-        textClassName="text-onSecondary"
-      />
-    </View>
-  );
-}
-//#endregion
-
-//#region Delete Workflow
-function DeleteWorkflow({
-  floatingContentProps,
-}: Omit<ReturnType<typeof useFloatingContent>, "offset">) {
-  const navigation = useNavigation();
-  const queryClient = useQueryClient();
-  const [lastChance, setLastChance] = useState(false);
-  const { data, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onDelete = async () => {
-    setLastChance(false);
-    setIsSubmitting(true);
-    // Slight buffer before running mutation.
-    await wait(1);
-    try {
-      await deletePlaylist(data.name);
-
-      queryClient.invalidateQueries({ queryKey: q.playlists._def });
-      queryClient.invalidateQueries({ queryKey: q.tracks._def });
-      queryClient.invalidateQueries({ queryKey: q.favorites.lists.queryKey });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
-
-      navigation.goBack();
-      navigation.goBack();
-    } catch {
-      setLastChance(true);
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <>
-      <View {...floatingContentProps}>
-        <ExtendedTButton
-          textKey="form.delete"
-          onPress={() => setLastChance(true)}
-          disabled={lastChance || isSubmitting}
-          className="bg-error active:bg-errorDim"
-          textClassName="text-onError"
-        />
-      </View>
-      <ModalTemplate
-        visible={lastChance}
-        titleKey="form.delete"
-        topAction={{
-          textKey: "form.confirm",
-          onPress: onDelete,
-        }}
-        bottomAction={{
-          textKey: "form.cancel",
-          onPress: () => setLastChance(false),
-        }}
-      />
-    </>
-  );
-}
-//#endregion
-
 //#region Schema
 const PlaylistNameSchema = z.pipe(
   ZSchema.NonEmptyString,
@@ -460,9 +354,6 @@ const PlaylistNameSchema = z.pipe(
 );
 
 const PlaylistEntrySchema = z.object({
-  // Additional context:
-  isFavoritesList: z.boolean(),
-  // Actual form fields:
   name: PlaylistNameSchema,
   trackIds: z.array(ZSchema.NonEmptyString),
 });

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -35,13 +35,13 @@ import { AddAlbumSheet } from "./sheets/AddAlbumSheet";
 import { clearAllQueries } from "~/lib/react-query";
 import { splitOn } from "~/utils/string";
 import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
-import { ExtendedTButton } from "~/components/Form/Button";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { TextInput } from "~/components/Form/Input";
 import { useSheetRef } from "~/components/Sheet/useSheetRef";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ZSchema } from "~/modules/form/utils";
 import {
+  FABWorkflow,
   FormStateProvider,
   useFormStateContext,
 } from "~/modules/form/FormState";
@@ -60,6 +60,7 @@ export default function ModifyTrack({
 }: Props) {
   const trackQuery = useTrack(id);
   const trackGenresQuery = useTrackGenres(id);
+  const delimiters = usePreferenceStore((s) => s.separators);
   const { offset, floatingContentProps } = useFloatingContent();
 
   if (
@@ -102,9 +103,35 @@ export default function ModifyTrack({
       }
     >
       <MetadataForm bottomOffset={offset} />
-      <ResetWorkflow
+      <FABWorkflow
+        label="form.reset"
+        action={async ({ setFields }) => {
+          try {
+            const trackMetadata = await getMetadata(trackQuery.data.uri, [
+              ...MetadataPresets.standard,
+              "discNumber",
+              "genre",
+            ]);
+            setFields({
+              name: trackMetadata.title ?? "",
+              artists: trackMetadata.artist
+                ? splitOn(trackMetadata.artist, delimiters)
+                : [],
+              album: trackMetadata.albumTitle,
+              albumArtists: trackMetadata.albumArtist
+                ? splitOn(trackMetadata.albumArtist, delimiters)
+                : [],
+              year: trackMetadata.year,
+              disc: trackMetadata.discNumber,
+              track: trackMetadata.trackNumber,
+              genres: trackMetadata.genre
+                ? splitOn(trackMetadata.genre, delimiters)
+                : [],
+            });
+          } catch {}
+        }}
+        danger
         floatingContentProps={floatingContentProps}
-        uri={trackQuery.data.uri}
       />
     </FormStateProvider>
   );
@@ -195,58 +222,6 @@ function MetadataForm({ bottomOffset }: { bottomOffset: number }) {
         <ArrayFormInput labelKey="term.genres" field="genres" />
       </KeyboardAwareScrollView>
     </>
-  );
-}
-//#endregion
-
-//#region Reset Workflow
-/** Logic to set the form fields to the embedded metadata from the track. */
-function ResetWorkflow(
-  props: Omit<ReturnType<typeof useFloatingContent>, "offset"> & {
-    uri: string;
-  },
-) {
-  const delimiters = usePreferenceStore((s) => s.separators);
-  const { setFields, isSubmitting, setIsSubmitting } = useFormState();
-
-  const onReset = async () => {
-    setIsSubmitting(true);
-    try {
-      const trackMetadata = await getMetadata(props.uri, [
-        ...MetadataPresets.standard,
-        "discNumber",
-        "genre",
-      ]);
-      setFields({
-        name: trackMetadata.title ?? "",
-        artists: trackMetadata.artist
-          ? splitOn(trackMetadata.artist, delimiters)
-          : [],
-        album: trackMetadata.albumTitle,
-        albumArtists: trackMetadata.albumArtist
-          ? splitOn(trackMetadata.albumArtist, delimiters)
-          : [],
-        year: trackMetadata.year,
-        disc: trackMetadata.discNumber,
-        track: trackMetadata.trackNumber,
-        genres: trackMetadata.genre
-          ? splitOn(trackMetadata.genre, delimiters)
-          : [],
-      });
-    } catch {}
-    setIsSubmitting(false);
-  };
-
-  return (
-    <View {...props.floatingContentProps}>
-      <ExtendedTButton
-        textKey="form.reset"
-        onPress={onReset}
-        disabled={isSubmitting}
-        className="bg-error active:bg-errorDim"
-        textClassName="text-onError"
-      />
-    </View>
   );
 }
 //#endregion


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR accomplishes 3 main tasks:
1. Fix up `~/modules` code import in other modules.
2. Moved equalizer & search screens to a `screens` folder in their respective `~/modules` folder.
3. Made the "floating action button" on our forms a resuable component.

In addition, this PR makes some adjustments & fixes some issues to the old flow:
1. ❗ Fixed bug where it was possible to delete an unrelated playlist if we changed the value in the "Name" field before going through the "Delete" workflow.
2. Make the "Reset" button on the "Edit Metadata" form require confirmation.
3. Importing a playlist via an M3U file will now override the value in the "Name" field.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
