### PR TITLE
feat: v2 of JSON backup feature

### DIFF
--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -183,7 +183,7 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
       await tx
         .delete(albumsToArtists)
         .where(inArray(albumsToArtists.albumId, albumIds));
-      await tx.insert(albumsToArtists).values(newRels);
+      await tx.insert(albumsToArtists).values(newRels).onConflictDoNothing();
     }
 
     return results;

--- a/mobile/src/data/playlist/api.ts
+++ b/mobile/src/data/playlist/api.ts
@@ -98,6 +98,7 @@ export async function getPlaylistsSummary<
       albumName: structuredTracksView.albumName,
       duration: structuredTracksView.duration,
       artwork: structuredTracksView.artwork,
+      uri: structuredTracksView.uri,
     })
     .from(tracksToPlaylists)
     .innerJoin(
@@ -128,7 +129,8 @@ export async function getPlaylistsSummary<
                   'id', ${orderedPlaylistTracks.id},
                   'name', ${orderedPlaylistTracks.name},
                   'rawArtistName', ${orderedPlaylistTracks.rawArtistName},
-                  'albumName', ${orderedPlaylistTracks.albumName}
+                  'albumName', ${orderedPlaylistTracks.albumName},
+                  'uri', ${orderedPlaylistTracks.uri}
                 )
               )`.as("grouped_tracks"),
           }

--- a/mobile/src/data/playlist/types.ts
+++ b/mobile/src/data/playlist/types.ts
@@ -20,4 +20,5 @@ export type PlaylistSummaryTrack = {
   /** @deprecated */
   rawArtistName: string | null;
   albumName: string | null;
+  uri: string;
 };

--- a/mobile/src/modules/backup/JSON/index.ts
+++ b/mobile/src/modules/backup/JSON/index.ts
@@ -4,9 +4,13 @@
 import { toast } from "@missingcore/ui/toast";
 import { useMutation } from "@tanstack/react-query";
 
+import i18next from "~/modules/i18n";
+
+import { pickFile } from "~/lib/file-system";
 import { clearAllQueries } from "~/lib/react-query";
+import { isRecord } from "~/utils/validation";
 import { importBackup } from "./v1";
-import { exportBackupV2 } from "./v2";
+import { exportBackupV2, importBackupV2 } from "./v2";
 
 export const useExportBackup = () => {
   return useMutation({
@@ -22,7 +26,7 @@ export const useExportBackup = () => {
 
 export const useImportBackup = () => {
   return useMutation({
-    mutationFn: importBackup,
+    mutationFn: decideImportVersion,
     onSuccess: () => {
       clearAllQueries();
       toast.t("feat.backup.extra.importSuccess");
@@ -32,3 +36,25 @@ export const useImportBackup = () => {
     },
   });
 };
+
+//#region Helpers
+/** Based on the picked file, determines which JSON backup version is used. */
+async function decideImportVersion() {
+  const backupFile = await pickFile([
+    "application/json",
+    "application/octet-stream",
+  ]);
+
+  let jsonContent: any;
+  try {
+    // Ensure a JSON object is returned.
+    jsonContent = await backupFile.json();
+    if (!isRecord(jsonContent)) throw new Error();
+  } catch {
+    throw new Error(i18next.t("err.msg.invalidStructure"));
+  }
+
+  if (jsonContent.version === 2) return importBackupV2(jsonContent);
+  return importBackup(jsonContent);
+}
+//#endregion

--- a/mobile/src/modules/backup/JSON/index.ts
+++ b/mobile/src/modules/backup/JSON/index.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { toast } from "@missingcore/ui/toast";
+import { useMutation } from "@tanstack/react-query";
+
+import { clearAllQueries } from "~/lib/react-query";
+import { importBackup, exportBackup } from "./v1";
+
+export const useExportBackup = () => {
+  return useMutation({
+    mutationFn: exportBackup,
+    onSuccess: () => {
+      toast.t("feat.backup.extra.exportSuccess");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+};
+
+export const useImportBackup = () => {
+  return useMutation({
+    mutationFn: importBackup,
+    onSuccess: () => {
+      clearAllQueries();
+      toast.t("feat.backup.extra.importSuccess");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+};

--- a/mobile/src/modules/backup/JSON/index.ts
+++ b/mobile/src/modules/backup/JSON/index.ts
@@ -5,11 +5,12 @@ import { toast } from "@missingcore/ui/toast";
 import { useMutation } from "@tanstack/react-query";
 
 import { clearAllQueries } from "~/lib/react-query";
-import { importBackup, exportBackup } from "./v1";
+import { importBackup } from "./v1";
+import { exportBackupV2 } from "./v2";
 
 export const useExportBackup = () => {
   return useMutation({
-    mutationFn: exportBackup,
+    mutationFn: exportBackupV2,
     onSuccess: () => {
       toast.t("feat.backup.extra.exportSuccess");
     },

--- a/mobile/src/modules/backup/JSON/v1.ts
+++ b/mobile/src/modules/backup/JSON/v1.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { eq, inArray } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
@@ -18,7 +18,7 @@ import { sanitizePlaylistName } from "~/data/playlist/utils";
 import { getTracks } from "~/data/track/api";
 import { mergeTracks } from "~/data/track/utils";
 
-import { pickDirectory, pickFile } from "~/lib/file-system";
+import { pickFile } from "~/lib/file-system";
 import { ZSchema } from "~/modules/form/utils";
 import { FavoritesPlaylistKey } from "~/modules/media/constants";
 
@@ -88,48 +88,6 @@ async function findExistingTracksFactory() {
       )
       .filter((entry) => entry !== undefined);
   };
-}
-//#endregion
-
-//#region Export
-/**
- * @deprecated We plan on updating the backup schema, so this old export
- * code will be replaced while the old import code will stay for a while.
- */
-export async function exportBackup() {
-  // Get favorited values.
-  const [favAlbums, favPlaylists] = await Promise.all([
-    getAlbumsSummary(false, [eq(albums.isFavorite, true)]),
-    getPlaylistsSummary(false, [eq(playlists.isFavorite, true)]),
-  ]);
-  // Get all user-generated playlists.
-  const allPlaylists = await getPlaylistsSummary(true);
-
-  // User selects location to save this backup file.
-  const dir = await pickDirectory();
-
-  // Create a new file in specified directory & write contents.
-  const backupFile = dir.createFile("music_backup", "application/json");
-  backupFile.write(
-    JSON.stringify({
-      favorites: {
-        playlists: favPlaylists.map(({ id }) => id),
-        albums: favAlbums.map(({ name, artistsKey }) => {
-          return { name, artistName: artistsKey };
-        }),
-        //! [Deprecated] For backwards compatibility.
-        tracks: [],
-      },
-      playlists: allPlaylists.map(({ id, tracks }) => ({
-        name: id,
-        tracks: tracks.map((t) => ({
-          name: t.name,
-          artistName: t.rawArtistName,
-          albumName: t.albumName,
-        })),
-      })),
-    }),
-  );
 }
 //#endregion
 

--- a/mobile/src/modules/backup/JSON/v1.ts
+++ b/mobile/src/modules/backup/JSON/v1.ts
@@ -1,8 +1,6 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { toast } from "@missingcore/ui/toast";
-import { useMutation } from "@tanstack/react-query";
 import { eq, inArray } from "drizzle-orm";
 import { z } from "zod/mini";
 
@@ -21,7 +19,6 @@ import { getTracks } from "~/data/track/api";
 import { mergeTracks } from "~/data/track/utils";
 
 import { pickDirectory, pickFile } from "~/lib/file-system";
-import { clearAllQueries } from "~/lib/react-query";
 import { ZSchema } from "~/modules/form/utils";
 import { FavoritesPlaylistKey } from "~/modules/media/constants";
 
@@ -99,7 +96,7 @@ async function findExistingTracksFactory() {
  * @deprecated We plan on updating the backup schema, so this old export
  * code will be replaced while the old import code will stay for a while.
  */
-async function exportBackup() {
+export async function exportBackup() {
   // Get favorited values.
   const [favAlbums, favPlaylists] = await Promise.all([
     getAlbumsSummary(false, [eq(albums.isFavorite, true)]),
@@ -137,7 +134,7 @@ async function exportBackup() {
 //#endregion
 
 //#region Import
-async function importBackup() {
+export async function importBackup() {
   const backupFile = await pickFile([
     "application/json",
     "application/octet-stream",
@@ -199,31 +196,4 @@ async function importBackup() {
       ),
   ]);
 }
-//#endregion
-
-//#region Mutation Hooks
-export const useExportBackup = () => {
-  return useMutation({
-    mutationFn: exportBackup,
-    onSuccess: () => {
-      toast.t("feat.backup.extra.exportSuccess");
-    },
-    onError: (err) => {
-      toast.error(err.message);
-    },
-  });
-};
-
-export const useImportBackup = () => {
-  return useMutation({
-    mutationFn: importBackup,
-    onSuccess: () => {
-      clearAllQueries();
-      toast.t("feat.backup.extra.importSuccess");
-    },
-    onError: (err) => {
-      toast.error(err.message);
-    },
-  });
-};
 //#endregion

--- a/mobile/src/modules/backup/JSON/v1.ts
+++ b/mobile/src/modules/backup/JSON/v1.ts
@@ -18,7 +18,6 @@ import { sanitizePlaylistName } from "~/data/playlist/utils";
 import { getTracks } from "~/data/track/api";
 import { mergeTracks } from "~/data/track/utils";
 
-import { pickFile } from "~/lib/file-system";
 import { ZSchema } from "~/modules/form/utils";
 import { FavoritesPlaylistKey } from "~/modules/media/constants";
 
@@ -92,17 +91,12 @@ async function findExistingTracksFactory() {
 //#endregion
 
 //#region Import
-export async function importBackup() {
-  const backupFile = await pickFile([
-    "application/json",
-    "application/octet-stream",
-  ]);
-
+export async function importBackup(jsonContent: Record<string, any>) {
   // Read, parse, and validate file contents.
   let backupContents;
   try {
     // Validate the data structure.
-    backupContents = MusicBackup.parse(await backupFile.json());
+    backupContents = MusicBackup.parse(jsonContent);
   } catch {
     throw new Error(i18next.t("err.msg.invalidStructure"));
   }

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -1,0 +1,58 @@
+import { z } from "zod/mini";
+
+import { sanitizePlaylistName } from "~/data/playlist/utils";
+
+import { ZSchema } from "~/modules/form/utils";
+
+//#region Schemas
+const PlaylistNameSchema = z.pipe(
+  z.string(),
+  z.transform(sanitizePlaylistName),
+);
+
+const AlbumSchema = z.object({
+  name: ZSchema.NonEmptyString,
+  // We can derive the album artists from this.
+  artistsKey: ZSchema.NonEmptyString,
+});
+
+const TrackSchema = z.object({
+  uri: ZSchema.NonEmptyString,
+  // Alternative method of locating the track if the `uri` isn't the same
+  // on the new device.
+  relativePath: ZSchema.NonEmptyString,
+});
+
+const TrackMetadataSchema = z.object({
+  ...TrackSchema.shape,
+  name: ZSchema.NonEmptyString,
+  artists: z.array(ZSchema.NonEmptyString),
+  album: z.nullable(AlbumSchema),
+  disc: ZSchema.NullableRealNumber,
+  track: ZSchema.NullableRealNumber,
+  year: ZSchema.NullableRealNumber,
+  genres: z.array(ZSchema.NonEmptyString),
+});
+
+const LyricSchema = z.object({
+  name: ZSchema.NonEmptyString,
+  lyrics: ZSchema.NonEmptyString,
+  linkedTracks: z.array(TrackSchema),
+});
+
+const BackupSchema = z.object({
+  trackMetadata: z.array(TrackMetadataSchema),
+  lyrics: z.array(LyricSchema),
+  // "Favorited Tracks" will be exported as a playlist.
+  playlists: z.array(
+    z.object({
+      name: PlaylistNameSchema,
+      tracks: z.array(TrackSchema),
+    }),
+  ),
+  favorites: z.object({
+    albums: z.array(AlbumSchema),
+    playlists: z.array(PlaylistNameSchema),
+  }),
+});
+//#endregion

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -190,7 +190,7 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
     columns: { id: true, name: true, artistsKey: true },
   });
   const albumIdLookUpTable: Record<string, Record<string, string>> = {};
-  allAlbums.map(({ id, name, artistsKey }) => {
+  allAlbums.forEach(({ id, name, artistsKey }) => {
     if (albumIdLookUpTable[artistsKey])
       albumIdLookUpTable[artistsKey][name] = id;
     else albumIdLookUpTable[artistsKey] = { [name]: id };
@@ -205,7 +205,7 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
     },
   });
   const playlistLookupTable: Record<string, string[]> = {};
-  allPlaylists.map(({ name, tracksToPlaylists }) => {
+  allPlaylists.forEach(({ name, tracksToPlaylists }) => {
     playlistLookupTable[name] = tracksToPlaylists.map((t) => t.trackId);
   });
 
@@ -217,7 +217,7 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
   let createdAlbums: Album[] = [];
   if (albumEntries.length > 0) {
     createdAlbums = await upsertAlbums(albumEntries);
-    createdAlbums.map(({ id, name, artistsKey }) => {
+    createdAlbums.forEach(({ id, name, artistsKey }) => {
       if (albumIdLookUpTable[artistsKey])
         albumIdLookUpTable[artistsKey][name] = id;
       else albumIdLookUpTable[artistsKey] = { [name]: id };
@@ -252,12 +252,12 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
       albumId = albumIdLookUpTable[artistsKey]?.[name];
     }
 
-    metadata.artists.map((artistName) => {
+    metadata.artists.forEach((artistName) => {
       artistNames.add(artistName);
       trackArtistRels.push({ trackId, artistName });
     });
 
-    metadata.genres.map((genreName) => {
+    metadata.genres.forEach((genreName) => {
       genreNames.add(genreName);
       trackGenreRels.push({ trackId, genreName });
     });

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -5,6 +5,7 @@ import { eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
+import type { Album } from "~/db/schema";
 import {
   albums,
   artists,
@@ -16,7 +17,7 @@ import {
 } from "~/db/schema";
 
 import i18next from "~/modules/i18n";
-import { getAlbumsSummary, upsertAlbums } from "~/data/album/api";
+import { getAlbumsSummary, updateAlbum, upsertAlbums } from "~/data/album/api";
 import {
   createPlaylist,
   getPlaylistsSummary,
@@ -31,6 +32,7 @@ import { getSubqueryFields } from "~/lib/drizzle";
 import { pickDirectory } from "~/lib/file-system";
 import { pickKeys } from "~/utils/object";
 import { ZSchema } from "~/modules/form/utils";
+import { getArtworkHash } from "~/modules/scanning/helpers/artwork";
 
 //#region Schemas
 const PlaylistNameSchema = z.pipe(
@@ -212,8 +214,9 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
   const albumEntries = backupContents.trackMetadata
     .map((t) => t.album)
     .filter((al) => al !== null);
+  let createdAlbums: Album[] = [];
   if (albumEntries.length > 0) {
-    const createdAlbums = await upsertAlbums(albumEntries);
+    createdAlbums = await upsertAlbums(albumEntries);
     createdAlbums.map(({ id, name, artistsKey }) => {
       if (albumIdLookUpTable[artistsKey])
         albumIdLookUpTable[artistsKey][name] = id;
@@ -351,5 +354,41 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
       .update(playlists)
       .set({ isFavorite: true })
       .where(inArray(playlists.name, backupContents.favorites.playlists));
+
+  //? 4. Since we may have created new albums, ensure they have artwork.
+  const albumsWithoutArtwork = createdAlbums
+    .filter((a) => a.embeddedArtwork === null)
+    .map((a) => a.id);
+
+  if (albumsWithoutArtwork.length > 0) {
+    // Determine list of tracks we can infer the album artwork from.
+    const albumArtworkSources = await db.query.tracks.findMany({
+      columns: { albumId: true, uri: true },
+      where: (fields, { inArray }) =>
+        inArray(fields.albumId, albumsWithoutArtwork),
+    });
+    const albumTrackMap: Record<string, string[]> = {};
+    for (const { albumId, uri } of albumArtworkSources) {
+      if (!albumId) continue;
+      if (albumTrackMap[albumId]) albumTrackMap[albumId].push(uri);
+      else albumTrackMap[albumId] = [uri];
+    }
+
+    // Get list of previously hashed images.
+    const prevHashedImages = await db.query.hashedImages.findMany();
+    const knownHashes = new Set(prevHashedImages.map((h) => h.hash));
+
+    for (const [albumId, albumTracks] of Object.entries(albumTrackMap)) {
+      // This inner loop will most likely iterate once.
+      for (const trackUri of albumTracks) {
+        const { artworkHash } = await getArtworkHash(trackUri, knownHashes);
+        if (artworkHash) {
+          const data = { embeddedArtwork: artworkHash };
+          await updateAlbum(albumId, data);
+          break;
+        }
+      }
+    }
+  }
 }
 //#endregion

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -28,6 +28,7 @@ const TrackSchema = z.object({
 
 const TrackMetadataSchema = z.object({
   ...TrackSchema.shape,
+  editedMetadata: ZSchema.RealNumber,
   name: ZSchema.NonEmptyString,
   artists: z.array(ZSchema.NonEmptyString),
   album: z.nullable(AlbumSchema),

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { z } from "zod/mini";
 
 import { sanitizePlaylistName } from "~/data/playlist/utils";
@@ -41,18 +44,23 @@ const LyricSchema = z.object({
 });
 
 const BackupSchema = z.object({
-  trackMetadata: z.array(TrackMetadataSchema),
-  lyrics: z.array(LyricSchema),
-  // "Favorited Tracks" will be exported as a playlist.
-  playlists: z.array(
-    z.object({
-      name: PlaylistNameSchema,
-      tracks: z.array(TrackSchema),
+  version: ZSchema.RealNumber,
+  exportedAt: ZSchema.NonEmptyString,
+
+  backup: z.object({
+    trackMetadata: z.array(TrackMetadataSchema),
+    lyrics: z.array(LyricSchema),
+    // "Favorited Tracks" will be exported as a playlist.
+    playlists: z.array(
+      z.object({
+        name: PlaylistNameSchema,
+        tracks: z.array(TrackSchema),
+      }),
+    ),
+    favorites: z.object({
+      albums: z.array(AlbumSchema),
+      playlists: z.array(PlaylistNameSchema),
     }),
-  ),
-  favorites: z.object({
-    albums: z.array(AlbumSchema),
-    playlists: z.array(PlaylistNameSchema),
   }),
 });
 //#endregion

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -5,14 +5,7 @@ import { eq, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
-import {
-  albums,
-  lyrics,
-  playlists,
-  tracks,
-  tracksToGenres,
-  tracksToLyrics,
-} from "~/db/schema";
+import { albums, playlists, tracksToGenres } from "~/db/schema";
 
 import { getAlbumsSummary } from "~/data/album/api";
 import { getPlaylistsSummary } from "~/data/playlist/api";
@@ -53,19 +46,12 @@ const TrackMetadataSchema = z.object({
   genres: z.array(ZSchema.NonEmptyString),
 });
 
-const LyricSchema = z.object({
-  name: ZSchema.NonEmptyString,
-  lyrics: ZSchema.NonEmptyString,
-  linkedTracks: z.array(TrackSchema),
-});
-
 const BackupSchema = z.object({
   version: ZSchema.RealNumber,
   exportedAt: ZSchema.NonEmptyString,
 
   backup: z.object({
     trackMetadata: z.array(TrackMetadataSchema),
-    lyrics: z.array(LyricSchema),
     // "Favorited Tracks" will be exported as a playlist.
     playlists: z.array(
       z.object({
@@ -83,7 +69,7 @@ const BackupSchema = z.object({
 
 //#region Export
 export async function exportBackupV2() {
-  const [favAlbums, favPlaylists, allPlaylists, editedTracks, allLinkedLyrics] =
+  const [favAlbums, favPlaylists, allPlaylists, editedTracks] =
     await Promise.all([
       // Get favorited values.
       getAlbumsSummary(false, [eq(albums.isFavorite, true)]),
@@ -126,30 +112,6 @@ export async function exportBackupV2() {
           genres: fromJSONArrayString(genres) ?? [],
         }));
       })(),
-      // Get all lyrics linked to tracks.
-      (async () => {
-        const results = await db
-          .select({
-            name: lyrics.name,
-            lyrics: lyrics.lyrics,
-            /** We need to unencode these fields. */
-            linkedTracks: sql<
-              string | null
-            >`NULLIF(json_group_array(${tracks.uri}), '[null]')`.as(
-              "derived_linked_tracks",
-            ),
-          })
-          .from(lyrics)
-          .innerJoin(tracksToLyrics, eq(lyrics.id, tracksToLyrics.lyricId))
-          .innerJoin(tracks, eq(tracksToLyrics.trackId, tracks.id))
-          .groupBy(lyrics.id);
-
-        return results.map(({ linkedTracks, ...rest }) => ({
-          ...rest,
-          linkedTracks:
-            fromJSONArrayString(linkedTracks)?.map((uri) => ({ uri })) ?? [],
-        }));
-      })(),
     ]);
 
   // User selects location to save this backup file.
@@ -173,7 +135,6 @@ export async function exportBackupV2() {
                 : null,
           }),
         ),
-        lyrics: allLinkedLyrics,
         playlists: allPlaylists.map(({ id, tracks }) => ({
           name: id,
           tracks: tracks.map(({ uri }) => ({ uri })),

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -1,10 +1,28 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { eq, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod/mini";
 
-import { sanitizePlaylistName } from "~/data/playlist/utils";
+import { db } from "~/db";
+import {
+  albums,
+  lyrics,
+  playlists,
+  tracks,
+  tracksToGenres,
+  tracksToLyrics,
+} from "~/db/schema";
 
+import { getAlbumsSummary } from "~/data/album/api";
+import { getPlaylistsSummary } from "~/data/playlist/api";
+import { sanitizePlaylistName } from "~/data/playlist/utils";
+import { fromJSONArrayString } from "~/data/utils";
+import { structuredTracksView } from "~/data/views";
+
+import { getSubqueryFields } from "~/lib/drizzle";
+import { pickDirectory } from "~/lib/file-system";
+import { pickKeys } from "~/utils/object";
 import { ZSchema } from "~/modules/form/utils";
 
 //#region Schemas
@@ -21,9 +39,6 @@ const AlbumSchema = z.object({
 
 const TrackSchema = z.object({
   uri: ZSchema.NonEmptyString,
-  // Alternative method of locating the track if the `uri` isn't the same
-  // on the new device.
-  relativePath: ZSchema.NonEmptyString,
 });
 
 const TrackMetadataSchema = z.object({
@@ -64,4 +79,113 @@ const BackupSchema = z.object({
     }),
   }),
 });
+//#endregion
+
+//#region Export
+export async function exportBackupV2() {
+  const [favAlbums, favPlaylists, allPlaylists, editedTracks, allLinkedLyrics] =
+    await Promise.all([
+      // Get favorited values.
+      getAlbumsSummary(false, [eq(albums.isFavorite, true)]),
+      getPlaylistsSummary(false, [eq(playlists.isFavorite, true)]),
+      // Get all user-generated playlists.
+      getPlaylistsSummary(true),
+      // Get all user-edited tracks.
+      (async () => {
+        const results = await db
+          .select({
+            ...pickKeys(getSubqueryFields(structuredTracksView), [
+              "uri",
+              "editedMetadata",
+              "name",
+              "artists",
+              "albumName",
+              "albumArtistsKey",
+              "disc",
+              "track",
+              "year",
+            ] as const),
+            /** We need to unencode these fields. */
+            genres: sql<
+              string | null
+            >`NULLIF(json_group_array(${tracksToGenres.genreName}), '[null]')`.as(
+              "derived_genres",
+            ),
+          })
+          .from(structuredTracksView)
+          .leftJoin(
+            tracksToGenres,
+            eq(structuredTracksView.id, tracksToGenres.trackId),
+          )
+          .groupBy(structuredTracksView.id)
+          .where(isNotNull(structuredTracksView.editedMetadata));
+
+        return results.map(({ artists, genres, ...rest }) => ({
+          ...rest,
+          artists: fromJSONArrayString(artists) ?? [],
+          genres: fromJSONArrayString(genres) ?? [],
+        }));
+      })(),
+      // Get all lyrics linked to tracks.
+      (async () => {
+        const results = await db
+          .select({
+            name: lyrics.name,
+            lyrics: lyrics.lyrics,
+            /** We need to unencode these fields. */
+            linkedTracks: sql<
+              string | null
+            >`NULLIF(json_group_array(${tracks.uri}), '[null]')`.as(
+              "derived_linked_tracks",
+            ),
+          })
+          .from(lyrics)
+          .innerJoin(tracksToLyrics, eq(lyrics.id, tracksToLyrics.lyricId))
+          .innerJoin(tracks, eq(tracksToLyrics.trackId, tracks.id))
+          .groupBy(lyrics.id);
+
+        return results.map(({ linkedTracks, ...rest }) => ({
+          ...rest,
+          linkedTracks:
+            fromJSONArrayString(linkedTracks)?.map((uri) => ({ uri })) ?? [],
+        }));
+      })(),
+    ]);
+
+  // User selects location to save this backup file.
+  const dir = await pickDirectory();
+
+  // Create a new file in specified directory & write contents.
+  const backupFile = dir.createFile("music_backup_v2", "application/json");
+  backupFile.write(
+    JSON.stringify({
+      version: 2,
+      exportedAt: new Date().toString(),
+
+      backup: {
+        trackMetadata: editedTracks.map(
+          ({ albumName, albumArtistsKey, ...rest }) => ({
+            ...rest,
+            editedMetadata: rest.editedMetadata!,
+            album:
+              albumName && albumArtistsKey
+                ? { name: albumName, artistsKey: albumArtistsKey }
+                : null,
+          }),
+        ),
+        lyrics: allLinkedLyrics,
+        playlists: allPlaylists.map(({ id, tracks }) => ({
+          name: id,
+          tracks: tracks.map(({ uri }) => ({ uri })),
+        })),
+        favorites: {
+          albums: favAlbums.map(({ name, artistsKey }) => {
+            return { name, artistsKey };
+          }),
+          playlists: favPlaylists.map(({ id }) => id),
+        },
+      },
+    } satisfies z.infer<typeof BackupSchema>),
+  );
+}
 //#endregion

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -189,3 +189,7 @@ export async function exportBackupV2() {
   );
 }
 //#endregion
+
+//#region Import
+export async function importBackupV2(jsonContent: Record<string, any>) {}
+//#endregion

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -288,24 +288,28 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
 
   if (trackArtistRels.length > 0) {
     const oldRels = trackArtistRels.map((rel) => rel.trackId);
-    await db
-      .delete(tracksToArtists)
-      .where(inArray(tracksToArtists.trackId, oldRels));
-    await db
-      .insert(tracksToArtists)
-      .values(trackArtistRels)
-      .onConflictDoNothing();
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(tracksToArtists)
+        .where(inArray(tracksToArtists.trackId, oldRels));
+      await tx
+        .insert(tracksToArtists)
+        .values(trackArtistRels)
+        .onConflictDoNothing();
+    });
   }
 
   if (trackGenreRels.length > 0) {
     const oldRels = trackGenreRels.map((rel) => rel.trackId);
-    await db
-      .delete(tracksToGenres)
-      .where(inArray(tracksToGenres.trackId, oldRels));
-    await db
-      .insert(tracksToGenres)
-      .values(trackGenreRels)
-      .onConflictDoNothing();
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(tracksToGenres)
+        .where(inArray(tracksToGenres.trackId, oldRels));
+      await tx
+        .insert(tracksToGenres)
+        .values(trackGenreRels)
+        .onConflictDoNothing();
+    });
   }
 
   for (const { id: trackId, ...trackEntry } of trackEntries) {

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -1,13 +1,22 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { eq, isNotNull, sql } from "drizzle-orm";
+import { eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
-import { albums, playlists, tracksToGenres } from "~/db/schema";
+import {
+  albums,
+  artists,
+  genres,
+  playlists,
+  tracks,
+  tracksToArtists,
+  tracksToGenres,
+} from "~/db/schema";
 
-import { getAlbumsSummary } from "~/data/album/api";
+import i18next from "~/modules/i18n";
+import { getAlbumsSummary, upsertAlbums } from "~/data/album/api";
 import { getPlaylistsSummary } from "~/data/playlist/api";
 import { sanitizePlaylistName } from "~/data/playlist/utils";
 import { fromJSONArrayString } from "~/data/utils";
@@ -152,5 +161,138 @@ export async function exportBackupV2() {
 //#endregion
 
 //#region Import
-export async function importBackupV2(jsonContent: Record<string, any>) {}
+export async function importBackupV2(jsonContent: Record<string, any>) {
+  // Read, parse, and validate file contents.
+  let _backupContents;
+  try {
+    // Validate the data structure.
+    _backupContents = BackupSchema.parse(jsonContent);
+  } catch {
+    throw new Error(i18next.t("err.msg.invalidStructure"));
+  }
+  const backupContents = _backupContents.backup;
+
+  const allTracks = await db.query.tracks.findMany({
+    columns: { id: true, uri: true },
+  });
+  const trackIdLookUpTable = Object.fromEntries(
+    allTracks.map((t) => [t.uri, t.id]),
+  );
+
+  const allAlbums = await db.query.albums.findMany({
+    columns: { id: true, name: true, artistsKey: true },
+  });
+  const albumIdLookUpTable: Record<string, Record<string, string>> = {};
+  allAlbums.map(({ id, name, artistsKey }) => {
+    if (albumIdLookUpTable[artistsKey])
+      albumIdLookUpTable[artistsKey][name] = id;
+    else albumIdLookUpTable[artistsKey] = { [name]: id };
+  });
+
+  //? 1. Update track metadata.
+  //? 1a. Create album entries before we do anything else.
+  const albumEntries = backupContents.trackMetadata
+    .map((t) => t.album)
+    .filter((al) => al !== null);
+  if (albumEntries.length > 0) {
+    const createdAlbums = await upsertAlbums(albumEntries);
+    createdAlbums.map(({ id, name, artistsKey }) => {
+      if (albumIdLookUpTable[artistsKey])
+        albumIdLookUpTable[artistsKey][name] = id;
+      else albumIdLookUpTable[artistsKey] = { [name]: id };
+    });
+  }
+
+  //? 1b. Find the things we need to insert.
+  const artistNames = new Set<string>();
+  const genreNames = new Set<string>();
+
+  const trackArtistRels: Array<{ trackId: string; artistName: string }> = [];
+  const trackGenreRels: Array<{ trackId: string; genreName: string }> = [];
+
+  const trackEntries: Array<{
+    id: string;
+    name: string;
+    albumId: string | null;
+    disc: number | null;
+    track: number | null;
+    year: number | null;
+    editedMetadata: number;
+  }> = [];
+
+  for (const metadata of backupContents.trackMetadata) {
+    const trackId = trackIdLookUpTable[metadata.uri];
+    if (!trackId) continue;
+
+    // We handle album-to-artists relations in `upsertAlbums()`.
+    let albumId: string | undefined;
+    if (metadata.album) {
+      const { artistsKey, name } = metadata.album;
+      albumId = albumIdLookUpTable[artistsKey]?.[name];
+    }
+
+    metadata.artists.map((artistName) => {
+      artistNames.add(artistName);
+      trackArtistRels.push({ trackId, artistName });
+    });
+
+    metadata.genres.map((genreName) => {
+      genreNames.add(genreName);
+      trackGenreRels.push({ trackId, genreName });
+    });
+
+    trackEntries.push({
+      id: trackId,
+      name: metadata.name,
+      albumId: albumId || null,
+      disc: metadata.disc,
+      track: metadata.track,
+      year: metadata.year,
+      editedMetadata: metadata.editedMetadata,
+    });
+  }
+
+  //? 1c. Insert relations.
+  if (artistNames.size > 0)
+    await db
+      .insert(artists)
+      .values(Array.from(artistNames).map((name) => ({ name })))
+      .onConflictDoNothing();
+
+  if (genreNames.size > 0)
+    await db
+      .insert(genres)
+      .values(Array.from(genreNames).map((name) => ({ name })))
+      .onConflictDoNothing();
+
+  if (trackArtistRels.length > 0) {
+    const oldRels = trackArtistRels.map((rel) => rel.trackId);
+    await db
+      .delete(tracksToArtists)
+      .where(inArray(tracksToArtists.trackId, oldRels));
+    await db
+      .insert(tracksToArtists)
+      .values(trackArtistRels)
+      .onConflictDoNothing();
+  }
+
+  if (trackGenreRels.length > 0) {
+    const oldRels = trackGenreRels.map((rel) => rel.trackId);
+    await db
+      .delete(tracksToGenres)
+      .where(inArray(tracksToGenres.trackId, oldRels));
+    await db
+      .insert(tracksToGenres)
+      .values(trackGenreRels)
+      .onConflictDoNothing();
+  }
+
+  for (const { id: trackId, ...trackEntry } of trackEntries) {
+    await db.update(tracks).set(trackEntry).where(eq(tracks.id, trackId));
+  }
+
+  //? 2. Import playlists.
+
+  //? 3. Favorite albums & playlists.
+}
 //#endregion

--- a/mobile/src/modules/backup/JSON/v2.ts
+++ b/mobile/src/modules/backup/JSON/v2.ts
@@ -17,8 +17,13 @@ import {
 
 import i18next from "~/modules/i18n";
 import { getAlbumsSummary, upsertAlbums } from "~/data/album/api";
-import { getPlaylistsSummary } from "~/data/playlist/api";
+import {
+  createPlaylist,
+  getPlaylistsSummary,
+  updatePlaylist,
+} from "~/data/playlist/api";
 import { sanitizePlaylistName } from "~/data/playlist/utils";
+import { mergeTracks } from "~/data/track/utils";
 import { fromJSONArrayString } from "~/data/utils";
 import { structuredTracksView } from "~/data/views";
 
@@ -189,6 +194,19 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
     else albumIdLookUpTable[artistsKey] = { [name]: id };
   });
 
+  const allPlaylists = await db.query.playlists.findMany({
+    columns: { name: true },
+    with: {
+      tracksToPlaylists: {
+        orderBy: (fields, { asc }) => asc(fields.position),
+      },
+    },
+  });
+  const playlistLookupTable: Record<string, string[]> = {};
+  allPlaylists.map(({ name, tracksToPlaylists }) => {
+    playlistLookupTable[name] = tracksToPlaylists.map((t) => t.trackId);
+  });
+
   //? 1. Update track metadata.
   //? 1a. Create album entries before we do anything else.
   const albumEntries = backupContents.trackMetadata
@@ -292,7 +310,46 @@ export async function importBackupV2(jsonContent: Record<string, any>) {
   }
 
   //? 2. Import playlists.
+  await Promise.allSettled(
+    backupContents.playlists.map(async ({ name, tracks: plTracks }) => {
+      const exists = playlistLookupTable[name];
+      const _playlistTracks = plTracks
+        .map(({ uri }) => trackIdLookUpTable[uri])
+        .filter((id) => id !== undefined);
+      // Remove any duplicates.
+      const playlistTracks = Array.from(new Set(_playlistTracks)).map(
+        (tId) => ({ id: tId }),
+      );
 
-  //? 3. Favorite albums & playlists.
+      // Create or update playlist to have the current track order.
+      if (exists) {
+        await updatePlaylist(name, {
+          tracks: mergeTracks(
+            exists.map((tId) => ({ id: tId })),
+            playlistTracks,
+          ),
+        });
+      } else await createPlaylist({ name, tracks: playlistTracks });
+    }),
+  );
+
+  //? 3. Favorite albums, playlists, and tracks (via `favorites` playlist).
+  const albumsToFavorite: string[] = [];
+  for (const { name, artistsKey } of backupContents.favorites.albums) {
+    const albumId = albumIdLookUpTable[artistsKey]?.[name];
+    if (albumId) albumsToFavorite.push(albumId);
+  }
+
+  if (albumsToFavorite.length > 0)
+    await db
+      .update(albums)
+      .set({ isFavorite: true })
+      .where(inArray(albums.id, albumsToFavorite));
+
+  if (backupContents.favorites.playlists.length > 0)
+    await db
+      .update(playlists)
+      .set({ isFavorite: true })
+      .where(inArray(playlists.name, backupContents.favorites.playlists));
 }
 //#endregion

--- a/mobile/src/modules/form/utils.ts
+++ b/mobile/src/modules/form/utils.ts
@@ -12,5 +12,6 @@ export const ZSchema = {
       z.transform((str) => (str === "" ? null : str)),
     ),
   ),
+  RealNumber: z.number().check(z.int(), z.gt(0)),
   NullableRealNumber: z.nullable(z.number().check(z.int(), z.gt(0))),
 };

--- a/mobile/src/modules/widget/utils/customize.ts
+++ b/mobile/src/modules/widget/utils/customize.ts
@@ -5,6 +5,7 @@ import Storage from "expo-sqlite/kv-store";
 import type { WidgetInfo } from "react-native-android-widget";
 import { createStore } from "zustand/vanilla";
 
+import { isRecord } from "~/utils/validation";
 import { DEFAULT_WIDGET_CONFIG } from "../constants/Config";
 import type { WidgetConfig } from "../types";
 
@@ -40,7 +41,7 @@ export async function getWidgetConfig(
     try {
       const storedConfig = JSON.parse(config);
       // Verify we're storing an object.
-      if (typeof storedConfig === "object" && storedConfig !== null) {
+      if (isRecord<WidgetConfig>(storedConfig)) {
         const formattedConfig = { ...baseConfig, ...storedConfig };
         widgetConfigCache.setState({ [widgetConfigKey]: formattedConfig });
         return formattedConfig;

--- a/mobile/src/utils/validation.ts
+++ b/mobile/src/utils/validation.ts
@@ -12,7 +12,7 @@ export function isNumber(item: any): item is number {
 export function isRecord<
   TData extends Record<string, any> = Record<string, any>,
 >(item: any): item is TData {
-  return typeof item === "object" && item !== null;
+  return typeof item === "object" && item !== null && !Array.isArray(item);
 }
 
 export function isString(item: any): item is string {

--- a/mobile/src/utils/validation.ts
+++ b/mobile/src/utils/validation.ts
@@ -9,6 +9,12 @@ export function isNumber(item: any): item is number {
   return typeof item === "number";
 }
 
+export function isRecord<
+  TData extends Record<string, any> = Record<string, any>,
+>(item: any): item is TData {
+  return typeof item === "object" && item !== null;
+}
+
 export function isString(item: any): item is string {
   return typeof item === "string";
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR implements v2 of our JSON backup feature. **The prior JSON backup files can still be imported as we still retained the old code. We'll keep supporting it for now until v4 or v5.**

The main difference in v2 of our JSON backup feature is that:
- Tracks are now identified by their `uri` instead of their "features" (name, artist name, album).
  - This makes it less likely for a different track with the same "features" from being incorrectly assigned to a playlist.
  - In a future revision or v3 of the JSON backup feature, we'll maybe add a fallback identifier which would be a relative path based on where we save the backup file.
- Manually edited track metadata is now also exported.

> [!NOTE]
> We also though about adding support for exporting lyrics, but that would probably be considered distributing, in which we don't want to take the risk.

One downside to the uri-based approach of identifying tracks is that **it might not behave as expected for tracks on SD cards, since their URI will most likely change when inserted in a different device (I can't really test this).**
- One solution to that problem is to manually edit the SD card URIs `music_backup_v2.json` file after figuring out the general structure of the URIs stored on the SD card on the new device.

### Other Changes

- Created a new `isRecord()` helper, which we also use for the widget customization feature.
- When creating the album-to-artists relation in `upsertAlbums()`, we now have a `.onConflictDoNothing()` when creating those relations due to potentially passing duplicate albums to `upsertAlbums()`.
- Tracks returned by `getPlaylistSummary()` now also include their `uri`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] New files have the SPDX license identifier at the top of the file.
- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved JSON backup support with export and import for the latest backup format.
  * Backups can now preserve edited track details, playlists, and favorites more completely.
  * Playlist summaries with tracks now include each track’s URI.

* **Bug Fixes**
  * Duplicate album-artist relation entries are now handled safely during album updates.
  * Backup and stored widget data now use stricter validation for more reliable loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->