### PR TITLE
❗refactor: Safe-guards due to making the `uri` field on the "Tracks" schema unique

### DIFF
--- a/mobile/src/data/track/api.ts
+++ b/mobile/src/data/track/api.ts
@@ -154,7 +154,13 @@ export function toggleTrackInPlaylist(entry: InsertedTrackPlaylistRelation) {
 /** Create/update track entries. */
 export function upsertTracks(entries: InsertedTrack[]) {
   return db.insert(tracks).values(entries).onConflictDoUpdate({
-    target: tracks.id,
+    //? This is only used in `findAndSaveAudio()`, in which we should
+    //? have prevented insertion of the following situations:
+    //?   1. Entries with the same `id` but different `uri`.
+    //?   2. Entries with the same `uri` but different `id`.
+    //? So if `onConflictDoUpdate` is triggered, it's only when we're
+    //? updating the track.
+    target: tracks.uri,
     set: UpsertFields,
   });
 }

--- a/mobile/src/data/track/api.ts
+++ b/mobile/src/data/track/api.ts
@@ -156,7 +156,8 @@ export function upsertTracks(entries: InsertedTrack[]) {
   return db.insert(tracks).values(entries).onConflictDoUpdate({
     //? This is only used in `findAndSaveAudio()`, in which we should
     //? have prevented insertion of the following situations:
-    //?   1. Entries with the same `uri` but different `id`.
+    //?   1. Entries with the same `id` but different `uri`.
+    //?   2. Entries with the same `uri` but different `id`.
     //? So if `onConflictDoUpdate` is triggered, it's only when we're
     //? updating the track.
     target: tracks.uri,

--- a/mobile/src/data/track/api.ts
+++ b/mobile/src/data/track/api.ts
@@ -156,8 +156,7 @@ export function upsertTracks(entries: InsertedTrack[]) {
   return db.insert(tracks).values(entries).onConflictDoUpdate({
     //? This is only used in `findAndSaveAudio()`, in which we should
     //? have prevented insertion of the following situations:
-    //?   1. Entries with the same `id` but different `uri`.
-    //?   2. Entries with the same `uri` but different `id`.
+    //?   1. Entries with the same `uri` but different `id`.
     //? So if `onConflictDoUpdate` is triggered, it's only when we're
     //? updating the track.
     target: tracks.uri,

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -100,9 +100,12 @@ export async function findAndSaveAudio() {
     db.query.invalidTracks.findMany(),
   ]);
   // Format data as objects for faster reads inside a loop.
-  const savedMap = Object.fromEntries(prevSaved.map((t) => [t.uri, t]));
-  const hiddenMap = Object.fromEntries(prevHidden.map((t) => [t.uri, t]));
-  const erroredMap = Object.fromEntries(prevErrored.map((t) => [t.uri, t]));
+  const savedIdMap = Object.fromEntries(prevSaved.map((t) => [t.id, t]));
+  const savedURIMap = Object.fromEntries(prevSaved.map((t) => [t.uri, t]));
+  const hiddenIdMap = Object.fromEntries(prevHidden.map((t) => [t.id, t]));
+  const hiddenURIMap = Object.fromEntries(prevHidden.map((t) => [t.uri, t]));
+  const erroredIdMap = Object.fromEntries(prevErrored.map((t) => [t.id, t]));
+  const erroredURIMap = Object.fromEntries(prevErrored.map((t) => [t.uri, t]));
 
   // Find the tracks we can skip indexing or need updating.
   const seenIdsMap: Record<string, string> = {};
@@ -113,6 +116,7 @@ export async function findAndSaveAudio() {
 
   //* We allow tracks with the same `id`, but different `uri` to "pass through".
   discoveredTracks.forEach(({ id, modificationTime, uri }) => {
+    //#region "Broken" Track Handling
     //? 1. Mark track as "broken" if MediaStore returns the `id` or `uri` again.
     const seenIdAgain = seenIdsMap[id]; // Returns prior `uri` for that `id`.
     seenIdsMap[id] = uri;
@@ -127,20 +131,58 @@ export async function findAndSaveAudio() {
       return;
     }
 
-    //? 2. Ignore if track is "broken".
-    if (broken.has(uri)) return;
-    //? 3. Ignore if track is hidden.
-    if (hiddenMap[uri]) return unmodified.add(uri);
+    //? 2. Mark track as "broken" if `uri` is the same, but `id` has changed.
+    if (
+      (savedURIMap[uri] && savedURIMap[uri].id !== id) ||
+      (hiddenURIMap[uri] && hiddenURIMap[uri].id !== id) ||
+      (erroredURIMap[uri] && erroredURIMap[uri].id !== id)
+    ) {
+      [
+        savedURIMap[uri]?.uri,
+        hiddenURIMap[uri]?.uri,
+        erroredURIMap[uri]?.uri,
+        uri,
+      ].forEach((brokenURI) => {
+        if (!brokenURI) return;
+        newOrModified.delete(brokenURI);
+        unmodified.delete(brokenURI);
+        broken.add(brokenURI);
+      });
+      return;
+    }
+    //? 3. Mark track as "broken" if `id` is the same, but `uri` has changed.
+    if (
+      (savedIdMap[id] && savedIdMap[id].uri !== uri) ||
+      (hiddenIdMap[id] && hiddenIdMap[id].uri !== uri) ||
+      (erroredIdMap[id] && erroredIdMap[id].uri !== uri)
+    ) {
+      [
+        savedIdMap[id]?.uri,
+        hiddenIdMap[id]?.uri,
+        erroredIdMap[id]?.uri,
+        uri,
+      ].forEach((brokenURI) => {
+        if (!brokenURI) return;
+        newOrModified.delete(brokenURI);
+        unmodified.delete(brokenURI);
+        broken.add(brokenURI);
+      });
+      return;
+    }
 
-    //? 4. Handle if track is new.
-    const isSaved = savedMap[uri];
-    const isInvalid = erroredMap[uri];
+    //? 4. Ignore if track is "broken".
+    if (broken.has(uri)) return;
+    //#endregion
+
+    //? 5. Ignore if track is hidden.
+    if (hiddenURIMap[uri]) return unmodified.add(uri);
+
+    //? 6. Handle if track is new.
+    const isSaved = savedURIMap[uri];
+    const isInvalid = erroredURIMap[uri];
     if (!isSaved && !isInvalid) return newOrModified.add(uri);
 
-    //? 5. Mark track as "broken" if `uri` is the same, but `id` has changed.
-    if ((isSaved || isInvalid)!.id !== id) return broken.add(uri);
-
-    //? 6. Determine if track is modified based on difference in `modificationTime`
+    //? 7. Determine if track is modified based on difference in `modificationTime`
     //? and whether it has been manually edited by the user.
     const hasEdited = typeof isSaved?.editedMetadata === "number";
     const isMaybeModified =

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -87,58 +87,77 @@ export async function findAndSaveAudio() {
   //#endregion
 
   //#region Change Detection
-  const savedTracks = await db.query.tracks.findMany({
-    columns: {
-      id: true,
-      modificationTime: true,
-      uri: true,
-      editedMetadata: true,
-    },
-  });
-  const hiddenTracks = await db.query.hiddenTracks.findMany();
-  const erroredTracks = await db.query.invalidTracks.findMany();
+  const [prevSaved, prevHidden, prevErrored] = await Promise.all([
+    db.query.tracks.findMany({
+      columns: {
+        id: true,
+        modificationTime: true,
+        uri: true,
+        editedMetadata: true,
+      },
+    }),
+    db.query.hiddenTracks.findMany(),
+    db.query.invalidTracks.findMany(),
+  ]);
   // Format data as objects for faster reads inside a loop.
-  const savedMap = Object.fromEntries(savedTracks.map((t) => [t.id, t]));
-  const hiddenMap = Object.fromEntries(hiddenTracks.map((t) => [t.id, t]));
-  const erroredMap = Object.fromEntries(erroredTracks.map((t) => [t.id, t]));
+  const savedMap = Object.fromEntries(prevSaved.map((t) => [t.uri, t]));
+  const hiddenMap = Object.fromEntries(prevHidden.map((t) => [t.uri, t]));
+  const erroredMap = Object.fromEntries(prevErrored.map((t) => [t.uri, t]));
 
   // Find the tracks we can skip indexing or need updating.
-  const modified = new Set<string>();
+  const seenIdsMap: Record<string, string> = {};
+  const newOrModified = new Set<string>();
   const unmodified = new Set<string>();
+  //? For weird edge-cases (ie: seeing the same `id` or `uri` multiple times).
+  const broken = new Set<string>();
+
+  //* We allow tracks with the same `id`, but different `uri` to "pass through".
   discoveredTracks.forEach(({ id, modificationTime, uri }) => {
-    // Skip if track is hidden.
-    if (hiddenMap[id]) return unmodified.add(id);
+    //? 1. Mark track as "broken" if MediaStore returns the `id` or `uri` again.
+    const seenIdAgain = seenIdsMap[id]; // Returns prior `uri` for that `id`.
+    seenIdsMap[id] = uri;
+    const seenURIAgain = newOrModified.has(uri) || unmodified.has(uri);
+    if (seenIdAgain !== undefined || seenURIAgain) {
+      [seenIdAgain, uri].forEach((brokenURI) => {
+        if (!brokenURI) return;
+        newOrModified.delete(brokenURI);
+        unmodified.delete(brokenURI);
+        broken.add(brokenURI);
+      });
+      return;
+    }
 
-    // Skip if track is new.
-    const isSaved = savedMap[id];
-    const isInvalid = erroredMap[id];
-    if (!isSaved && !isInvalid) return;
+    //? 2. Ignore if track is "broken".
+    if (broken.has(uri)) return;
+    //? 3. Ignore if track is hidden.
+    if (hiddenMap[uri]) return unmodified.add(uri);
 
-    // Get context for determining if track has been modified.
+    //? 4. Handle if track is new.
+    const isSaved = savedMap[uri];
+    const isInvalid = erroredMap[uri];
+    if (!isSaved && !isInvalid) return newOrModified.add(uri);
+
+    //? 5. Mark track as "broken" if `uri` is the same, but `id` has changed.
+    if ((isSaved || isInvalid)!.id !== id) return broken.add(uri);
+
+    //? 6. Determine if track is modified based on difference in `modificationTime`
+    //? and whether it has been manually edited by the user.
+    const hasEdited = typeof isSaved?.editedMetadata === "number";
     const isMaybeModified =
       Math.abs(modificationTime - (isSaved ?? isInvalid)!.modificationTime) >
       CHANGE_DELTA;
-    const hasEdited = typeof isSaved?.editedMetadata === "number";
-    let isDifferentUri = (isSaved ?? isInvalid)!.uri !== uri;
 
-    // A track which has been moved may be detected twice by `expo-media-library`
-    // in its new & old location with the same `id`. This logic helps mark the
-    // track as modified.
-    if (isDifferentUri && unmodified.has(id)) unmodified.delete(id);
-    else if (!isDifferentUri && modified.has(id)) isDifferentUri = true; // Encountered old location.
-
-    // Retry indexing if modification time or uri is different.
-    if ((!hasEdited && isMaybeModified) || isDifferentUri) modified.add(id);
-    else unmodified.add(id);
+    if (!hasEdited && isMaybeModified) newOrModified.add(uri);
+    else unmodified.add(uri);
   });
 
-  const unstagedTracks = discoveredTracks.filter(
-    ({ id }) => !unmodified.has(id),
+  const unstagedTracks = discoveredTracks.filter(({ uri }) =>
+    newOrModified.has(uri),
   );
 
   scanningProgressStore.setState({
     scannedTracks: 0,
-    modifiedTracks: discoveredTracks.length - unmodified.size,
+    modifiedTracks: newOrModified.size,
     failedTrackScans: 0,
   });
   console.log(`Determined unstaged content in ${stopwatch.lapTime()}.`);
@@ -260,9 +279,9 @@ export async function findAndSaveAudio() {
   );
 
   return {
-    foundFiles: discoveredTracks,
+    foundFiles: discoveredTracks.filter(({ uri }) => !broken.has(uri)),
     unstagedFiles: unstagedTracks,
-    changed: discoveredTracks.length - unmodified.size,
+    changed: newOrModified.size,
   };
 }
 

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -114,7 +114,6 @@ export async function findAndSaveAudio() {
   //? For weird edge-cases (ie: seeing the same `id` or `uri` multiple times).
   const broken = new Set<string>();
 
-  //* We allow tracks with the same `id`, but different `uri` to "pass through".
   discoveredTracks.forEach(({ id, modificationTime, uri }) => {
     //#region "Broken" Track Handling
     //? 1. Mark track as "broken" if MediaStore returns the `id` or `uri` again.

--- a/mobile/src/modules/scanning/helpers/cleanup.ts
+++ b/mobile/src/modules/scanning/helpers/cleanup.ts
@@ -129,6 +129,7 @@ export const AppCleanUp = {
     )
       .flatMap((ids) => ids.map(({ id }) => id))
       .filter((id) => !foundTrackIdsSet.has(id));
+    console.log(`Deleting ${unusedTrackIds.length} tracks...`);
 
     if (unusedTrackIds.length > 0) {
       await Promise.allSettled([


### PR DESCRIPTION
> [!NOTE]
> We removed the unique constraint in #491, with the goal of just doing all of this at once (switching `id` to use the uri), so this isn't needed anymore.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

In preparation to potentially switch to making the `id` property on tracks contain the `uri` property from MediaStore instead of the `id` property, we added a unique constraint on the `uri` property on the "Tracks schema in 6f6d173.

**The problem is that if we replaced the file at that location with the same file, but with updated metadata, there's a chance that MediaStore will assign a new id to that entry. Due to how our upsert logic worked, we would end up making a new "Track" entry with a different `id` compared to the existing entry in the database with the same `uri`. This will then result in the `UNIQUE constraint failed: tracks.uri` error that can't be dismissed unless we remove the file that we've replaced from the device (which is almost impossible). We can't revert adding the unique constraint due to basically breaking installs for users using the `v3.1.0-rc.*` versions.**


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [ ] This diff will work correctly for `pnpm android:prod`.
