### PR TITLE
chore: Add SPDX license header to project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ The [full list of translators can be found here](./TRANSLATORS.md). A huge thank
 
 # Legal
 
-This application and code is published under the GNU Affero General Public License v3.0 (https://github.com/MissingCore/Music/blob/main/LICENSE).
-
 Nothing Technology Limited or any of its affiliates, subsidiaries, or related entities (collectively, "Nothing Technology") is a valid licensee and can use this app for any purpose, including commercial purposes, without compensation to the developers of this app. Nothing Technology is not required to comply with the terms of the GNU Affero General Public License v3.0.
 
 This app is developed by cyanChill and is not affiliated with, funded, authorized, endorsed by, or in any way associated with Nothing Technology or any of its affiliates and subsidiaries. Any trademark, service mark, trade name, or other intellectual property rights used in this project are owned by the respective owners.
@@ -201,7 +199,22 @@ Refer to [THIRD_PARTY.md](./THIRD_PARTY.md).
 
 ## License
 
-[AGPL-3.0](./LICENSE)
+Copyright (C) 2024 - present, MissingCore
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+See [LICENSE](./LICENSE) for the full license text.
 
 ## Privacy Policy
 

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import navigationBarPlugin from "@zoontek/react-native-navigation-bar/expo";
 import type { ExpoConfig } from "expo/config";
 import fontPlugin from "expo-font/plugin";

--- a/mobile/index.ts
+++ b/mobile/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /* Polyfills */
 import "intl-pluralrules";
 

--- a/mobile/modules/ui/LICENSE
+++ b/mobile/modules/ui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MissingCore <missingcoredev@outlook.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mobile/scripts/licenses/updateLicenses.mjs
+++ b/mobile/scripts/licenses/updateLicenses.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { neatJSON } from "neatjson";
 import fs from "node:fs";
 import path from "node:path";

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useEffect, useMemo, useState } from "react";
 import { View } from "react-native";
 import Bootsplash from "react-native-bootsplash";

--- a/mobile/src/components/Base/AnimatedMaterialSymbol.tsx
+++ b/mobile/src/components/Base/AnimatedMaterialSymbol.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import Animated from "react-native-reanimated";
 import { Path, Svg } from "react-native-svg";
 

--- a/mobile/src/components/Base/GestureHandlerRootView.tsx
+++ b/mobile/src/components/Base/GestureHandlerRootView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { GestureHandlerRootView as RawGestureHandlerRootView } from "react-native-gesture-handler";
 import { withUniwind } from "uniwind";
 

--- a/mobile/src/components/Base/LegendList.tsx
+++ b/mobile/src/components/Base/LegendList.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type {
   LegendListRef as RawLegendListRef,
   LegendListRenderItemProps,

--- a/mobile/src/components/Base/List.tsx
+++ b/mobile/src/components/Base/List.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useRef } from "react";
 import type { ListRenderItemInfo as RawListRenderItemInfo } from "react-native";
 import type {

--- a/mobile/src/components/Base/Pressable.tsx
+++ b/mobile/src/components/Base/Pressable.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { PressableProps as RNPressableProps } from "react-native";
 import { Pressable as RNPresasble } from "react-native";
 

--- a/mobile/src/components/Base/ScrollView.tsx
+++ b/mobile/src/components/Base/ScrollView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useRef } from "react";
 import type { KeyboardAwareScrollViewProps } from "react-native-keyboard-controller";
 import { KeyboardAwareScrollView as RawKeyboardAwareScrollView } from "react-native-keyboard-controller";

--- a/mobile/src/components/Divider.tsx
+++ b/mobile/src/components/Divider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { View } from "react-native";
 
 import { cn } from "~/lib/style";

--- a/mobile/src/components/Form/Button/Icon.tsx
+++ b/mobile/src/components/Form/Button/Icon.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo } from "react";
 import { View } from "react-native";
 

--- a/mobile/src/components/Form/Button/index.tsx
+++ b/mobile/src/components/Form/Button/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { memo } from "react";
 

--- a/mobile/src/components/Form/Button/types.ts
+++ b/mobile/src/components/Form/Button/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { PressableProps } from "../../Base/Pressable";
 
 /** The most "used" action props used on `<Pressable />`. */

--- a/mobile/src/components/Form/Checkbox.tsx
+++ b/mobile/src/components/Form/Checkbox.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { memo } from "react";
 import { View } from "react-native";

--- a/mobile/src/components/Form/Input.tsx
+++ b/mobile/src/components/Form/Input.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo, useRef } from "react";
 import type { TextInputProps } from "react-native";
 import { TextInput as RNTextInput } from "react-native";

--- a/mobile/src/components/Form/NumberStepper.tsx
+++ b/mobile/src/components/Form/NumberStepper.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/components/Form/Radio.tsx
+++ b/mobile/src/components/Form/Radio.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo } from "react";
 import { View } from "react-native";
 

--- a/mobile/src/components/Form/SegmentedPicker.tsx
+++ b/mobile/src/components/Form/SegmentedPicker.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { View } from "react-native";
 import Animated, {
   useAnimatedStyle,

--- a/mobile/src/components/Form/Slider.tsx
+++ b/mobile/src/components/Form/Slider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import type { Dispatch, SetStateAction } from "react";
 import { memo, useCallback, useMemo, useRef, useState } from "react";

--- a/mobile/src/components/Gradient.tsx
+++ b/mobile/src/components/Gradient.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { LinearGradient } from "expo-linear-gradient";
 import { useMemo } from "react";
 

--- a/mobile/src/components/List/ListItemContent.tsx
+++ b/mobile/src/components/List/ListItemContent.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/components/List/RemovableItem.tsx
+++ b/mobile/src/components/List/RemovableItem.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/components/List/Segmented.tsx
+++ b/mobile/src/components/List/Segmented.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import React, { createContext, memo, use, useMemo } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 import { View } from "react-native";

--- a/mobile/src/components/List/index.tsx
+++ b/mobile/src/components/List/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useMemo } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 import { View } from "react-native";

--- a/mobile/src/components/Marquee.tsx
+++ b/mobile/src/components/Marquee.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { LinearGradient } from "expo-linear-gradient";
 import Animated, {
   Easing,

--- a/mobile/src/components/Menu.tsx
+++ b/mobile/src/components/Menu.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Portal } from "@rn-primitives/portal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ViewStyle } from "react-native";

--- a/mobile/src/components/Modal.tsx
+++ b/mobile/src/components/Modal.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useState } from "react";
 import { Modal as RNModal, View } from "react-native";

--- a/mobile/src/components/NScrollbar.tsx
+++ b/mobile/src/components/NScrollbar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useCallback, useMemo, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import {

--- a/mobile/src/components/SafeContainer.tsx
+++ b/mobile/src/components/SafeContainer.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ViewProps } from "react-native";
 import { View } from "react-native";
 import type { AnimatedProps } from "react-native-reanimated";

--- a/mobile/src/components/Sheet/DetachedDimView.tsx
+++ b/mobile/src/components/Sheet/DetachedDimView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { PositionChangeEvent } from "@lodev09/react-native-true-sheet";
 import { useMemo } from "react";
 import type { SharedValue } from "react-native-reanimated";

--- a/mobile/src/components/Sheet/Numeric.tsx
+++ b/mobile/src/components/Sheet/Numeric.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useCallback, useEffect, useState } from "react";
 import { Keyboard } from "react-native";

--- a/mobile/src/components/Sheet/SheetButtonGroup.tsx
+++ b/mobile/src/components/Sheet/SheetButtonGroup.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { View } from "react-native";
 
 import { cn } from "~/lib/style";

--- a/mobile/src/components/Sheet/SheetLabelAction.tsx
+++ b/mobile/src/components/Sheet/SheetLabelAction.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { View } from "react-native";
 

--- a/mobile/src/components/Sheet/index.tsx
+++ b/mobile/src/components/Sheet/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { TrueSheetProps } from "@lodev09/react-native-true-sheet";
 import { TrueSheet } from "@lodev09/react-native-true-sheet";
 import type { ParseKeys } from "i18next";

