### PR TITLE
chore: Use Uniwind's `ltr:` & `rtl:` variants

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -69,7 +69,7 @@
     "react-native-svg": "15.15.5",
     "react-native-worklets": "0.10.1",
     "tailwind-merge": "3.6.0",
-    "uniwind": "1.9.0",
+    "uniwind": "1.10.0",
     "zod": "4.4.3",
     "zustand": "5.0.14"
   },

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       uniwind:
-        specifier: 1.9.0
-        version: 1.9.0(@expo/metro-config@56.0.14(expo@56.0.12)(typescript@6.0.3))(metro-cache@0.84.4)(metro-transform-worker@0.84.4)(metro@0.84.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.2)
+        specifier: 1.10.0
+        version: 1.10.0(@expo/metro-config@56.0.14(expo@56.0.12)(typescript@6.0.3))(metro-cache@0.84.4)(metro-transform-worker@0.84.4)(metro@0.84.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.2)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -5192,8 +5192,8 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
-  uniwind@1.9.0:
-    resolution: {integrity: sha512-XdTrQmdAiaTHfOd6TXH355UQ4bLz/M6RGAikiTd1JltBrbJGVCrRpQepKFb7IJsbDZPWsgYrQ6CftHeBvaEL+A==}
+  uniwind@1.10.0:
+    resolution: {integrity: sha512-YUCM90mqtNn172XQmC2SOmRK502HgL0NK5jdd9bJQhqGhJNvmzK+G894lOkzX94SLOGlDe0te4AaYLwyBSW+Cg==}
     hasBin: true
     peerDependencies:
       '@expo/metro-config': '*'
@@ -8295,7 +8295,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-expo: 1.1.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -8319,7 +8319,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8334,14 +8334,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8369,7 +8369,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10825,7 +10825,7 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
-  uniwind@1.9.0(@expo/metro-config@56.0.14(expo@56.0.12)(typescript@6.0.3))(metro-cache@0.84.4)(metro-transform-worker@0.84.4)(metro@0.84.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.2):
+  uniwind@1.10.0(@expo/metro-config@56.0.14(expo@56.0.12)(typescript@6.0.3))(metro-cache@0.84.4)(metro-transform-worker@0.84.4)(metro@0.84.4)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(tailwindcss@4.3.2):
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0

