### PR TITLE
feat: Lyrics QOLs

### DIFF
--- a/mobile/src/modules/lyric/components/LyricsOverlay.tsx
+++ b/mobile/src/modules/lyric/components/LyricsOverlay.tsx
@@ -6,12 +6,14 @@ import { usePolledProgress } from "react-native-audio-browser";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useLyricForTrack } from "~/data/lyric/queries";
+import { PlaybackControls } from "~/stores/Playback/actions";
 import { usePreferenceStore } from "~/stores/Preference/store";
 
 import { cn } from "~/lib/style";
 import { bgWait } from "~/utils/promise";
 import type { FlatListProps, FlatListRef } from "~/components/Base/List";
 import { FlatList, useFlatListRef } from "~/components/Base/List";
+import { Pressable } from "~/components/Base/Pressable";
 import { ExtendedTButton } from "~/components/Form/Button";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { TopDownGradient } from "~/components/Gradient";
@@ -227,24 +229,24 @@ function SynchronizedLyrics(props: { lines: string[]; offset: number }) {
   // on every render.
   const renderedLines = useMemo(
     () =>
-      parsedLines.map(({ words }, index) => {
-        if (index !== activeLineIndex) {
-          return words.reduce((prev, { word }) => prev + word, "");
-        } else {
-          return words.reduce(
-            (prev, { word }, index) => {
-              if (
-                inActiveWordStartIndex === -1 ||
-                index < inActiveWordStartIndex
-              ) {
-                prev[0] += word;
-              } else prev[1] += word;
-              return prev;
-            },
-            ["", ""] as [string, string],
-          );
-        }
-      }),
+      parsedLines.map(({ timeMS, words }, index) => ({
+        timeMS,
+        line:
+          index !== activeLineIndex
+            ? words.reduce((prev, { word }) => prev + word, "")
+            : words.reduce(
+                (prev, { word }, index) => {
+                  if (
+                    inActiveWordStartIndex === -1 ||
+                    index < inActiveWordStartIndex
+                  ) {
+                    prev[0] += word;
+                  } else prev[1] += word;
+                  return prev;
+                },
+                ["", ""] as [string, string],
+              ),
+      })),
     [parsedLines, activeLineIndex, inActiveWordStartIndex],
   );
 
@@ -262,10 +264,15 @@ function SynchronizedLyrics(props: { lines: string[]; offset: number }) {
 }
 
 //#region Memoized Lyric List
+type FormattedSynchronizedLine = {
+  timeMS: number;
+  line: string | [string, string];
+};
+
 const MemoLyricList = memo(
   function MemoLyricList(
-    props: Omit<FlatListProps<string | [string, string]>, "renderItem"> & {
-      ref: FlatListRef<string | [string, string]>;
+    props: Omit<FlatListProps<FormattedSynchronizedLine>, "renderItem"> & {
+      ref: FlatListRef<FormattedSynchronizedLine>;
       offset: number;
     },
   ) {
@@ -273,15 +280,19 @@ const MemoLyricList = memo(
       <FlatList
         {...props}
         keyExtractor={(_, index) => `${index}`}
-        renderItem={({ item }) => {
-          if (typeof item === "string") {
-            return <Em className="text-xl text-onSurfaceVariant/50">{item}</Em>;
+        renderItem={({ item: { timeMS, line } }) => {
+          if (typeof line === "string") {
+            return (
+              <Pressable onPress={() => PlaybackControls.seekTo(timeMS / 1000)}>
+                <Em className="text-xl text-onSurfaceVariant/50">{line}</Em>
+              </Pressable>
+            );
           } else {
             return (
               <Em className="text-xl">
-                {item[0]}
-                {item[1].length > 0 && (
-                  <Text className="text-onSurfaceVariant/50">{item[1]}</Text>
+                {line[0]}
+                {line[1].length > 0 && (
+                  <Text className="text-onSurfaceVariant/50">{line[1]}</Text>
                 )}
               </Em>
             );

--- a/mobile/src/modules/lyric/screens/ProviderView.tsx
+++ b/mobile/src/modules/lyric/screens/ProviderView.tsx
@@ -6,7 +6,7 @@ import { View } from "react-native";
 
 import { Icon } from "~/resources/icons";
 import { useLyricStore } from "../core/store";
-import { moveLyricProvider, toggleCheckEmbeddedLyrics } from "../core/actions";
+import { moveLyricProvider } from "../core/actions";
 import type { LyricProvider } from "../core/constants";
 
 import { ContentPlaceholder } from "~/navigation/components/Placeholder";
@@ -17,9 +17,7 @@ import { Links, openLink } from "~/lib/web-browser";
 import { Button } from "~/components/Form/Button";
 import { FilledIconButton, IconButton } from "~/components/Form/Button/Icon";
 import { ListItem } from "~/components/List";
-import { SegmentedList } from "~/components/List/Segmented";
 import { StyledText } from "~/components/Typography/StyledText";
-import { Switch } from "~/components/UI/Switch";
 
 export default function LyricsProviders() {
   const { t } = useTranslation();
@@ -96,27 +94,18 @@ function RenderItem({ item, index }: DragListRenderItemInfo<LyricProvider>) {
 
 function Instructions() {
   const { t } = useTranslation();
-  const checkEmbeddedLyrics = useLyricStore((s) => s.checkEmbedded);
-
   return (
-    <View className="mb-6 gap-6">
-      <Button
-        onPress={() => openLink(Links.LyricsProviders)}
-        className="flex-row items-start pl-2"
-      >
-        <Icon name="info" size={20} color="onSurfaceVariant" />
-        <StyledText dim className="shrink grow text-sm">
-          {t("feat.lyrics.extra.providersInstructions.line1")}
-          {"\n\n"}
-          {t("feat.lyrics.extra.providersInstructions.line2")}
-        </StyledText>
-        <Icon name="open-in-new" />
-      </Button>
-      <SegmentedList.Item
-        labelTextKey="feat.lyrics.extra.useEmbedded"
-        onPress={toggleCheckEmbeddedLyrics}
-        RightElement={<Switch enabled={checkEmbeddedLyrics} />}
-      />
-    </View>
+    <Button
+      onPress={() => openLink(Links.LyricsProviders)}
+      className="mb-6 flex-row items-start pl-2"
+    >
+      <Icon name="info" size={20} color="onSurfaceVariant" />
+      <StyledText dim className="shrink grow text-sm">
+        {t("feat.lyrics.extra.providersInstructions.line1")}
+        {"\n\n"}
+        {t("feat.lyrics.extra.providersInstructions.line2")}
+      </StyledText>
+      <Icon name="open-in-new" />
+    </Button>
   );
 }

--- a/mobile/src/modules/lyric/screens/SettingsView.tsx
+++ b/mobile/src/modules/lyric/screens/SettingsView.tsx
@@ -1,0 +1,44 @@
+import { useNavigation } from "@react-navigation/native";
+import { useTranslation } from "react-i18next";
+
+import { Icon } from "~/resources/icons";
+import { useLyricStore } from "../core/store";
+import { toggleCheckEmbeddedLyrics } from "../core/actions";
+
+import { ListLayout } from "~/navigation/layouts/ListLayout";
+
+import { SegmentedList } from "~/components/List/Segmented";
+import { Switch } from "~/components/UI/Switch";
+
+export default function LyricsSettings() {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+  const checkEmbeddedLyrics = useLyricStore((s) => s.checkEmbedded);
+
+  return (
+    <ListLayout>
+      <SegmentedList>
+        <SegmentedList.Item
+          labelTextKey="feat.lyrics.extra.providers"
+          onPress={() => navigation.navigate("LyricsProviders")}
+          LeftElement={<Icon name="search" />}
+          className="gap-4"
+        />
+        <SegmentedList.Item
+          labelText={t("template.entryManage", {
+            name: t("feat.lyrics.title"),
+          })}
+          onPress={() => navigation.navigate("Lyrics", {})}
+          LeftElement={<Icon name="lyrics" />}
+          className="gap-4"
+        />
+      </SegmentedList>
+
+      <SegmentedList.Item
+        labelTextKey="feat.lyrics.extra.useEmbedded"
+        onPress={toggleCheckEmbeddedLyrics}
+        RightElement={<Switch enabled={checkEmbeddedLyrics} />}
+      />
+    </ListLayout>
+  );
+}

--- a/mobile/src/modules/lyric/screens/index.ts
+++ b/mobile/src/modules/lyric/screens/index.ts
@@ -4,6 +4,7 @@ import Lyric from "./CurrentView";
 import ModifyLyricProvider from "./ModifyProviderView";
 import ModifyLyric from "./ModifyView";
 import LyricsProviders from "./ProviderView";
+import LyricsSettings from "./SettingsView";
 import Lyrics from "./View";
 
 const LyricScreenGroup = {
@@ -11,6 +12,11 @@ const LyricScreenGroup = {
     animation: "fade",
   },
   screens: {
+    LyricsSettings: {
+      screen: LyricsSettings,
+      options: { title: "feat.lyrics.title" },
+    },
+
     Lyrics: {
       screen: Lyrics,
       options: { title: "feat.lyrics.title" },

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -7,6 +7,8 @@ import type { Track } from "~/data/track/types";
 import { usePlaybackStore } from "~/stores/Playback/store";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { presentTrackSheet } from "~/stores/Session/actions";
+import { useLyricStore } from "~/modules/lyric/core/store";
+import { toggleLyricVisibility } from "~/modules/lyric/core/actions";
 
 import { Back } from "~/navigation/components/Back";
 import { SeekbarContext } from "./helpers/Seekbar.context";
@@ -134,10 +136,11 @@ function BottomAppBar({ trackId }: { trackId: string }) {
 
       <View className="flex-row items-center justify-between gap-4 p-4 pt-2">
         <BackButton />
-        <View className="flex-row items-center gap-1 rounded-full bg-surfaceContainerLowest">
+        <View className="flex-row items-center rounded-full bg-surfaceContainerLowest">
           <SleepTimerButton
             present={() => sleepTimerSheetRef.current?.present()}
           />
+          <LyricsButton />
           <FilledIconButton
             icon="view-agenda"
             accessibilityLabel={t("term.upcoming")}
@@ -169,6 +172,24 @@ function SleepTimerButton(props: { present: VoidFunction }) {
       }
       size="lg"
       _iconColor={sleepTimerActive ? "onSecondary" : undefined}
+    />
+  );
+}
+
+function LyricsButton() {
+  const { t } = useTranslation();
+  const lyricsActive = useLyricStore((s) => s.visible);
+  return (
+    <FilledIconButton
+      icon="lyrics"
+      accessibilityLabel={t("feat.sleepTimer.title")}
+      onPress={toggleLyricVisibility}
+      className={
+        lyricsActive
+          ? "bg-surfaceContainer active:bg-surfaceContainerHigh"
+          : undefined
+      }
+      size="lg"
     />
   );
 }

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -141,7 +141,7 @@ function BottomAppBar({ trackId }: { trackId: string }) {
           />
           <FilledIconButton
             icon="lyrics"
-            accessibilityLabel={t("feat.sleepTimer.title")}
+            accessibilityLabel={t("feat.lyrics.title")}
             onPress={toggleLyricVisibility}
             size="lg"
           />

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -7,7 +7,6 @@ import type { Track } from "~/data/track/types";
 import { usePlaybackStore } from "~/stores/Playback/store";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { presentTrackSheet } from "~/stores/Session/actions";
-import { useLyricStore } from "~/modules/lyric/core/store";
 import { toggleLyricVisibility } from "~/modules/lyric/core/actions";
 
 import { Back } from "~/navigation/components/Back";
@@ -136,11 +135,16 @@ function BottomAppBar({ trackId }: { trackId: string }) {
 
       <View className="flex-row items-center justify-between gap-4 p-4 pt-2">
         <BackButton />
-        <View className="flex-row items-center rounded-full bg-surfaceContainerLowest">
+        <View className="flex-row items-center gap-1 rounded-full bg-surfaceContainerLowest">
           <SleepTimerButton
             present={() => sleepTimerSheetRef.current?.present()}
           />
-          <LyricsButton />
+          <FilledIconButton
+            icon="lyrics"
+            accessibilityLabel={t("feat.sleepTimer.title")}
+            onPress={toggleLyricVisibility}
+            size="lg"
+          />
           <FilledIconButton
             icon="view-agenda"
             accessibilityLabel={t("term.upcoming")}
@@ -172,24 +176,6 @@ function SleepTimerButton(props: { present: VoidFunction }) {
       }
       size="lg"
       _iconColor={sleepTimerActive ? "onSecondary" : undefined}
-    />
-  );
-}
-
-function LyricsButton() {
-  const { t } = useTranslation();
-  const lyricsActive = useLyricStore((s) => s.visible);
-  return (
-    <FilledIconButton
-      icon="lyrics"
-      accessibilityLabel={t("feat.sleepTimer.title")}
-      onPress={toggleLyricVisibility}
-      className={
-        lyricsActive
-          ? "bg-surfaceContainer active:bg-surfaceContainerHigh"
-          : undefined
-      }
-      size="lg"
     />
   );
 }

--- a/mobile/src/navigation/screens/now-playing/sheets/PlaybackOptionsSheet.tsx
+++ b/mobile/src/navigation/screens/now-playing/sheets/PlaybackOptionsSheet.tsx
@@ -9,8 +9,6 @@ import {
   PreferenceSetters,
   PreferenceTogglers,
 } from "~/stores/Preference/actions";
-import { useLyricStore } from "~/modules/lyric/core/store";
-import { toggleLyricVisibility } from "~/modules/lyric/core/actions";
 
 import { getMediaLinkContext } from "~/navigation/utils/router";
 import { AppearanceSheet } from "./AppearanceSheet";
@@ -37,7 +35,6 @@ export function PlaybackOptionsSheet(props: {
   const playingSource = usePlaybackStore((s) => s.playingFrom);
   const sourceName = usePlaybackStore((s) => s.playingFromName);
   const playbackDelay = usePreferenceStore((s) => s.playbackDelay);
-  const showLyrics = useLyricStore((s) => s.visible);
   const waveformSlider = usePreferenceStore((s) => s.waveformSlider);
   const volume = usePlaybackStore((s) => s.volume);
   const appearanceSheetRef = useSheetRef();
@@ -102,17 +99,6 @@ export function PlaybackOptionsSheet(props: {
                 max={10}
                 suffix="s"
               />
-            }
-          />
-          <SheetLabelAction
-            labelKey="feat.lyrics.title"
-            RightElement={
-              <Pressable
-                onPress={toggleLyricVisibility}
-                className="h-8 justify-center"
-              >
-                <Switch enabled={showLyrics} />
-              </Pressable>
             }
           />
           <SheetLabelAction

--- a/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
@@ -1,5 +1,4 @@
 import { toast } from "@missingcore/ui/toast";
-import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 
 import { db } from "~/db";
@@ -19,7 +18,6 @@ import { Switch } from "~/components/UI/Switch";
 
 export default function ExperimentalSettings() {
   const { t } = useTranslation();
-  const navigation = useNavigation();
   const queueAwareNext = usePreferenceStore((s) => s.queueAwareNext);
   const downsamplingProcessor = usePreferenceStore(
     (s) => s.downsamplingProcessor,
@@ -55,13 +53,6 @@ export default function ExperimentalSettings() {
         labelText="Android Auto"
         onPress={() => openLink(Links.AndroidAuto)}
         RightElement={<Icon name="open-in-new" />}
-      />
-
-      <SegmentedList.Item
-        labelTextKey="feat.lyrics.extra.providers"
-        onPress={() => navigation.navigate("LyricsProviders")}
-        LeftElement={<Icon name="search" />}
-        className="gap-4"
       />
     </ListLayout>
   );

--- a/mobile/src/navigation/screens/settings/View.tsx
+++ b/mobile/src/navigation/screens/settings/View.tsx
@@ -82,7 +82,7 @@ export default function Settings() {
           />
           <SegmentedList.Item
             labelTextKey="feat.lyrics.title"
-            onPress={() => navigation.navigate("Lyrics", {})}
+            onPress={() => navigation.navigate("LyricsSettings")}
             LeftElement={<Icon name="lyrics" />}
             className="gap-4"
           />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds some QOL improvements to the lyrics feature:

- Making the toggle to display lyrics easier to access.
  - Since obtaining lyrics to be displayed is much easier as of `v3.2.0`, it makes sense to make it easier to toggle the displaying feature itself.
- Seeking to the synchronized lyric line.
  - **Seeking to a synchronized work is not supported. It will just seek to the start of the line.**

We've also redesigned the screen you get brought to when clicking the "Lyrics" button on the settings screen. All of the "lyric" related features/options are now displayed here:
- Lyrics Providers (still experimental)
- Managing lyrics (basically the old screen contents)
- Enabling using embedded lyrics

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive seeking within synchronized lyrics by tapping the current line
  * Added a dedicated lyrics settings screen to manage providers and embedded lyrics
  * Added a quick “lyrics” visibility toggle button on the now playing screen
* **Refactoring**
  * Updated synchronized lyrics rendering to support precise tap-to-seek behavior
* **UI/Behavior Updates**
  * Removed embedded-lyrics toggle from the providers and playback options flows
  * Updated Settings navigation to open the new lyrics settings route
<!-- end of auto-generated comment: release notes by coderabbit.ai -->