--- a/mobile/src/components/Sheet/useEnableSheetScroll.ts
+++ b/mobile/src/components/Sheet/useEnableSheetScroll.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo, useRef, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 

--- a/mobile/src/components/Sheet/useSheetRef.ts
+++ b/mobile/src/components/Sheet/useSheetRef.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { TrueSheet } from "@lodev09/react-native-true-sheet";
 import { useRef } from "react";
 

--- a/mobile/src/components/Swipeable.tsx
+++ b/mobile/src/components/Swipeable.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import { Animated, View } from "react-native";

--- a/mobile/src/components/Typography/AccentText.tsx
+++ b/mobile/src/components/Typography/AccentText.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { TextProps } from "react-native";
 import { Text } from "react-native";
 

--- a/mobile/src/components/Typography/StyledText.tsx
+++ b/mobile/src/components/Typography/StyledText.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import type { TextProps } from "react-native";

--- a/mobile/src/components/UI/Legend.tsx
+++ b/mobile/src/components/UI/Legend.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { memo } from "react";
 import { View } from "react-native";

--- a/mobile/src/components/UI/ProgressBar.tsx
+++ b/mobile/src/components/UI/ProgressBar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useState } from "react";
 import { View } from "react-native";
 import Animated from "react-native-reanimated";

--- a/mobile/src/components/UI/Switch.tsx
+++ b/mobile/src/components/UI/Switch.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import Animated, {
   useAnimatedStyle,
   withTiming,

--- a/mobile/src/constants/Styles.ts
+++ b/mobile/src/constants/Styles.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import colors from "tailwindcss/colors";
 
 export const BorderRadius = {

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   and,
   count,

--- a/mobile/src/data/album/queries.ts
+++ b/mobile/src/data/album/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/data/album/types.ts
+++ b/mobile/src/data/album/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { CommonTrack } from "../types";
 
 export type AlbumTrack = CommonTrack & {

--- a/mobile/src/data/album/utils.ts
+++ b/mobile/src/data/album/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const KEY_SEPARATOR = "[joiner]";
 
 /** Helper functions for generating & using `artistsKey`. */

--- a/mobile/src/data/artist/api.ts
+++ b/mobile/src/data/artist/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { count, eq, getTableColumns, sql, sum } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/artist/queries.ts
+++ b/mobile/src/data/artist/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/data/artist/types.ts
+++ b/mobile/src/data/artist/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export type ArtistAlbum = {
   id: string;
   name: string;

--- a/mobile/src/data/artist/utils.ts
+++ b/mobile/src/data/artist/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Maybe } from "~/utils/types";
 
 /** Generate a string listing out all the artists. */

--- a/mobile/src/data/favorite/api.ts
+++ b/mobile/src/data/favorite/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { eq } from "drizzle-orm";
 
 import { albums, playlists } from "~/db/schema";

--- a/mobile/src/data/favorite/queries.ts
+++ b/mobile/src/data/favorite/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/data/folder/api.ts
+++ b/mobile/src/data/folder/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { and, eq, exists, isNull, like, sql } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/folder/queries.ts
+++ b/mobile/src/data/folder/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 
 import { useViewPreferenceStore } from "~/stores/ViewPreference/store";

--- a/mobile/src/data/genre/api.ts
+++ b/mobile/src/data/genre/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { count, eq, getTableColumns, sum } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/genre/queries.ts
+++ b/mobile/src/data/genre/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/data/keyStore.ts
+++ b/mobile/src/data/keyStore.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { queryOptions } from "@tanstack/react-query";
 import { ne } from "drizzle-orm";
 

--- a/mobile/src/data/lyric/api.ts
+++ b/mobile/src/data/lyric/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { count, eq, getTableColumns } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/lyric/queries.ts
+++ b/mobile/src/data/lyric/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 
 import { queries as q } from "../keyStore";

--- a/mobile/src/data/playlist/api.ts
+++ b/mobile/src/data/playlist/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { and, count, eq, getTableColumns, sql, sum } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/playlist/queries.ts
+++ b/mobile/src/data/playlist/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/data/playlist/types.ts
+++ b/mobile/src/data/playlist/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { MediaImage } from "~/modules/media/components/MediaImage";
 
 export type PlaylistSummary = {

--- a/mobile/src/data/playlist/utils.ts
+++ b/mobile/src/data/playlist/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import i18next from "~/modules/i18n";
 
 import { ReservedNames } from "~/modules/media/constants";

--- a/mobile/src/data/recent/api.ts
+++ b/mobile/src/data/recent/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { and, eq, gt, sql } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/recent/queries.ts
+++ b/mobile/src/data/recent/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 
 import { getRecentMedia } from "./api";

--- a/mobile/src/data/track/api.ts
+++ b/mobile/src/data/track/api.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { and, eq, inArray } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/data/track/constants.ts
+++ b/mobile/src/data/track/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   tracksToArtists,
   tracksToGenres,

--- a/mobile/src/data/track/queries.ts
+++ b/mobile/src/data/track/queries.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { db } from "~/db";

--- a/mobile/src/data/track/types.ts
+++ b/mobile/src/data/track/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { tracks } from "~/db/schema";
 
 import type { Prettify } from "~/utils/types";

--- a/mobile/src/data/track/utils.ts
+++ b/mobile/src/data/track/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * Merge 2 lists of tracks. Tracks that appear in both lists will result
  * in the latest instance of the track being merged so that there'll be

--- a/mobile/src/data/types.ts
+++ b/mobile/src/data/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { SQLWrapper } from "drizzle-orm";
 
 import type { ScreenSortOptions } from "~/stores/ViewPreference/constants";

--- a/mobile/src/data/utils.ts
+++ b/mobile/src/data/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { viewPreferenceStore } from "~/stores/ViewPreference/store";
 import type { MutableTrackOrder } from "~/stores/ViewPreference/types";
 

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { eq, getTableColumns, sql } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/db/index.ts
+++ b/mobile/src/db/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { drizzle } from "drizzle-orm/expo-sqlite";
 import { migrate } from "drizzle-orm/expo-sqlite/migrator";
 import { openDatabaseSync } from "expo-sqlite";

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createId } from "@paralleldrive/cuid2";
 import type { InferSelectModel, SQL } from "drizzle-orm";
 import { relations, sql } from "drizzle-orm";

--- a/mobile/src/env/index.ts
+++ b/mobile/src/env/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Indicates whether the app is `__DEV__`. */
 export const IS_DEV = __DEV__;
 

--- a/mobile/src/global.css
+++ b/mobile/src/global.css
@@ -1,3 +1,8 @@
+/*
+  Copyright (C) 2024 - present, MissingCore
+  SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 @import "tailwindcss";
 @import "uniwind";
 

--- a/mobile/src/hooks/useDelayedReady.ts
+++ b/mobile/src/hooks/useDelayedReady.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useEffect, useState } from "react";
 
 /** Sends a "Ready" signal after a delay. */

--- a/mobile/src/hooks/useGetColumn.ts
+++ b/mobile/src/hooks/useGetColumn.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useWindowDimensions } from "react-native";
 
 export type GCWProps = {

--- a/mobile/src/hooks/useSafeAreaHeight.ts
+++ b/mobile/src/hooks/useSafeAreaHeight.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 

--- a/mobile/src/initServices.ts
+++ b/mobile/src/initServices.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import BackgroundTimer from "@boterop/react-native-background-timer";
 import { toast } from "@missingcore/ui/toast";
 import AsyncStorage from "expo-sqlite/kv-store";

--- a/mobile/src/lib/device.ts
+++ b/mobile/src/lib/device.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Platform } from "react-native";
 
 /**

--- a/mobile/src/lib/drizzle.ts
+++ b/mobile/src/lib/drizzle.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ColumnsSelection, SQLWrapper } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import { toSnakeCase } from "drizzle-orm/casing";

--- a/mobile/src/lib/file-system.ts
+++ b/mobile/src/lib/file-system.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { saveBundledAssetToURI } from "@missingcore/native-utils";
 import { Directory, File, Paths } from "expo-file-system";
 import { ImageManipulator, SaveFormat } from "expo-image-manipulator";

--- a/mobile/src/lib/react-native-audio-browser.ts
+++ b/mobile/src/lib/react-native-audio-browser.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { UpdateOptions } from "react-native-audio-browser";
 import AudioBrowser from "react-native-audio-browser";
 

--- a/mobile/src/lib/react-query.ts
+++ b/mobile/src/lib/react-query.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type {
   DefaultOptions,
   UseMutationResult,

--- a/mobile/src/lib/react.ts
+++ b/mobile/src/lib/react.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { I18nManager } from "react-native";
 
 export const OnRTL = {

--- a/mobile/src/lib/sentry.ts
+++ b/mobile/src/lib/sentry.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 let Sentry: any;
 
 /*

--- a/mobile/src/lib/style.ts
+++ b/mobile/src/lib/style.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 import { extendTailwindMerge } from "tailwind-merge";

--- a/mobile/src/lib/web-browser.ts
+++ b/mobile/src/lib/web-browser.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Linking } from "react-native";
 
 import { APP_VERSION } from "~/constants/Config";

--- a/mobile/src/lib/zustand.ts
+++ b/mobile/src/lib/zustand.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AsyncStorage from "expo-sqlite/kv-store";
 import type { StateCreator } from "zustand";
 import type { PersistOptions } from "zustand/middleware";

--- a/mobile/src/modules/audio/_components/AudioEffectSlider.tsx
+++ b/mobile/src/modules/audio/_components/AudioEffectSlider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { View } from "react-native";
 
 import type { SupportedIconName } from "~/resources/icons";

--- a/mobile/src/modules/audio/_components/PlaybackParameterSettings.tsx
+++ b/mobile/src/modules/audio/_components/PlaybackParameterSettings.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AudioBrowser from "react-native-audio-browser";
 
 import { SegmentedList } from "~/components/List/Segmented";

--- a/mobile/src/modules/audio/_components/PlaybackParameterSlider.tsx
+++ b/mobile/src/modules/audio/_components/PlaybackParameterSlider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useCallback, useMemo } from "react";
 import { View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";

--- a/mobile/src/modules/audio/_components/VolumeSettings.tsx
+++ b/mobile/src/modules/audio/_components/VolumeSettings.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useState } from "react";
 import AudioBrowser from "react-native-audio-browser";
 import { useAnimatedReaction, useSharedValue } from "react-native-reanimated";

--- a/mobile/src/modules/audio/_screens.tsx
+++ b/mobile/src/modules/audio/_screens.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 
 import { ListLayout } from "~/navigation/layouts/ListLayout";

--- a/mobile/src/modules/audio/equalizer/components/EQGraph.tsx
+++ b/mobile/src/modules/audio/equalizer/components/EQGraph.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createContext, use, useMemo, useState } from "react";
 import { View } from "react-native";
 import {

--- a/mobile/src/modules/audio/equalizer/components/EqualizerSettings.tsx
+++ b/mobile/src/modules/audio/equalizer/components/EqualizerSettings.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useMemo } from "react";
 import { View } from "react-native";

--- a/mobile/src/modules/audio/equalizer/components/FrequencySlider.tsx
+++ b/mobile/src/modules/audio/equalizer/components/FrequencySlider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useState } from "react";
 import { View } from "react-native";
 import { useAnimatedReaction, useSharedValue } from "react-native-reanimated";

--- a/mobile/src/modules/audio/equalizer/core/actions.ts
+++ b/mobile/src/modules/audio/equalizer/core/actions.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AudioBrowser from "react-native-audio-browser";
 
 import { equalizerStore } from "./store";

--- a/mobile/src/modules/audio/equalizer/core/constants.ts
+++ b/mobile/src/modules/audio/equalizer/core/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export type EQPreset =
   | "Custom"
   | "Normal"

--- a/mobile/src/modules/audio/equalizer/core/store.ts
+++ b/mobile/src/modules/audio/equalizer/core/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useStore } from "zustand";
 
 import { createPersistedStore } from "~/lib/zustand";

--- a/mobile/src/modules/audio/replayGain/components/PreAmpSlider.tsx
+++ b/mobile/src/modules/audio/replayGain/components/PreAmpSlider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo } from "react";
 import { View } from "react-native";
 

--- a/mobile/src/modules/audio/replayGain/components/ReplayGainSettings.tsx
+++ b/mobile/src/modules/audio/replayGain/components/ReplayGainSettings.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { View } from "react-native";
 
 import { usePlaybackStore } from "~/stores/Playback/store";

--- a/mobile/src/modules/audio/replayGain/core/actions.ts
+++ b/mobile/src/modules/audio/replayGain/core/actions.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AudioBrowser from "react-native-audio-browser";
 
 import { playbackStore } from "~/stores/Playback/store";

--- a/mobile/src/modules/audio/replayGain/core/apply.ts
+++ b/mobile/src/modules/audio/replayGain/core/apply.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getR128Gain } from "@missingcore/react-native-metadata-retriever";
 import type { Track as AddTrack } from "react-native-audio-browser";
 

--- a/mobile/src/modules/audio/replayGain/core/constants.ts
+++ b/mobile/src/modules/audio/replayGain/core/constants.ts
@@ -1,2 +1,5 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** The min & max dB we can offset the ReplayGain by. */
 export const DB_OFFSET = { min: -15, max: 15 };

--- a/mobile/src/modules/backup/JSON.ts
+++ b/mobile/src/modules/backup/JSON.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useMutation } from "@tanstack/react-query";
 import { eq, inArray } from "drizzle-orm";

--- a/mobile/src/modules/backup/M3U.ts
+++ b/mobile/src/modules/backup/M3U.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getActualPath } from "@missingcore/react-native-actual-path";
 import { inArray } from "drizzle-orm";
 import { Paths } from "expo-file-system";

