### PR TITLE
feat: Auto pull lyrics from adjacent `.lrc` files

### DIFF
--- a/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
@@ -1,5 +1,6 @@
 import { getLyric } from "@missingcore/react-native-metadata-retriever";
 import { useNavigation } from "@react-navigation/native";
+import { File } from "expo-file-system";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Text, View } from "react-native";
@@ -125,7 +126,7 @@ function LyricsNotFound(props: { trackId: string; offset: number }) {
 
   useEffect(() => {
     (async () => {
-      await fetchEmbeddedLyrics();
+      await fetchLyrics();
       setCheckingEmbeddedLyrics(false);
     })();
   }, []);
@@ -148,16 +149,24 @@ function LyricsNotFound(props: { trackId: string; offset: number }) {
   );
 }
 
-async function fetchEmbeddedLyrics() {
+async function fetchLyrics() {
   const { activeTrack } = playbackStore.getState();
   if (!activeTrack) return;
   try {
-    const embeddedLyrics = await getLyric(activeTrack.uri);
-    if (!embeddedLyrics) return;
+    //? 1. Start by looking for embedded lyrics.
+    let foundLyrics = await getLyric(activeTrack.uri);
+
+    //? 2. Check for adjacent lyric files (`.lrc`).
+    const fileSlug = activeTrack.uri.split(".").slice(0, -1).join(".");
+    const adjacentLrcFile = new File(`${fileSlug}.lrc`);
+    if (adjacentLrcFile.exists) foundLyrics = await adjacentLrcFile.text();
+
+    // Silently return if no lyrics are found.
+    if (!foundLyrics) return;
 
     const newLyric = await createLyric({
       name: `${activeTrack.name} - ${getArtistsString(activeTrack.artists)}`,
-      lyrics: embeddedLyrics,
+      lyrics: foundLyrics,
     });
     if (!newLyric) throw new Error("Lyric not returned after insertion.");
     await linkTrackToLyric(
@@ -166,7 +175,9 @@ async function fetchEmbeddedLyrics() {
     );
 
     queryClient.invalidateQueries({ queryKey: q.lyrics._def });
-  } catch {}
+  } catch (err) {
+    console.log(err);
+  }
 }
 //#endregion
 

--- a/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
@@ -70,7 +70,7 @@ function LyricsContent(props: { trackId: string; offset: number }) {
 
   const lyricsLines = useMemo(() => {
     if (!data?.lyrics) return [];
-    return data.lyrics.split("\n");
+    return data.lyrics.split("\n").map((line) => line.trim());
   }, [data?.lyrics]);
 
   const isSynchronized = useMemo(
@@ -175,9 +175,7 @@ async function fetchLyrics() {
     );
 
     queryClient.invalidateQueries({ queryKey: q.lyrics._def });
-  } catch (err) {
-    console.log(err);
-  }
+  } catch {}
 }
 //#endregion
 

--- a/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
@@ -164,13 +164,13 @@ async function fetchLyrics() {
     // Silently return if no lyrics are found.
     if (!foundLyrics) return;
 
-    let lrcEntryName = activeTrack.name;
+    const lrcEntryName = [activeTrack.name];
     if (activeTrack.artists)
-      lrcEntryName += ` - ${getArtistsString(activeTrack.artists)}`;
-    if (activeTrack.albumName) lrcEntryName += ` - ${activeTrack.albumName}`;
+      lrcEntryName.push(getArtistsString(activeTrack.artists));
+    if (activeTrack.albumName) lrcEntryName.push(activeTrack.albumName);
 
     const newLyric = await createLyric({
-      name: lrcEntryName,
+      name: lrcEntryName.join(" - "),
       lyrics: foundLyrics,
     });
     if (!newLyric) throw new Error("Lyric not returned after insertion.");

--- a/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
@@ -164,8 +164,13 @@ async function fetchLyrics() {
     // Silently return if no lyrics are found.
     if (!foundLyrics) return;
 
+    let lrcEntryName = activeTrack.name;
+    if (activeTrack.artists)
+      lrcEntryName += ` - ${getArtistsString(activeTrack.artists)}`;
+    if (activeTrack.albumName) lrcEntryName += ` - ${activeTrack.albumName}`;
+
     const newLyric = await createLyric({
-      name: `${activeTrack.name} - ${getArtistsString(activeTrack.artists)}`,
+      name: lrcEntryName,
       lyrics: foundLyrics,
     });
     if (!newLyric) throw new Error("Lyric not returned after insertion.");

--- a/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/LyricsOverlay.tsx
@@ -157,9 +157,11 @@ async function fetchLyrics() {
     let foundLyrics = await getLyric(activeTrack.uri);
 
     //? 2. Check for adjacent lyric files (`.lrc`).
-    const fileSlug = activeTrack.uri.split(".").slice(0, -1).join(".");
-    const adjacentLrcFile = new File(`${fileSlug}.lrc`);
-    if (adjacentLrcFile.exists) foundLyrics = await adjacentLrcFile.text();
+    if (!foundLyrics) {
+      const fileSlug = activeTrack.uri.split(".").slice(0, -1).join(".");
+      const adjacentLrcFile = new File(`${fileSlug}.lrc`);
+      if (adjacentLrcFile.exists) foundLyrics = await adjacentLrcFile.text();
+    }
 
     // Silently return if no lyrics are found.
     if (!foundLyrics) return;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds support for checking for lyrics from an adjacent `.lrc` file with the same name as the track that's being played (minus the extension).
- Validated working on both OnePlus 6 (Android 11) & Nothing Phone 2a (Android 15).
- Adjacent `.txt` files don't get scanned (most likely due to security reasons by Android), so you would need change the extension of the `.txt` file to `.lrc` in order for it to be automatically detected.

### Other Changes

- To make searching for stored lyrics easier, automatically generated entries (from embedded lyrics or the adjacent lyrics) will now also include the album name (ie: `<track name> - <artist names> - <album name>`).
- Fixed an issue where lyrics would failed to be detected as synchronized if it contained `\n\r\n`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved lyrics display by removing excess whitespace from lyrics lines
* Enhanced lyrics loading with automatic fallback to external lyrics files when embedded lyrics are unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->