### PR TITLE
fix: Revert adding the unique constraint to `uri` field

### DIFF
--- a/mobile/src/db/drizzle/0012_organic_mordo.sql
+++ b/mobile/src/db/drizzle/0012_organic_mordo.sql
@@ -36,4 +36,4 @@ CREATE TABLE `custom_themes` (
 	`inverse_on_surface` text NOT NULL
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `tracks_uri_unique` ON `tracks` (`uri`);
+DROP INDEX IF EXISTS `tracks_uri_unique`;

--- a/mobile/src/db/drizzle/0013_gigantic_senator_kelly.sql
+++ b/mobile/src/db/drizzle/0013_gigantic_senator_kelly.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS `tracks_uri_unique`;

--- a/mobile/src/db/drizzle/meta/0013_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0013_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "6bf3aafe-3c6e-49b2-a895-8e33d7d78415",
-  "prevId": "af4c5398-3b5b-47fb-bc3a-8219f61c6b4f",
+  "id": "c1dfd855-3c22-470e-b85a-0a37f441421a",
+  "prevId": "6bf3aafe-3c6e-49b2-a895-8e33d7d78415",
   "tables": {
     "albums": {
       "name": "albums",

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778799949927,
       "tag": "0012_organic_mordo",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1779473921237,
+      "tag": "0013_gigantic_senator_kelly",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -14,6 +14,7 @@ import m0009 from "./0009_ambitious_puppet_master.sql";
 import m0010 from "./0010_spooky_blue_marvel.sql";
 import m0011 from "./0011_awesome_gateway.sql";
 import m0012 from "./0012_organic_mordo.sql";
+import m0013 from "./0013_gigantic_senator_kelly.sql";
 
 export default {
   journal,
@@ -31,5 +32,6 @@ export default {
     m0010,
     m0011,
     m0012,
+    m0013,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -104,7 +104,7 @@ export const tracks = sqliteTable("tracks", {
   bitrate: integer(),
   sampleRate: integer(),
   size: integer().notNull(),
-  uri: text().notNull().unique(),
+  uri: text().notNull(),
   modificationTime: integer().notNull(),
   discoverTime: integer().notNull().default(-1),
   // Artwork


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR reverts adding the unique constraint on the `uri` field in the "Tracks" table due to causing a bit of issues, notably with our complex patch to the problem in #490. So if we're going to eventually do a "breaking change" (switch over to using the "uri" in the `id` field), we should do it all at once and break things once instead of multiple times.

We need a new migration to undo the changes for users on `v3.1.0-rc.*` versions. We revised the migration introduced in `v3.1.0-rc.1` so that the unique constraint never gets created, preventing the earlier issues faced.
- I've only tested to see that the unique constraint gets removed when going from `v3.1.0-rc.2`.
- For testing from coming from `v3.0.1` where the unique constraint never existed, this will be tested after we create the production APK build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database schema to remove uniqueness constraint on track identifiers, allowing the system to handle duplicate track references in the database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MissingCore/Music/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->