--- a/mobile/src/modules/customization/font/core/constants.ts
+++ b/mobile/src/modules/customization/font/core/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { CustomFont } from "~/db/schema";
 
 //#region Bundled Fonts

--- a/mobile/src/modules/customization/font/core/data.ts
+++ b/mobile/src/modules/customization/font/core/data.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { createId } from "@paralleldrive/cuid2";
 import { useQuery } from "@tanstack/react-query";

--- a/mobile/src/modules/customization/font/screens/CreateView.tsx
+++ b/mobile/src/modules/customization/font/screens/CreateView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";

--- a/mobile/src/modules/customization/font/screens/View.tsx
+++ b/mobile/src/modules/customization/font/screens/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/modules/customization/font/screens/index.ts
+++ b/mobile/src/modules/customization/font/screens/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import CreateFont from "./CreateView";
 import { AccentFonts, PrimaryFonts } from "./View";
 

--- a/mobile/src/modules/customization/font/utils.ts
+++ b/mobile/src/modules/customization/font/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { loadAsync as loadFontsAsync } from "expo-font";
 
 import { toLowerCase, removeFileExtension } from "~/utils/string";

--- a/mobile/src/modules/customization/theme/components/ColorPicker.tsx
+++ b/mobile/src/modules/customization/theme/components/ColorPicker.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { LinearGradient } from "expo-linear-gradient";
 import { useCallback, useEffect } from "react";
 import { View } from "react-native";

--- a/mobile/src/modules/customization/theme/components/ColorPickerInput.tsx
+++ b/mobile/src/modules/customization/theme/components/ColorPickerInput.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useState } from "react";
 import { View } from "react-native";
 

--- a/mobile/src/modules/customization/theme/components/ModifyViewBase.tsx
+++ b/mobile/src/modules/customization/theme/components/ModifyViewBase.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { View } from "react-native";
 import { z } from "zod/mini";

--- a/mobile/src/modules/customization/theme/core/constants.ts
+++ b/mobile/src/modules/customization/theme/core/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { isSystemDarkMode } from "@missingcore/native-utils";
 
 import { Colors } from "~/constants/Styles";

--- a/mobile/src/modules/customization/theme/core/data.ts
+++ b/mobile/src/modules/customization/theme/core/data.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { eq } from "drizzle-orm";
 import { z } from "zod/mini";

--- a/mobile/src/modules/customization/theme/core/utils.ts
+++ b/mobile/src/modules/customization/theme/core/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { z } from "zod/mini";
 
 import { ZSchema } from "~/modules/form/utils";

