### PR TITLE
fix: Failure to create playlist from importing an M3U file with duplicate tracks

### DIFF
--- a/mobile/src/modules/backup/M3U.ts
+++ b/mobile/src/modules/backup/M3U.ts
@@ -50,12 +50,15 @@ export async function readM3UPlaylist() {
   }
 
   // Get uris so we can search our database.
-  const trackUris =
-    strategy === "absolute"
-      ? trackPaths.map((path) => `file://${slashStart ? "" : "/"}${path}`)
-      : strategy === "relative"
-        ? trackPaths.map((path) => joinPaths(fileDirectory, path))
-        : trackPaths;
+  const trackUris = Array.from(
+    new Set(
+      strategy === "absolute"
+        ? trackPaths.map((path) => `file://${slashStart ? "" : "/"}${path}`)
+        : strategy === "relative"
+          ? trackPaths.map((path) => joinPaths(fileDirectory, path))
+          : trackPaths,
+    ),
+  );
 
   const playlistTracks = await getTracks([
     inArray(structuredTracksView.uri, trackUris),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR fixes an edge case which prevents the creation of a playlist when importing from an M3U file. The problem is that it's possible for the M3U file to reference the same track multiple time (ie: if it was created from a different app which supports having a track appear multiple times). In our case, we didn't account for this, so when we went to create the `tracksToPlaylists` relations, Drizzle will throw an error since we were trying to insert a new entry with a track id that's already used.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved M3U playlist import efficiency by eliminating redundant track lookups for duplicate playlist entries, enhancing performance during backup restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MissingCore/Music/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->