--- a/mobile/src/components/Marquee.tsx
+++ b/mobile/src/components/Marquee.tsx
@@ -96,7 +96,6 @@ export function Marquee({
       offset.get() === OnRTLWorklet.decide(contentWidth - containerWidth, 0)
         ? "none"
         : "flex",
-    [OnRTLWorklet.decide("right", "left")]: 0,
   }));
   const isRightVisible = useAnimatedStyle(() => ({
     display:
@@ -104,7 +103,6 @@ export function Marquee({
       offset.get() !== OnRTLWorklet.decide(0, contentWidth - containerWidth)
         ? "flex"
         : "none",
-    [OnRTLWorklet.decide("left", "right")]: 0,
   }));
 
   return (
@@ -134,14 +132,18 @@ export function Marquee({
       <Animated.View
         pointerEvents="none"
         style={isLeftVisible}
-        className={cn("absolute h-full", { hidden: isStatic })}
+        className={cn("absolute h-full ltr:left-0 rtl:right-0", {
+          hidden: isStatic,
+        })}
       >
         <LinearGradient colors={[endColor, startColor]} {...ShadowProps} />
       </Animated.View>
       <Animated.View
         pointerEvents="none"
         style={isRightVisible}
-        className={cn("absolute h-full", { hidden: isStatic })}
+        className={cn("absolute h-full ltr:right-0 rtl:left-0", {
+          hidden: isStatic,
+        })}
       >
         <LinearGradient colors={[startColor, endColor]} {...ShadowProps} />
       </Animated.View>

--- a/mobile/src/components/Swipeable.tsx
+++ b/mobile/src/components/Swipeable.tsx
@@ -20,7 +20,6 @@ import { scheduleOnRN } from "react-native-worklets";
 
 import { Icon } from "~/resources/icons";
 
-import { OnRTLWorklet } from "~/lib/react";
 import { cn } from "~/lib/style";
 
 const DRAG_TOSS = 0.02;
@@ -221,11 +220,6 @@ export function Swipeable({
 //#region Swipe Indicator
 type Direction = "left" | "right";
 
-const IconPosition: Record<Direction, [string, string]> = {
-  left: ["right", "left"],
-  right: ["left", "right"],
-};
-
 const InterpolateOptions: Record<
   Direction,
   (
@@ -273,7 +267,6 @@ function SwipeIconWrapper({
   const wrapperStyles = useAnimatedStyle(() => ({ maxWidth: maxWidth.get() }));
 
   const iconWrapperStyles = useAnimatedStyle(() => ({
-    [OnRTLWorklet.decide(...IconPosition[direction])]: 0,
     transform: [
       {
         translateX: interpolate(
@@ -292,7 +285,10 @@ function SwipeIconWrapper({
       <Animated.View
         onLayout={onIconLayout}
         style={iconWrapperStyles}
-        className="absolute"
+        className={cn("absolute", {
+          "ltr:left-0 rtl:right-0": direction === "left",
+          "ltr:right-0 rtl:left-0": direction === "right",
+        })}
       >
         {props.Icon}
       </Animated.View>

--- a/mobile/src/components/UI/Switch.tsx
+++ b/mobile/src/components/UI/Switch.tsx
@@ -6,7 +6,6 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 
 export function Switch({ enabled }: { enabled: boolean }) {
@@ -23,8 +22,8 @@ export function Switch({ enabled }: { enabled: boolean }) {
       )}
     >
       <Animated.View
-        style={[{ [OnRTL.decide("right", "left")]: 2 }, thumbStyle]}
-        className="absolute top-0.5 size-5 rounded-full bg-onPrimary"
+        style={thumbStyle}
+        className="absolute top-0.5 size-5 rounded-full bg-onPrimary ltr:left-0.5 rtl:right-0.5"
       />
     </Animated.View>
   );

--- a/mobile/src/lib/react.ts
+++ b/mobile/src/lib/react.ts
@@ -4,10 +4,6 @@
 import { I18nManager } from "react-native";
 
 export const OnRTL = {
-  _use<T>(val: T) {
-    if (I18nManager.isRTL) return val;
-  },
-
   decide<T, U>(valIfTrue: T, valIfFalse: U) {
     return I18nManager.isRTL ? valIfTrue : valIfFalse;
   },

--- a/mobile/src/modules/audio/equalizer/components/EqualizerSettings.tsx
+++ b/mobile/src/modules/audio/equalizer/components/EqualizerSettings.tsx
@@ -9,7 +9,6 @@ import { useEqualizerSettings } from "react-native-audio-browser";
 import { useEqualizerStore } from "../core/store";
 import { toggleEQ, setEQPreset } from "../core/actions";
 
-import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { Button } from "~/components/Form/Button";
 import { SegmentedList } from "~/components/List/Segmented";
@@ -50,10 +49,7 @@ export function EqualizerSettings() {
         >
           <EQGraph points={eqDataPoints} />
 
-          <View
-            style={{ flexDirection: OnRTL.decide("row-reverse", "row") }}
-            className="justify-evenly gap-2"
-          >
+          <View className="flex-row justify-evenly gap-2 rtl:flex-row-reverse">
             {currEQ?.bandLevels.map((level, index) => (
               <FrequencySlider
                 key={`${currEQ.activePreset}_${index}`}

--- a/mobile/src/navigation/components/BottomActions/MiniPlayer.tsx
+++ b/mobile/src/navigation/components/BottomActions/MiniPlayer.tsx
@@ -25,7 +25,6 @@ import { PlaybackControls } from "~/stores/Playback/actions";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { BottomActionsOffset } from "./useBottomActions";
 
-import { OnRTL } from "~/lib/react";
 import { cn } from "~/lib/style";
 import { Pressable } from "~/components/Base/Pressable";
 import { IconButton } from "~/components/Form/Button/Icon";
@@ -146,8 +145,7 @@ export function MiniPlayer() {
 
           <Animated.View
             layout={LinearTransition}
-            style={{ flexDirection: OnRTL.decide("row-reverse", "row") }}
-            className="items-center"
+            className="flex-row items-center rtl:flex-row-reverse"
           >
             {!gestureUI ? <PreviousButton /> : null}
             <IconButton

--- a/mobile/src/navigation/components/BottomActions/NavActions.tsx
+++ b/mobile/src/navigation/components/BottomActions/NavActions.tsx
@@ -141,15 +141,13 @@ export function Navbar() {
         pointerEvents="none"
         colors={[`${surfaceContainerLowest}E6`, `${surfaceContainerLowest}00`]}
         {...ShadowProps}
-        style={{ [OnRTL.decide("right", "left")]: 0 }}
-        className="absolute h-full w-4"
+        className="absolute h-full w-4 ltr:left-0 rtl:right-0"
       />
       <LinearGradient
         pointerEvents="none"
         colors={[`${surfaceContainerLowest}00`, `${surfaceContainerLowest}E6`]}
         {...ShadowProps}
-        style={{ [OnRTL.decide("left", "right")]: 0 }}
-        className="absolute h-full w-4"
+        className="absolute h-full w-4 ltr:right-0 rtl:left-0"
       />
     </Animated.View>
   );

--- a/mobile/src/navigation/components/TopAppBar.tsx
+++ b/mobile/src/navigation/components/TopAppBar.tsx
@@ -8,7 +8,6 @@ import type { ParseKeys } from "i18next";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
-import { OnRTL } from "~/lib/react";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { SafeContainer } from "~/components/SafeContainer";
 import { TEm } from "~/components/Typography/StyledText";
@@ -27,7 +26,7 @@ export function TopAppBar({ options, route }: NativeStackHeaderProps) {
           accessibilityLabel={t("form.back")}
           onPress={() => navigation.goBack()}
           disabled={!!options.headerLeft}
-          className={OnRTL._use("rotate-180")}
+          className="rtl:rotate-180"
         />
 
         {title ? (

--- a/mobile/src/navigation/screens/now-playing/View.tsx
+++ b/mobile/src/navigation/screens/now-playing/View.tsx
@@ -20,7 +20,6 @@ import { PlaybackOptionsSheet } from "./sheets/PlaybackOptionsSheet";
 import { SleepTimerSheet } from "./sheets/SleepTimerSheet";
 import { useSleepTimerStore } from "./sheets/SleepTimerSheet/store";
 
-import { OnRTL } from "~/lib/react";
 import { Pressable } from "~/components/Base/Pressable";
 import { FilledIconButton, IconButton } from "~/components/Form/Button/Icon";
 import { Marquee } from "~/components/Marquee";
@@ -110,10 +109,7 @@ function Metadata({ track }: { track: Track }) {
 //#region Playback Controls
 function PlaybackControls() {
   return (
-    <View
-      style={{ flexDirection: OnRTL.decide("row-reverse", "row") }}
-      className="mx-auto w-full max-w-96 items-center justify-between gap-2"
-    >
+    <View className="mx-auto w-full max-w-96 flex-row items-center justify-between gap-2 rtl:flex-row-reverse">
       <ShuffleButton />
       <PreviousButton />
       <PlayToggleButton />

--- a/mobile/src/navigation/screens/now-playing/components/SeekBar.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/SeekBar.tsx
@@ -15,7 +15,6 @@ import {
   renderedPositionAtom,
 } from "../helpers/Seekbar.context";
 
-import { OnRTL } from "~/lib/react";
 import { clamp, formatSeconds } from "~/utils/number";
 import { CachedSlider } from "~/components/Form/Slider";
 import { Em } from "~/components/Typography/StyledText";
@@ -73,10 +72,7 @@ export function SeekBar(props: SeekBarProps) {
           roundedEndStop
         />
       )}
-      <View
-        style={{ flexDirection: OnRTL.decide("row-reverse", "row") }}
-        className="justify-between"
-      >
+      <View className="flex-row justify-between rtl:flex-row-reverse">
         <Em>{formatSeconds(clampedPos)}</Em>
         <Em>{formatSeconds(props.trackLength)}</Em>
       </View>

--- a/mobile/src/navigation/screens/now-playing/components/TopAppBar.tsx
+++ b/mobile/src/navigation/screens/now-playing/components/TopAppBar.tsx
@@ -12,7 +12,6 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 
 import { getMediaLinkContext } from "~/navigation/utils/router";
 
-import { OnRTL } from "~/lib/react";
 import { Pressable } from "~/components/Base/Pressable";
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { Marquee } from "~/components/Marquee";
@@ -53,7 +52,7 @@ function AppBarContent() {
         icon="arrow-back"
         accessibilityLabel={t("form.back")}
         onPress={() => navigation.goBack()}
-        className={OnRTL._use("rotate-180")}
+        className="rtl:rotate-180"
       />
       <Pressable
         onPress={() =>

--- a/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
@@ -10,7 +10,6 @@ import {
   PreferenceTogglers,
 } from "~/stores/Preference/actions";
 
-import { OnRTL } from "~/lib/react";
 import { Links, openLink } from "~/lib/web-browser";
 import { FlatList } from "~/components/Base/List";
 import { Pressable } from "~/components/Base/Pressable";
@@ -47,7 +46,7 @@ export function LanguageSheet(props: { ref: TrueSheetRef }) {
           className="min-h-10 flex-row items-center justify-between gap-1 border-b border-outline active:opacity-50"
         >
           <StyledText>{selectedLanguage?.name}</StyledText>
-          <View className={OnRTL.decide("rotate-90", "-rotate-90")}>
+          <View className="ltr:-rotate-90 rtl:rotate-90">
             <Icon name="keyboard-arrow-down" />
           </View>
         </Pressable>

--- a/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
+++ b/mobile/src/navigation/screens/settings/sheets/LanguageSheet.tsx
@@ -46,7 +46,7 @@ export function LanguageSheet(props: { ref: TrueSheetRef }) {
           className="min-h-10 flex-row items-center justify-between gap-1 border-b border-outline active:opacity-50"
         >
           <StyledText>{selectedLanguage?.name}</StyledText>
-          <View className="ltr:-rotate-90 rtl:rotate-90">
+          <View className="-rotate-90 rtl:rotate-90">
             <Icon name="keyboard-arrow-down" />
           </View>
         </Pressable>

--- a/mobile/src/resources/licenses.json
+++ b/mobile/src/resources/licenses.json
@@ -365,7 +365,7 @@
   },
   "uniwind": {
     "name": "uniwind",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "source": "https://github.com/uni-stack/uniwind",
     "license": "MIT",
     "licenseText": "MIT License\n\nCopyright (c) 2026 Uniwind\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR replaces some uses of our `OnRTL` & `OnRTLWorklet` helpers with Uniwind's `ltr:` & `rtl:` variants.
- We would use the `start-*` & `end-*` logical properties instead of for example `ltr:left-0 rtl:right-0` (which would be replaced by `start-0`), but it didn't work the way we expect it to.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] Documentation is up to date to reflect these changes.
- [x] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-to-left layout behavior across navigation, playback, settings, and controls.
  * Fixed icon, shadow, and slider positioning so they display correctly in both RTL and LTR languages.
  * Updated some mirrored buttons and rows for more consistent alignment.

* **Chores**
  * Bumped a UI dependency to the latest patch/minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->