--- a/mobile/src/modules/customization/theme/hooks.ts
+++ b/mobile/src/modules/customization/theme/hooks.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { useColorScheme } from "react-native";
 

--- a/mobile/src/modules/customization/theme/screens/CreateView.tsx
+++ b/mobile/src/modules/customization/theme/screens/CreateView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useNavigation } from "@react-navigation/native";
 

--- a/mobile/src/modules/customization/theme/screens/ModifyView.tsx
+++ b/mobile/src/modules/customization/theme/screens/ModifyView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";

--- a/mobile/src/modules/customization/theme/screens/View.tsx
+++ b/mobile/src/modules/customization/theme/screens/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";

--- a/mobile/src/modules/customization/theme/screens/index.ts
+++ b/mobile/src/modules/customization/theme/screens/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import CreateTheme from "./CreateView";
 import ModifyTheme from "./ModifyView";
 import Themes from "./View";

--- a/mobile/src/modules/customization/theme/utils.ts
+++ b/mobile/src/modules/customization/theme/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Uniwind } from "uniwind";
 import { Appearance } from "react-native";
 

--- a/mobile/src/modules/form/FormState/FormInput.tsx
+++ b/mobile/src/modules/form/FormState/FormInput.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/modules/form/FormState/index.tsx
+++ b/mobile/src/modules/form/FormState/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import type { ParseKeys } from "i18next";
 import type { Dispatch, SetStateAction } from "react";

--- a/mobile/src/modules/form/useInputForm.ts
+++ b/mobile/src/modules/form/useInputForm.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { wait } from "~/utils/promise";

--- a/mobile/src/modules/form/utils.ts
+++ b/mobile/src/modules/form/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { z } from "zod/mini";
 
 /** Reusable pre-defined Zod Mini schemas. */

--- a/mobile/src/modules/i18n/constants.ts
+++ b/mobile/src/modules/i18n/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 type LanguageItem = {
   code: string;
   name: string;

--- a/mobile/src/modules/i18n/index.ts
+++ b/mobile/src/modules/i18n/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 

--- a/mobile/src/modules/i18n/translations/resources.ts
+++ b/mobile/src/modules/i18n/translations/resources.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import ar from "./ar.json";
 import ca from "./ca.json";
 import da from "./da.json";

--- a/mobile/src/modules/lyric/components/LyricsOverlay.tsx
+++ b/mobile/src/modules/lyric/components/LyricsOverlay.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/modules/lyric/components/ModifyProviderViewBase.tsx
+++ b/mobile/src/modules/lyric/components/ModifyProviderViewBase.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { z } from "zod/mini";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";

--- a/mobile/src/modules/lyric/components/ModifyViewBase.tsx
+++ b/mobile/src/modules/lyric/components/ModifyViewBase.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { z } from "zod/mini";
 
 import { useFloatingContent } from "~/navigation/hooks/useFloatingContent";

--- a/mobile/src/modules/lyric/core/actions.ts
+++ b/mobile/src/modules/lyric/core/actions.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createId } from "@paralleldrive/cuid2";
 
 import { lyricStore } from "./store";

--- a/mobile/src/modules/lyric/core/constants.ts
+++ b/mobile/src/modules/lyric/core/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export interface LyricProvider {
   id: string;
   name: string;

--- a/mobile/src/modules/lyric/core/data.ts
+++ b/mobile/src/modules/lyric/core/data.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getArtistsString } from "~/data/artist/utils";
 import type { Track } from "~/data/track/types";
 

--- a/mobile/src/modules/lyric/core/store.ts
+++ b/mobile/src/modules/lyric/core/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useStore } from "zustand";
 
 import { createPersistedStore } from "~/lib/zustand";

--- a/mobile/src/modules/lyric/helpers/autoDiscoverLyrics.ts
+++ b/mobile/src/modules/lyric/helpers/autoDiscoverLyrics.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getLyric } from "@missingcore/react-native-metadata-retriever";
 import { File } from "expo-file-system";
 

--- a/mobile/src/modules/lyric/helpers/cleanUpLyricsJunk.ts
+++ b/mobile/src/modules/lyric/helpers/cleanUpLyricsJunk.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { eq } from "drizzle-orm";
 
 import { db } from "~/db";

--- a/mobile/src/modules/lyric/helpers/linkTrackToLyric.ts
+++ b/mobile/src/modules/lyric/helpers/linkTrackToLyric.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 
 import { db } from "~/db";

--- a/mobile/src/modules/lyric/screens/CreateProviderView.tsx
+++ b/mobile/src/modules/lyric/screens/CreateProviderView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 

--- a/mobile/src/modules/lyric/screens/CreateView.tsx
+++ b/mobile/src/modules/lyric/screens/CreateView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";

--- a/mobile/src/modules/lyric/screens/CurrentView.tsx
+++ b/mobile/src/modules/lyric/screens/CurrentView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
 import { eq } from "drizzle-orm";

--- a/mobile/src/modules/lyric/screens/ModifyProviderView.tsx
+++ b/mobile/src/modules/lyric/screens/ModifyProviderView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
 

--- a/mobile/src/modules/lyric/screens/ModifyView.tsx
+++ b/mobile/src/modules/lyric/screens/ModifyView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";

--- a/mobile/src/modules/lyric/screens/ProviderView.tsx
+++ b/mobile/src/modules/lyric/screens/ProviderView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { DragListRenderItemInfo } from "@missingcore/ui/drag-list";
 import { DragList, useDragListState } from "@missingcore/ui/drag-list";
 import { useNavigation } from "@react-navigation/native";

--- a/mobile/src/modules/lyric/screens/SettingsView.tsx
+++ b/mobile/src/modules/lyric/screens/SettingsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/modules/lyric/screens/View.tsx
+++ b/mobile/src/modules/lyric/screens/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/modules/lyric/screens/index.ts
+++ b/mobile/src/modules/lyric/screens/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import CreateLyricProvider from "./CreateProviderView";
 import CreateLyric from "./CreateView";
 import Lyric from "./CurrentView";

--- a/mobile/src/modules/lyric/sheets/LinkTracksSheet.tsx
+++ b/mobile/src/modules/lyric/sheets/LinkTracksSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getArtistsString } from "~/data/artist/utils";
 
 import { DetachedSheet } from "~/components/Sheet";

--- a/mobile/src/modules/media/components/AnimatedBars.tsx
+++ b/mobile/src/modules/media/components/AnimatedBars.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo } from "react";
 import { View } from "react-native";
 import Animated from "react-native-reanimated";

--- a/mobile/src/modules/media/components/ArtistsLink.tsx
+++ b/mobile/src/modules/media/components/ArtistsLink.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 
 import {

--- a/mobile/src/modules/media/components/MediaCard.tsx
+++ b/mobile/src/modules/media/components/MediaCard.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";
 

--- a/mobile/src/modules/media/components/MediaCard.type.ts
+++ b/mobile/src/modules/media/components/MediaCard.type.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Prettify } from "~/utils/types";
 import type { MediaImage } from "./MediaImage";
 

--- a/mobile/src/modules/media/components/MediaControls.tsx
+++ b/mobile/src/modules/media/components/MediaControls.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useTranslation } from "react-i18next";
 
 import { usePlaybackStore } from "~/stores/Playback/store";

--- a/mobile/src/modules/media/components/MediaImage.tsx
+++ b/mobile/src/modules/media/components/MediaImage.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Image as ExpoImage } from "expo-image";
 import { useMemo } from "react";
 import { View } from "react-native";

--- a/mobile/src/modules/media/components/MediaListControls.tsx
+++ b/mobile/src/modules/media/components/MediaListControls.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 

--- a/mobile/src/modules/media/components/Track.tsx
+++ b/mobile/src/modules/media/components/Track.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/modules/media/components/Track.type.ts
+++ b/mobile/src/modules/media/components/Track.type.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Prettify } from "~/utils/types";
 import type { SearchResult } from "~/modules/search/components/SearchResult";
 import type { PlayFromSource } from "~/stores/Playback/types";

--- a/mobile/src/modules/media/components/Vinyl.tsx
+++ b/mobile/src/modules/media/components/Vinyl.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { View } from "react-native";
 import type { CircleProps } from "react-native-svg";

--- a/mobile/src/modules/media/constants.ts
+++ b/mobile/src/modules/media/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const FavoritesPlaylistKey = "favorites";
 
 /** Names of playlists a user can't create. */

--- a/mobile/src/modules/media/multiSelect/components/AddToCreatedPlaylistSheet.tsx
+++ b/mobile/src/modules/media/multiSelect/components/AddToCreatedPlaylistSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/modules/media/multiSelect/components/AddToPlaylistsSheet.tsx
+++ b/mobile/src/modules/media/multiSelect/components/AddToPlaylistsSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useCallback, useEffect, useState } from "react";
 

--- a/mobile/src/modules/media/multiSelect/components/TrackMultiSelectListeners.tsx
+++ b/mobile/src/modules/media/multiSelect/components/TrackMultiSelectListeners.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation, useNavigationState } from "@react-navigation/native";
 import { Portal } from "@rn-primitives/portal";
 import { useEffect, useMemo } from "react";

--- a/mobile/src/modules/media/multiSelect/core/actions.ts
+++ b/mobile/src/modules/media/multiSelect/core/actions.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 
 import { db } from "~/db";

--- a/mobile/src/modules/media/multiSelect/core/store.ts
+++ b/mobile/src/modules/media/multiSelect/core/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 

--- a/mobile/src/modules/scanning/ScanningProgress.ts
+++ b/mobile/src/modules/scanning/ScanningProgress.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 

--- a/mobile/src/modules/scanning/components/OnboardingConfigurationView.tsx
+++ b/mobile/src/modules/scanning/components/OnboardingConfigurationView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useTranslation } from "react-i18next";
 import Animated, { FadeIn } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";

--- a/mobile/src/modules/scanning/components/ScanningProgressView.tsx
+++ b/mobile/src/modules/scanning/components/ScanningProgressView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useEffect } from "react";
 import { Dimensions, View } from "react-native";

--- a/mobile/src/modules/scanning/constants.ts
+++ b/mobile/src/modules/scanning/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export type MigrationOption =
   | "fileNodes-adjustment"
   | "discover-time-field"

--- a/mobile/src/modules/scanning/helpers/artwork.ts
+++ b/mobile/src/modules/scanning/helpers/artwork.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   SaveFormat,
   saveArtwork,

--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Asset } from "@missingcore/native-utils/media";
 import { getAudioAssets } from "@missingcore/native-utils/media";
 import {

--- a/mobile/src/modules/scanning/helpers/cleanup.ts
+++ b/mobile/src/modules/scanning/helpers/cleanup.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { inArray, isNotNull, lt } from "drizzle-orm";
 import { Directory } from "expo-file-system";
 

--- a/mobile/src/modules/scanning/helpers/migrations.ts
+++ b/mobile/src/modules/scanning/helpers/migrations.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { eq, inArray } from "drizzle-orm";
 import AsyncStorage from "expo-sqlite/kv-store";
 

--- a/mobile/src/modules/scanning/helpers/rescan.ts
+++ b/mobile/src/modules/scanning/helpers/rescan.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useMutation } from "@tanstack/react-query";
 import { and, eq, isNull } from "drizzle-orm";

--- a/mobile/src/modules/scanning/hooks/useLoadResources.ts
+++ b/mobile/src/modules/scanning/hooks/useLoadResources.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import { useDrizzleStudio } from "expo-drizzle-studio-plugin";
 import type { SQLiteDatabase } from "expo-sqlite";

--- a/mobile/src/modules/scanning/hooks/useScanning.ts
+++ b/mobile/src/modules/scanning/hooks/useScanning.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMediaLibraryPermissions } from "@missingcore/native-utils/media";
 import { useCallback, useEffect, useState } from "react";
 

--- a/mobile/src/modules/scanning/hooks/useSetup.ts
+++ b/mobile/src/modules/scanning/hooks/useSetup.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useEffect, useState } from "react";
 import AudioBrowser from "react-native-audio-browser";
 

--- a/mobile/src/modules/search/components/SearchBar.tsx
+++ b/mobile/src/modules/search/components/SearchBar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 

--- a/mobile/src/modules/search/components/SearchEngine.tsx
+++ b/mobile/src/modules/search/components/SearchEngine.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/modules/search/components/SearchList.tsx
+++ b/mobile/src/modules/search/components/SearchList.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/modules/search/components/SearchResult.tsx
+++ b/mobile/src/modules/search/components/SearchResult.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { PressProps } from "~/components/Form/Button/types";
 import { ListItem } from "~/components/List";
 import { MediaImage } from "~/modules/media/components/MediaImage";

--- a/mobile/src/modules/search/hooks/useSearch.ts
+++ b/mobile/src/modules/search/hooks/useSearch.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { ne } from "drizzle-orm";
 import { useEffect, useRef, useState } from "react";

--- a/mobile/src/modules/search/screens/View.tsx
+++ b/mobile/src/modules/search/screens/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useMemo } from "react";

--- a/mobile/src/modules/search/types.ts
+++ b/mobile/src/modules/search/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Album, FileNode } from "~/db/schema";
 
 import type { PlaylistSummary } from "~/data/playlist/types";

--- a/mobile/src/modules/search/utils.ts
+++ b/mobile/src/modules/search/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { KeysOfValue } from "~/utils/types";
 
 /**

--- a/mobile/src/modules/widget/ArtworkPlayerWidget.tsx
+++ b/mobile/src/modules/widget/ArtworkPlayerWidget.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { FlexWidget, OverlapWidget } from "react-native-android-widget";
 
 import { Colors } from "~/constants/Styles";

--- a/mobile/src/modules/widget/NowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/NowPlayingWidget.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { OverlapWidget } from "react-native-android-widget";
 
 import { Colors } from "~/constants/Styles";

--- a/mobile/src/modules/widget/ResizableNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/ResizableNowPlayingWidget.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { TextWidgetProps } from "react-native-android-widget";
 import {
   FlexWidget,

--- a/mobile/src/modules/widget/WidgetTaskHandler.tsx
+++ b/mobile/src/modules/widget/WidgetTaskHandler.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { launchAppViaIntent } from "@missingcore/native-utils";
 import type { WidgetTaskHandlerProps } from "react-native-android-widget";
 

--- a/mobile/src/modules/widget/components/WidgetArtwork.tsx
+++ b/mobile/src/modules/widget/components/WidgetArtwork.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ClickActionProps } from "react-native-android-widget";
 import { ImageWidget } from "react-native-android-widget";
 

--- a/mobile/src/modules/widget/components/WidgetBaseLayout.tsx
+++ b/mobile/src/modules/widget/components/WidgetBaseLayout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type {
   ClickActionProps,
   FlexWidgetStyle,

--- a/mobile/src/modules/widget/components/WidgetCell.tsx
+++ b/mobile/src/modules/widget/components/WidgetCell.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type {
   ClickActionProps,
   FlexWidgetStyle,

--- a/mobile/src/modules/widget/components/WidgetSVG.tsx
+++ b/mobile/src/modules/widget/components/WidgetSVG.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ClickActionProps } from "react-native-android-widget";
 import { SvgWidget } from "react-native-android-widget";
 

--- a/mobile/src/modules/widget/constants/Action.ts
+++ b/mobile/src/modules/widget/constants/Action.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const Action = {
   Open: "OPEN_APP",
   PlayPause: "PLAY_PAUSE",

--- a/mobile/src/modules/widget/constants/Styles.ts
+++ b/mobile/src/modules/widget/constants/Styles.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const Styles = {
   color: {
     /** Nothing widget color from color picker. */

--- a/mobile/src/modules/widget/constants/Widgets.ts
+++ b/mobile/src/modules/widget/constants/Widgets.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { ArtworkPlayerWidget } from "../ArtworkPlayerWidget";
 import { NowPlayingWidget } from "../NowPlayingWidget";
 import { ResizableNowPlayingWidget } from "../ResizableNowPlayingWidget";

--- a/mobile/src/modules/widget/types.ts
+++ b/mobile/src/modules/widget/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 type WidgetTrackData = {
   title: string;
   artist: string | null;

--- a/mobile/src/modules/widget/utils/index.ts
+++ b/mobile/src/modules/widget/utils/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { playbackStore } from "~/stores/Playback/store";
 import { getArtistsString } from "~/data/artist/utils";
 

--- a/mobile/src/modules/widget/utils/update.tsx
+++ b/mobile/src/modules/widget/utils/update.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { requestWidgetUpdate } from "react-native-android-widget";
 
 import type { PlayerWidgetData } from "../types";

--- a/mobile/src/navigation/components/Back.tsx
+++ b/mobile/src/navigation/components/Back.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
 import { View } from "react-native";

--- a/mobile/src/navigation/components/BottomActions/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/BottomActions/MiniPlayer.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import BackgroundTimer from "@boterop/react-native-background-timer";
 import { useNavigation } from "@react-navigation/native";
 import { useCallback, useMemo, useState } from "react";

--- a/mobile/src/navigation/components/BottomActions/NavActions.tsx
+++ b/mobile/src/navigation/components/BottomActions/NavActions.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation, useNavigationState } from "@react-navigation/native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useMemo, useState } from "react";

--- a/mobile/src/navigation/components/BottomActions/index.tsx
+++ b/mobile/src/navigation/components/BottomActions/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { View } from "react-native";
 import Animated, { LinearTransition } from "react-native-reanimated";

--- a/mobile/src/navigation/components/BottomActions/useBottomActions.ts
+++ b/mobile/src/navigation/components/BottomActions/useBottomActions.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { NavigationRoute, ParamListBase } from "@react-navigation/native";
 import { useNavigationState } from "@react-navigation/native";
 import { useMemo } from "react";

--- a/mobile/src/navigation/components/CurrentListMenu.tsx
+++ b/mobile/src/navigation/components/CurrentListMenu.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/navigation/components/DeferredRender.tsx
+++ b/mobile/src/navigation/components/DeferredRender.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useDelayedReady } from "~/hooks/useDelayedReady";
 
 /**

--- a/mobile/src/navigation/components/ErrorBoundary.tsx
+++ b/mobile/src/navigation/components/ErrorBoundary.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/navigation/components/Placeholder.tsx
+++ b/mobile/src/navigation/components/Placeholder.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import { useEffect, useState } from "react";
 import { View } from "react-native";

--- a/mobile/src/navigation/components/ScreenOptions.tsx
+++ b/mobile/src/navigation/components/ScreenOptions.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import type { ParseKeys } from "i18next";
 import { useLayoutEffect } from "react";

--- a/mobile/src/navigation/components/TopAppBar.tsx
+++ b/mobile/src/navigation/components/TopAppBar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getHeaderTitle } from "@react-navigation/elements";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackHeaderProps } from "@react-navigation/native-stack";

--- a/mobile/src/navigation/hooks/useFloatingContent.ts
+++ b/mobile/src/navigation/hooks/useFloatingContent.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { LayoutChangeEvent, View, ViewStyle } from "react-native";
 import { useWindowDimensions } from "react-native";

--- a/mobile/src/navigation/hooks/useHasNewUpdate.ts
+++ b/mobile/src/navigation/hooks/useHasNewUpdate.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 
 import { usePreferenceStore } from "~/stores/Preference/store";

--- a/mobile/src/navigation/index.tsx
+++ b/mobile/src/navigation/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Navigation } from "./routes";
 import { linking } from "./utils/linking";
 import { navigationRef } from "./utils/router";

--- a/mobile/src/navigation/layouts/CurrentListLayout.tsx
+++ b/mobile/src/navigation/layouts/CurrentListLayout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useCallback } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import { View, useWindowDimensions } from "react-native";

--- a/mobile/src/navigation/layouts/ListLayout.tsx
+++ b/mobile/src/navigation/layouts/ListLayout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { cn } from "~/lib/style";
 import type { ScrollViewProps } from "~/components/Base/ScrollView";
 import { ScrollView } from "~/components/Base/ScrollView";

--- a/mobile/src/navigation/layouts/NScrollLayout.tsx
+++ b/mobile/src/navigation/layouts/NScrollLayout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 import {
   useCallback,

--- a/mobile/src/navigation/providers/AppProvider.tsx
+++ b/mobile/src/navigation/providers/AppProvider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { Toaster } from "@missingcore/ui/toast";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { NavigationBar } from "@zoontek/react-native-navigation-bar";

--- a/mobile/src/navigation/routes.tsx
+++ b/mobile/src/navigation/routes.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import type {
   EventArg,

--- a/mobile/src/navigation/screens/HomeView.tsx
+++ b/mobile/src/navigation/screens/HomeView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/RecentlyPlayedView.tsx
+++ b/mobile/src/navigation/screens/RecentlyPlayedView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/albums/CurrentView.tsx
+++ b/mobile/src/navigation/screens/albums/CurrentView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/navigation/screens/albums/View.tsx
+++ b/mobile/src/navigation/screens/albums/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 
 import { useAlbums } from "~/data/album/queries";

--- a/mobile/src/navigation/screens/artists/CurrentView.tsx
+++ b/mobile/src/navigation/screens/artists/CurrentView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
 

--- a/mobile/src/navigation/screens/artists/View.tsx
+++ b/mobile/src/navigation/screens/artists/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/folders/View.tsx
+++ b/mobile/src/navigation/screens/folders/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";

--- a/mobile/src/navigation/screens/genres/CurrentView.tsx
+++ b/mobile/src/navigation/screens/genres/CurrentView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 
 import { useGenreDetails, useGenreTracks } from "~/data/genre/queries";

--- a/mobile/src/navigation/screens/genres/View.tsx
+++ b/mobile/src/navigation/screens/genres/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/now-playing/UpcomingView.tsx
+++ b/mobile/src/navigation/screens/now-playing/UpcomingView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { DragListRenderItemInfo } from "@missingcore/ui/drag-list";
 import { DragList, useDragListState } from "@missingcore/ui/drag-list";
 import { useQuery, useQueryClient } from "@tanstack/react-query";

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/navigation/screens/now-playing/components/Artwork.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/Artwork.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useAtomValue } from "jotai";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/navigation/screens/now-playing/components/ArtworkSlot.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/ArtworkSlot.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { LayoutChangeEvent } from "react-native";
 import { View } from "react-native";

--- a/mobile/src/navigation/screens/now-playing/components/SeekBar.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/SeekBar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useAtomValue, useSetAtom } from "jotai";
 import { useMemo } from "react";
 import { I18nManager, View } from "react-native";

--- a/mobile/src/navigation/screens/now-playing/components/TopAppBar.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/TopAppBar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useMemo } from "react";

--- a/mobile/src/navigation/screens/now-playing/components/Waveform.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/Waveform.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { computeAmplitude } from "@missingcore/react-native-audio-analyzer";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { View, useWindowDimensions } from "react-native";

--- a/mobile/src/navigation/screens/now-playing/helpers/Seekbar.context.tsx
+++ b/mobile/src/navigation/screens/now-playing/helpers/Seekbar.context.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 import { AppState } from "react-native";

--- a/mobile/src/navigation/screens/now-playing/helpers/useVinylSeekbar.ts
+++ b/mobile/src/navigation/screens/now-playing/helpers/useVinylSeekbar.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, useRef } from "react";
 import { usePanGesture } from "react-native-gesture-handler";

--- a/mobile/src/navigation/screens/now-playing/sheets/AppearanceSheet.tsx
+++ b/mobile/src/navigation/screens/now-playing/sheets/AppearanceSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { PreferenceSetters } from "~/stores/Preference/actions";
 

--- a/mobile/src/navigation/screens/now-playing/sheets/PlaybackOptionsSheet.tsx
+++ b/mobile/src/navigation/screens/now-playing/sheets/PlaybackOptionsSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useCallback, useState } from "react";
 import AudioBrowser from "react-native-audio-browser";

--- a/mobile/src/navigation/screens/now-playing/sheets/SleepTimerSheet/index.tsx
+++ b/mobile/src/navigation/screens/now-playing/sheets/SleepTimerSheet/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard } from "react-native";

--- a/mobile/src/navigation/screens/now-playing/sheets/SleepTimerSheet/store.ts
+++ b/mobile/src/navigation/screens/now-playing/sheets/SleepTimerSheet/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import BackgroundTimer from "@boterop/react-native-background-timer";
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";

--- a/mobile/src/navigation/screens/playlists/CreateView.tsx
+++ b/mobile/src/navigation/screens/playlists/CreateView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";

--- a/mobile/src/navigation/screens/playlists/CurrentView.tsx
+++ b/mobile/src/navigation/screens/playlists/CurrentView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";

--- a/mobile/src/navigation/screens/playlists/ModifyView.tsx
+++ b/mobile/src/navigation/screens/playlists/ModifyView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useNavigation } from "@react-navigation/native";

--- a/mobile/src/navigation/screens/playlists/View.tsx
+++ b/mobile/src/navigation/screens/playlists/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/navigation/screens/playlists/components/ModifyViewBase.tsx
+++ b/mobile/src/navigation/screens/playlists/components/ModifyViewBase.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { DragListRenderItemInfo } from "@missingcore/ui/drag-list";
 import { DragList, useDragListState } from "@missingcore/ui/drag-list";
 import { toast } from "@missingcore/ui/toast";

--- a/mobile/src/navigation/screens/playlists/sheets/AddMusicSheet.tsx
+++ b/mobile/src/navigation/screens/playlists/sheets/AddMusicSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { DetachedSheet } from "~/components/Sheet";
 import type { TrueSheetRef } from "~/components/Sheet/useSheetRef";
 import { SearchEngine } from "~/modules/search/components/SearchEngine";

--- a/mobile/src/navigation/screens/playlists/sheets/ExportM3USheet.tsx
+++ b/mobile/src/navigation/screens/playlists/sheets/ExportM3USheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/navigation/screens/settings/AppUpdateView.tsx
+++ b/mobile/src/navigation/screens/settings/AppUpdateView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 import { Text, View } from "react-native";
 import Markdown from "react-native-markdown-renderer";

--- a/mobile/src/navigation/screens/settings/AppearanceSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/AppearanceSettingsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/settings/HiddenTracksView.tsx
+++ b/mobile/src/navigation/screens/settings/HiddenTracksView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { inArray } from "drizzle-orm";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/mobile/src/navigation/screens/settings/InsightsView.tsx
+++ b/mobile/src/navigation/screens/settings/InsightsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useQuery } from "@tanstack/react-query";
 import { sum } from "drizzle-orm";

--- a/mobile/src/navigation/screens/settings/MostPlayedView.tsx
+++ b/mobile/src/navigation/screens/settings/MostPlayedView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";

--- a/mobile/src/navigation/screens/settings/PackageLicenseView.tsx
+++ b/mobile/src/navigation/screens/settings/PackageLicenseView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { StaticScreenProps } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/settings/PlaybackSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/PlaybackSettingsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useTranslation } from "react-i18next";
 
 import { usePreferenceStore } from "~/stores/Preference/store";

--- a/mobile/src/navigation/screens/settings/SaveErrorsView.tsx
+++ b/mobile/src/navigation/screens/settings/SaveErrorsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQuery } from "@tanstack/react-query";
 
 import { db } from "~/db";

--- a/mobile/src/navigation/screens/settings/ScanningSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ScanningSettingsView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/settings/ThirdPartyView.tsx
+++ b/mobile/src/navigation/screens/settings/ThirdPartyView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 
 import LicensesList from "~/resources/licenses.json";

--- a/mobile/src/navigation/screens/settings/View.tsx
+++ b/mobile/src/navigation/screens/settings/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 

--- a/mobile/src/navigation/screens/settings/sheets/BackupSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/BackupSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useExportBackup, useImportBackup } from "~/modules/backup/JSON";
 
 import { mutateGuard } from "~/lib/react-query";

--- a/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { View } from "react-native";
 
 import { Icon } from "~/resources/icons";

--- a/mobile/src/navigation/screens/settings/sheets/MinDurationSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/MinDurationSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { PreferenceSetters } from "~/stores/Preference/actions";
 

--- a/mobile/src/navigation/screens/settings/sheets/ScanFilterListSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/ScanFilterListSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getActualPath } from "@missingcore/react-native-actual-path";
 import { toast } from "@missingcore/ui/toast";
 import { Directory } from "expo-file-system";

--- a/mobile/src/navigation/screens/settings/sheets/SeparatorsSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/SeparatorsSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { useTranslation } from "react-i18next";
 import { Keyboard, View } from "react-native";

--- a/mobile/src/navigation/screens/settings/sheets/TabOrderSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/TabOrderSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { DragListRenderItemInfo } from "@missingcore/ui/drag-list";
 import { DragList, useDragListState } from "@missingcore/ui/drag-list";
 import { memo, useState } from "react";

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   MetadataPresets,
   getMetadata,

--- a/mobile/src/navigation/screens/tracks/View.tsx
+++ b/mobile/src/navigation/screens/tracks/View.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 
 import { useSortedTracks } from "~/data/track/queries";

--- a/mobile/src/navigation/screens/tracks/sheets/AddAlbumSheet.tsx
+++ b/mobile/src/navigation/screens/tracks/sheets/AddAlbumSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useAlbums } from "~/data/album/queries";
 import type { AlbumSummary } from "~/data/album/types";
 

--- a/mobile/src/navigation/screens/tracks/sheets/TrackSheet.tsx
+++ b/mobile/src/navigation/screens/tracks/sheets/TrackSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { TrueSheet } from "@lodev09/react-native-true-sheet";
 import { useNavigation, useNavigationState } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";

--- a/mobile/src/navigation/screens/tracks/sheets/TrackToPlaylistsSheet.tsx
+++ b/mobile/src/navigation/screens/tracks/sheets/TrackToPlaylistsSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 
 import { usePlaylistsNames } from "~/data/playlist/queries";

--- a/mobile/src/navigation/sheets/ArtistsSheet.tsx
+++ b/mobile/src/navigation/sheets/ArtistsSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { TrueSheet } from "@lodev09/react-native-true-sheet";
 import { useNavigation } from "@react-navigation/native";
 

--- a/mobile/src/navigation/sheets/ArtworkSheet.tsx
+++ b/mobile/src/navigation/sheets/ArtworkSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useWindowDimensions } from "react-native";

--- a/mobile/src/navigation/sheets/SortSheet.tsx
+++ b/mobile/src/navigation/sheets/SortSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useViewPreferenceStore } from "~/stores/ViewPreference/store";
 import {
   ViewPreferenceSetters,

--- a/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
+++ b/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 

--- a/mobile/src/navigation/utils/linking.ts
+++ b/mobile/src/navigation/utils/linking.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getActualPath } from "@missingcore/react-native-actual-path";
 import type { LinkingOptions, ParamListBase } from "@react-navigation/native";
 import { getActionFromState } from "@react-navigation/native";

--- a/mobile/src/navigation/utils/router.ts
+++ b/mobile/src/navigation/utils/router.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createNavigationContainerRef } from "@react-navigation/native";
 
 import { ReservedPlaylists } from "~/modules/media/constants";

--- a/mobile/src/navigation/utils/theme.ts
+++ b/mobile/src/navigation/utils/theme.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Theme } from "@react-navigation/native";
 import { DefaultTheme } from "@react-navigation/native";
 import { useMemo } from "react";

--- a/mobile/src/resources/icons/index.tsx
+++ b/mobile/src/resources/icons/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createNanoIconSet } from "react-native-nano-icons";
 
 import type { AppColor } from "~/modules/customization/theme/core/constants";

--- a/mobile/src/stores/ListenerState.ts
+++ b/mobile/src/stores/ListenerState.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { atom, useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
 import type { AppStateStatus } from "react-native";

--- a/mobile/src/stores/Playback/actions/index.ts
+++ b/mobile/src/stores/Playback/actions/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export * as PlaybackControls from "./playbackControls";
 export * as PlaybackSettings from "./playbackSettings";
 export * as Queue from "./queue";

--- a/mobile/src/stores/Playback/actions/playbackControls.ts
+++ b/mobile/src/stores/Playback/actions/playbackControls.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AudioBrowser from "react-native-audio-browser";
 
 import { addPlayedMediaList } from "~/data/recent/api";

--- a/mobile/src/stores/Playback/actions/playbackSettings.ts
+++ b/mobile/src/stores/Playback/actions/playbackSettings.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AudioBrowser from "react-native-audio-browser";
 
 import { playbackStore } from "../store";

--- a/mobile/src/stores/Playback/actions/queue.ts
+++ b/mobile/src/stores/Playback/actions/queue.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { createId } from "@paralleldrive/cuid2";
 import AudioBrowser from "react-native-audio-browser";

--- a/mobile/src/stores/Playback/actions/resynchronize.ts
+++ b/mobile/src/stores/Playback/actions/resynchronize.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AudioBrowser from "react-native-audio-browser";
 
 import {

--- a/mobile/src/stores/Playback/constants.ts
+++ b/mobile/src/stores/Playback/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Track } from "~/data/track/types";
 
 import type { ObjectValues } from "~/utils/types";

--- a/mobile/src/stores/Playback/store.ts
+++ b/mobile/src/stores/Playback/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { inArray } from "drizzle-orm";
 import AudioBrowser from "react-native-audio-browser";
 import { useStore } from "zustand";

--- a/mobile/src/stores/Playback/types.ts
+++ b/mobile/src/stores/Playback/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Types of "media" we can play audio from. */
 export type MediaType =
   | "album"

--- a/mobile/src/stores/Playback/utils.ts
+++ b/mobile/src/stores/Playback/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import i18next from "~/modules/i18n";
 import { getAlbumDetails, getAlbumTracks } from "~/data/album/api";
 import { getSortedArtistTracks } from "~/data/artist/api";

--- a/mobile/src/stores/Preference/actions/index.ts
+++ b/mobile/src/stores/Preference/actions/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export * as PreferenceSetters from "./preferenceSetters";
 export * as PreferenceTogglers from "./preferenceTogglers";
 export * as Tabs from "./tabs";

--- a/mobile/src/stores/Preference/actions/preferenceSetters.ts
+++ b/mobile/src/stores/Preference/actions/preferenceSetters.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { toast } from "@missingcore/ui/toast";
 import { Uniwind } from "uniwind";
 

--- a/mobile/src/stores/Preference/actions/preferenceTogglers.ts
+++ b/mobile/src/stores/Preference/actions/preferenceTogglers.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import AsyncStorage from "expo-sqlite/kv-store";
 import { I18nManager } from "react-native";
 import AudioBrowser from "react-native-audio-browser";

--- a/mobile/src/stores/Preference/actions/tabs.ts
+++ b/mobile/src/stores/Preference/actions/tabs.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { preferenceStore } from "../store";
 import type { Tab } from "../types";
 

--- a/mobile/src/stores/Preference/constants.ts
+++ b/mobile/src/stores/Preference/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Font } from "~/modules/customization/font/core/constants";
 import type {
   CustomTheme,

--- a/mobile/src/stores/Preference/hooks.ts
+++ b/mobile/src/stores/Preference/hooks.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo } from "react";
 
 import { usePreferenceStore } from "./store";

--- a/mobile/src/stores/Preference/store.ts
+++ b/mobile/src/stores/Preference/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { I18nManager } from "react-native";
 import { Uniwind } from "uniwind";
 import { useStore } from "zustand";

--- a/mobile/src/stores/Preference/types.ts
+++ b/mobile/src/stores/Preference/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Tabs available on the Home screen. */
 export type Tab =
   | "album"

--- a/mobile/src/stores/Preference/utils.ts
+++ b/mobile/src/stores/Preference/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { I18nManager } from "react-native";
 
 import i18next from "~/modules/i18n";

--- a/mobile/src/stores/Session/actions.ts
+++ b/mobile/src/stores/Session/actions.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { TrueSheet } from "@lodev09/react-native-true-sheet";
 import { getMetadata } from "@missingcore/react-native-metadata-retriever";
 import type { NavigationProp } from "@react-navigation/native";

--- a/mobile/src/stores/Session/constants.ts
+++ b/mobile/src/stores/Session/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { Artist, WaveformSample } from "~/db/schema";
 
 import type { Track } from "~/data/track/types";

--- a/mobile/src/stores/Session/store.ts
+++ b/mobile/src/stores/Session/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 

--- a/mobile/src/stores/Session/types.ts
+++ b/mobile/src/stores/Session/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * The screen popping strategies offered when navigating to the artist screen.
  * - `popTo`: Uses the `pop` option in `navigate()`.

--- a/mobile/src/stores/ViewPreference/actions/index.ts
+++ b/mobile/src/stores/ViewPreference/actions/index.ts
@@ -1,2 +1,5 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export * as ViewPreferenceSetters from "./setters";
 export * as ViewPreferenceTogglers from "./togglers";

--- a/mobile/src/stores/ViewPreference/actions/setters.ts
+++ b/mobile/src/stores/ViewPreference/actions/setters.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { viewPreferenceStore } from "../store";
 import type { LayoutOption, ScreenSortOptions } from "../constants";
 import type { MutableViewLayout, MutableViewOrder } from "../types";

--- a/mobile/src/stores/ViewPreference/actions/togglers.ts
+++ b/mobile/src/stores/ViewPreference/actions/togglers.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { viewPreferenceStore } from "../store";
 import type { MutableViewOrder } from "../types";
 

--- a/mobile/src/stores/ViewPreference/constants.ts
+++ b/mobile/src/stores/ViewPreference/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ParseKeys } from "i18next";
 
 import type { MutableViewOrder } from "./types";

--- a/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewLayout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";
 

--- a/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
+++ b/mobile/src/stores/ViewPreference/hooks/useViewOrder.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useMemo, useRef, useState } from "react";
 
 import { useViewPreferenceStore } from "../store";

--- a/mobile/src/stores/ViewPreference/store.ts
+++ b/mobile/src/stores/ViewPreference/store.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useStore } from "zustand";
 
 import { createPersistedStore } from "~/lib/zustand";

--- a/mobile/src/stores/ViewPreference/types.ts
+++ b/mobile/src/stores/ViewPreference/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { MediaImage } from "~/modules/media/components/MediaImage";
 
 /** Screens where the layout of the content can be change. */

--- a/mobile/src/utils/debug.ts
+++ b/mobile/src/utils/debug.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Help track performance of code. */
 export class Stopwatch {
   laps: number[] = [];

--- a/mobile/src/utils/number.ts
+++ b/mobile/src/utils/number.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Convert bit rate to kbit/s. */
 export function abbreviateBitRate(rate: number) {
   return `${(rate / 1000).toFixed(2).replace(".00", "")} kbit/s`;

--- a/mobile/src/utils/object.ts
+++ b/mobile/src/utils/object.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Split an array into "chunks". */
 export function chunkArray<T>(arr: T[], chunkSize: number) {
   const chunkedArray: T[][] = [];

--- a/mobile/src/utils/promise.ts
+++ b/mobile/src/utils/promise.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import BackgroundTimer from "@boterop/react-native-background-timer";
 
 /** Typeguard for finding promises that were fulfilled in `Promise.allsettled()`. */

--- a/mobile/src/utils/string.ts
+++ b/mobile/src/utils/string.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Ensure a path ends with a trailing forward slash. */
 export function addTrailingSlash(path: string) {
   return path.endsWith("/") ? path : `${path}/`;

--- a/mobile/src/utils/types.ts
+++ b/mobile/src/utils/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /** Get a partial of an object with some required fields. */
 export type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>;
 

--- a/mobile/src/utils/validation.ts
+++ b/mobile/src/utils/validation.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export function isBoolean(item: any): item is boolean {
   return typeof item === "boolean";
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds an SPDX license header to project file (excluding the auto-generated ones, translations, or non-text format files):

```
// Copyright (C) 2024 - present, MissingCore
// SPDX-License-Identifier: AGPL-3.0-only
```

In addition, we marked the code in `mobile/modules/ui` as MIT licensed.

> We're doing this right after releasing `v3.3.0` as to make the git diff to see the changes for the next version easier to see (as we don't have this "noise").

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.
