### PR TITLE
🧪chore: Apply transparent style to more areas in widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -30,7 +30,7 @@ Displays the current playing track artwork. Clicking on the widget will play/pau
 
 Offers quick access to media controls (Play/Pause). **When the widget is wide enough, it also offers Prev & Next controls.** Clicking anywhere but the media controls will open the app.
 
-> **Supports:** Customizations, Resizing
+> **Supports:** Customizations, Resizing (Horizontal)
 
 ### [2×2] Now Playing
 
@@ -46,7 +46,7 @@ Offers quick access to media controls (Play/Pause, Prev, Next). Clicking on the 
 
 Offers quick access to media controls (Play/Pause, Prev, Next). Clicking anywhere but the media controls will open the app.
 
-> **Supports:** Customizations, Resizing
+> **Supports:** Customizations, Resizing (Horizontal)
 
 ## Customizations
 
@@ -55,9 +55,6 @@ We support customizing the colors used by our widgets. **These are applied per-w
 - `[2×1] Now Playing`
 - `[2×2] Now Playing`
 - `[4×2] Now Playing`
-
-> [!NOTE]
-> Not all of the options that can be configured will be applied as they aren't used.
 
 ## Known Issues
 

--- a/mobile/src/modules/widget/WidgetConfigurationScreen.tsx
+++ b/mobile/src/modules/widget/WidgetConfigurationScreen.tsx
@@ -21,11 +21,8 @@ import type { WidgetName } from "./impl";
 import { nameToWidget } from "./impl";
 import type { WidgetConfig } from "./types";
 import { getWidgetData } from "./utils";
-import {
-  getWidgetConfig,
-  getWidgetConfigKey,
-  updateWidgetConfig,
-} from "./utils/customize";
+import { getWidgetConfigKey } from "./utils/customize";
+import { getWidgetConfig, updateWidgetConfig } from "./utils/customize.core";
 
 export function WidgetConfigurationScreen(
   props: WidgetConfigurationScreenProps,

--- a/mobile/src/modules/widget/WidgetConfigurationScreen.tsx
+++ b/mobile/src/modules/widget/WidgetConfigurationScreen.tsx
@@ -57,11 +57,7 @@ function WidgetConfigurationScreenPropsImpl({
 
         const Widget = nameToWidget[widgetInfo.widgetName as WidgetName];
         renderWidget(
-          <Widget
-            {...widgetData}
-            stylingConfig={config}
-            openApp={shouldOpen}
-          />,
+          <Widget {...widgetData} config={config} openApp={shouldOpen} />,
         );
       } catch (err) {
         console.log(err);

--- a/mobile/src/modules/widget/WidgetTaskHandler.tsx
+++ b/mobile/src/modules/widget/WidgetTaskHandler.tsx
@@ -42,11 +42,7 @@ export async function widgetTaskHandler({
       const shouldOpen = !(await isAudioBrowserSetUp());
       const styleConfig = await getWidgetConfig(widgetKey);
       renderWidget(
-        <Widget
-          {...widgetData}
-          stylingConfig={styleConfig}
-          openApp={shouldOpen}
-        />,
+        <Widget {...widgetData} config={styleConfig} openApp={shouldOpen} />,
       );
       break;
 
@@ -80,14 +76,14 @@ export async function widgetTaskHandler({
             renderWidget(
               <Widget
                 {...widgetData}
-                stylingConfig={DEFAULT_WIDGET_CONFIG}
+                config={DEFAULT_WIDGET_CONFIG}
                 overlayState={i}
               />,
             );
             await bgWait(i === 0 ? 500 : 50);
           }
           renderWidget(
-            <Widget {...widgetData} stylingConfig={DEFAULT_WIDGET_CONFIG} />,
+            <Widget {...widgetData} config={DEFAULT_WIDGET_CONFIG} />,
           );
         }
       } else {

--- a/mobile/src/modules/widget/WidgetTaskHandler.tsx
+++ b/mobile/src/modules/widget/WidgetTaskHandler.tsx
@@ -17,7 +17,7 @@ import {
   deleteWidgetConfig,
   getWidgetConfig,
   getWidgetConfigKey,
-} from "./utils/customize";
+} from "./utils/customize.core";
 import { updateWidgets } from "./utils/update";
 
 export async function widgetTaskHandler({

--- a/mobile/src/modules/widget/WidgetTaskHandler.tsx
+++ b/mobile/src/modules/widget/WidgetTaskHandler.tsx
@@ -13,11 +13,8 @@ import { DEFAULT_WIDGET_CONFIG } from "./constants/Config";
 import type { WidgetName } from "./impl";
 import { nameToWidget } from "./impl";
 import { getWidgetData } from "./utils";
-import {
-  deleteWidgetConfig,
-  getWidgetConfig,
-  getWidgetConfigKey,
-} from "./utils/customize.core";
+import { getWidgetConfigKey } from "./utils/customize";
+import { deleteWidgetConfig, getWidgetConfig } from "./utils/customize.core";
 import { updateWidgets } from "./utils/update";
 
 export async function widgetTaskHandler({

--- a/mobile/src/modules/widget/components/WidgetBaseLayout.tsx
+++ b/mobile/src/modules/widget/components/WidgetBaseLayout.tsx
@@ -7,8 +7,9 @@ import type {
 } from "react-native-android-widget";
 import { FlexWidget } from "react-native-android-widget";
 
-import type { WidgetDefinition } from "../types";
 import { Styles } from "../constants/Styles";
+import type { WidgetDefinition } from "../types";
+import { applyColor } from "../utils/customize";
 
 /**
  * General layout for widget while also center-aligning it on devices where
@@ -45,10 +46,7 @@ export function WidgetBaseLayout({
           overflow: "hidden",
           height,
           width,
-          backgroundColor:
-            transparent || config.transparent
-              ? Styles.color.transparent
-              : config.bgColor,
+          backgroundColor: applyColor(config, "bgColor", transparent),
           borderRadius: Styles.radius,
           ...style,
         }}

--- a/mobile/src/modules/widget/components/WidgetBaseLayout.tsx
+++ b/mobile/src/modules/widget/components/WidgetBaseLayout.tsx
@@ -19,7 +19,7 @@ export function WidgetBaseLayout({
   width = "match_parent",
   transparent,
   style,
-  stylingConfig,
+  config,
   ...props
 }: Omit<
   WidgetDefinition<
@@ -46,9 +46,9 @@ export function WidgetBaseLayout({
           height,
           width,
           backgroundColor:
-            transparent || stylingConfig.transparent
+            transparent || config.transparent
               ? Styles.color.transparent
-              : stylingConfig.bgColor,
+              : config.bgColor,
           borderRadius: Styles.radius,
           ...style,
         }}

--- a/mobile/src/modules/widget/constants/Styles.ts
+++ b/mobile/src/modules/widget/constants/Styles.ts
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 export const Styles = {
-  color: {
-    /** Can't pass `transparent` to `backgroundColor`. */
-    transparent: "#00000000",
-  },
-
   /** Estimated radius used by Nothing widgets from experimentation. */
   radius: 20,
 

--- a/mobile/src/modules/widget/impl/ArtworkPlayerWidget.tsx
+++ b/mobile/src/modules/widget/impl/ArtworkPlayerWidget.tsx
@@ -25,7 +25,7 @@ export function ArtworkPlayerWidget(props: WidgetProps) {
       height={size}
       width={size}
       style={{ alignItems: "center", justifyContent: "center" }}
-      stylingConfig={props.stylingConfig}
+      config={props.config}
     >
       <OverlapWidget>
         <WidgetArtwork

--- a/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
@@ -22,15 +22,10 @@ export function NowPlayingWidget(props: WidgetProps) {
   const positionOffset = cellSize + Styles.layoutGap;
   const openApp = props.openApp || props.track === undefined;
 
-  const clrs = props.stylingConfig;
+  const clrs = props.config;
 
   return (
-    <WidgetBaseLayout
-      height={size}
-      width={size}
-      stylingConfig={clrs}
-      transparent
-    >
+    <WidgetBaseLayout height={size} width={size} config={clrs} transparent>
       <OverlapWidget>
         <WidgetCell
           clickAction={Action.Open}

--- a/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { OverlapWidget } from "react-native-android-widget";
+import { FlexWidget } from "react-native-android-widget";
 
 import { Action, withAction } from "../constants/Action";
 import { Styles } from "../constants/Styles";
@@ -20,12 +20,17 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
   const cellSize = (size - Styles.layoutGap) / 2;
   const svgSize = cellSize / 2;
 
-  const positionOffset = cellSize + Styles.layoutGap;
   const openApp = props.openApp || props.track === undefined;
 
   return (
-    <WidgetBaseLayout height={size} width={size} config={config} transparent>
-      <OverlapWidget>
+    <WidgetBaseLayout
+      height={size}
+      width={size}
+      config={config}
+      transparent
+      style={{ flexGap: Styles.layoutGap }}
+    >
+      <FlexWidget style={{ flexDirection: "row", flexGap: Styles.layoutGap }}>
         <WidgetCell
           clickAction={Action.Open}
           size={cellSize}
@@ -37,7 +42,6 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
             artwork={props.track?.artwork ?? null}
           />
         </WidgetCell>
-
         <WidgetCell
           clickAction={withAction(Action.PlayPause, openApp)}
           size={cellSize}
@@ -45,7 +49,6 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
             config,
             props.isPlaying ? "inactiveColor" : "activeColor",
           )}
-          style={{ marginLeft: positionOffset }}
         >
           <WidgetSVG
             name={props.isPlaying ? "pause" : "play"}
@@ -56,12 +59,12 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
             )}
           />
         </WidgetCell>
-
+      </FlexWidget>
+      <FlexWidget style={{ flexDirection: "row", flexGap: Styles.layoutGap }}>
         <WidgetCell
           clickAction={withAction(Action.Prev, openApp)}
           size={cellSize}
           bgColor={applyColor(config, "bgColor")}
-          style={{ marginTop: positionOffset }}
         >
           <WidgetSVG name="prev" size={svgSize} color={config.textColor} />
         </WidgetCell>
@@ -70,11 +73,10 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
           clickAction={withAction(Action.Next, openApp)}
           size={cellSize}
           bgColor={applyColor(config, "bgColor")}
-          style={{ marginLeft: positionOffset, marginTop: positionOffset }}
         >
           <WidgetSVG name="next" size={svgSize} color={config.textColor} />
         </WidgetCell>
-      </OverlapWidget>
+      </FlexWidget>
     </WidgetBaseLayout>
   );
 }

--- a/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
@@ -13,7 +13,7 @@ import type { PlayerWidgetData, WidgetDefinition } from "../types";
 
 type WidgetProps = WidgetDefinition<PlayerWidgetData>;
 
-export function NowPlayingWidget(props: WidgetProps) {
+export function NowPlayingWidget({ config, ...props }: WidgetProps) {
   const size = Math.min(props.width, props.height);
 
   const cellSize = (size - Styles.layoutGap) / 2;
@@ -22,15 +22,13 @@ export function NowPlayingWidget(props: WidgetProps) {
   const positionOffset = cellSize + Styles.layoutGap;
   const openApp = props.openApp || props.track === undefined;
 
-  const clrs = props.config;
-
   return (
-    <WidgetBaseLayout height={size} width={size} config={clrs} transparent>
+    <WidgetBaseLayout height={size} width={size} config={config} transparent>
       <OverlapWidget>
         <WidgetCell
           clickAction={Action.Open}
           size={cellSize}
-          bgColor={clrs.bgColor}
+          bgColor={config.bgColor}
           style={{ borderRadius: Styles.radius }}
         >
           <WidgetArtwork
@@ -42,32 +40,34 @@ export function NowPlayingWidget(props: WidgetProps) {
         <WidgetCell
           clickAction={withAction(Action.PlayPause, openApp)}
           size={cellSize}
-          bgColor={clrs[props.isPlaying ? "inactiveColor" : "activeColor"]}
+          bgColor={config[props.isPlaying ? "inactiveColor" : "activeColor"]}
           style={{ marginLeft: positionOffset }}
         >
           <WidgetSVG
             name={props.isPlaying ? "pause" : "play"}
             size={svgSize}
-            color={clrs[props.isPlaying ? "onInactiveColor" : "onActiveColor"]}
+            color={
+              config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]
+            }
           />
         </WidgetCell>
 
         <WidgetCell
           clickAction={withAction(Action.Prev, openApp)}
           size={cellSize}
-          bgColor={clrs.bgColor}
+          bgColor={config.bgColor}
           style={{ marginTop: positionOffset }}
         >
-          <WidgetSVG name="prev" size={svgSize} color={clrs.textColor} />
+          <WidgetSVG name="prev" size={svgSize} color={config.textColor} />
         </WidgetCell>
 
         <WidgetCell
           clickAction={withAction(Action.Next, openApp)}
           size={cellSize}
-          bgColor={clrs.bgColor}
+          bgColor={config.bgColor}
           style={{ marginLeft: positionOffset, marginTop: positionOffset }}
         >
-          <WidgetSVG name="next" size={svgSize} color={clrs.textColor} />
+          <WidgetSVG name="next" size={svgSize} color={config.textColor} />
         </WidgetCell>
       </OverlapWidget>
     </WidgetBaseLayout>

--- a/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
@@ -10,6 +10,7 @@ import { WidgetBaseLayout } from "../components/WidgetBaseLayout";
 import { WidgetCell } from "../components/WidgetCell";
 import { WidgetSVG } from "../components/WidgetSVG";
 import type { PlayerWidgetData, WidgetDefinition } from "../types";
+import { applyColor, applyTextColor } from "../utils/customize";
 
 type WidgetProps = WidgetDefinition<PlayerWidgetData>;
 
@@ -40,30 +41,26 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
         <WidgetCell
           clickAction={withAction(Action.PlayPause, openApp)}
           size={cellSize}
-          bgColor={
-            config.transparent
-              ? Styles.color.transparent
-              : config[props.isPlaying ? "inactiveColor" : "activeColor"]
-          }
+          bgColor={applyColor(
+            config,
+            props.isPlaying ? "inactiveColor" : "activeColor",
+          )}
           style={{ marginLeft: positionOffset }}
         >
           <WidgetSVG
             name={props.isPlaying ? "pause" : "play"}
             size={svgSize}
-            color={
-              config.transparent
-                ? config.textColor
-                : config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]
-            }
+            color={applyTextColor(
+              config,
+              props.isPlaying ? "onInactiveColor" : "onActiveColor",
+            )}
           />
         </WidgetCell>
 
         <WidgetCell
           clickAction={withAction(Action.Prev, openApp)}
           size={cellSize}
-          bgColor={
-            config.transparent ? Styles.color.transparent : config.bgColor
-          }
+          bgColor={applyColor(config, "bgColor")}
           style={{ marginTop: positionOffset }}
         >
           <WidgetSVG name="prev" size={svgSize} color={config.textColor} />
@@ -72,9 +69,7 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
         <WidgetCell
           clickAction={withAction(Action.Next, openApp)}
           size={cellSize}
-          bgColor={
-            config.transparent ? Styles.color.transparent : config.bgColor
-          }
+          bgColor={applyColor(config, "bgColor")}
           style={{ marginLeft: positionOffset, marginTop: positionOffset }}
         >
           <WidgetSVG name="next" size={svgSize} color={config.textColor} />

--- a/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/NowPlayingWidget.tsx
@@ -40,14 +40,20 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
         <WidgetCell
           clickAction={withAction(Action.PlayPause, openApp)}
           size={cellSize}
-          bgColor={config[props.isPlaying ? "inactiveColor" : "activeColor"]}
+          bgColor={
+            config.transparent
+              ? Styles.color.transparent
+              : config[props.isPlaying ? "inactiveColor" : "activeColor"]
+          }
           style={{ marginLeft: positionOffset }}
         >
           <WidgetSVG
             name={props.isPlaying ? "pause" : "play"}
             size={svgSize}
             color={
-              config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]
+              config.transparent
+                ? config.textColor
+                : config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]
             }
           />
         </WidgetCell>
@@ -55,7 +61,9 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
         <WidgetCell
           clickAction={withAction(Action.Prev, openApp)}
           size={cellSize}
-          bgColor={config.bgColor}
+          bgColor={
+            config.transparent ? Styles.color.transparent : config.bgColor
+          }
           style={{ marginTop: positionOffset }}
         >
           <WidgetSVG name="prev" size={svgSize} color={config.textColor} />
@@ -64,7 +72,9 @@ export function NowPlayingWidget({ config, ...props }: WidgetProps) {
         <WidgetCell
           clickAction={withAction(Action.Next, openApp)}
           size={cellSize}
-          bgColor={config.bgColor}
+          bgColor={
+            config.transparent ? Styles.color.transparent : config.bgColor
+          }
           style={{ marginLeft: positionOffset, marginTop: positionOffset }}
         >
           <WidgetSVG name="next" size={svgSize} color={config.textColor} />

--- a/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
@@ -15,6 +15,7 @@ import type {
   WidgetConfig,
   WidgetDefinition,
 } from "../types";
+import { applyColor, applyTextColor } from "../utils/customize";
 
 type WidgetProps = WidgetDefinition<PlayerWidgetData>;
 
@@ -127,20 +128,20 @@ function MediaControls({
         style={{
           paddingHorizontal: paddingX,
           paddingVertical: paddingY,
-          backgroundColor: config.transparent
-            ? Styles.color.transparent
-            : config[props.isPlaying ? "inactiveColor" : "activeColor"],
+          backgroundColor: applyColor(
+            config,
+            props.isPlaying ? "inactiveColor" : "activeColor",
+          ),
           borderRadius: 999,
         }}
       >
         <WidgetSVG
           name={props.isPlaying ? "pause" : "play"}
           size={svgSize}
-          color={
-            config.transparent
-              ? config.textColor
-              : config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]
-          }
+          color={applyTextColor(
+            config,
+            props.isPlaying ? "onInactiveColor" : "onActiveColor",
+          )}
         />
       </FlexWidget>
       <WidgetSVG

--- a/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { FlexWidget, OverlapWidget } from "react-native-android-widget";
+import { FlexWidget } from "react-native-android-widget";
 
 import { Action, withAction } from "../constants/Action";
 import { Styles } from "../constants/Styles";
@@ -48,47 +48,45 @@ export function ResizableNowPlayingWidget({ config, ...props }: WidgetProps) {
       clickAction={Action.Open}
       height={widgetHeight}
       config={config}
+      style={{ flexDirection: "row" }}
     >
-      <OverlapWidget>
-        <WidgetCell
+      <WidgetCell
+        size={widgetHeight}
+        bgColor={config.inactiveColor}
+        style={{ borderRadius: config.transparent ? Styles.radius : 0 }}
+      >
+        <WidgetArtwork
           size={widgetHeight}
-          bgColor={config.inactiveColor}
-          style={{ borderRadius: config.transparent ? Styles.radius : 0 }}
-        >
-          <WidgetArtwork
-            size={widgetHeight}
-            artwork={props.track?.artwork ?? null}
-          />
-        </WidgetCell>
-        <FlexWidget
-          style={{
-            height: widgetHeight,
-            justifyContent: "flex-end",
-            padding: contentPadding,
-            marginLeft: widgetHeight,
-          }}
-        >
-          <WidgetText
-            text={props.track?.title}
-            maxLines={2}
-            color={config.textColor}
-            fontSize={textFontSize}
-          />
-          <WidgetText
-            text={props.track?.artist}
-            color={config.mutedTextColor}
-            fontSize={textFontSize}
-            style={{ paddingBottom: contentPadding }}
-          />
-          <MediaControls
-            maxWidth={contentWidth}
-            maxHeight={widgetHeight / 4}
-            openApp={openApp}
-            isPlaying={props.isPlaying}
-            config={config}
-          />
-        </FlexWidget>
-      </OverlapWidget>
+          artwork={props.track?.artwork ?? null}
+        />
+      </WidgetCell>
+      <FlexWidget
+        style={{
+          height: widgetHeight,
+          justifyContent: "flex-end",
+          padding: contentPadding,
+        }}
+      >
+        <WidgetText
+          text={props.track?.title}
+          maxLines={2}
+          color={config.textColor}
+          fontSize={textFontSize}
+        />
+        <WidgetText
+          text={props.track?.artist}
+          color={config.mutedTextColor}
+          fontSize={textFontSize}
+          style={{ paddingBottom: contentPadding }}
+        />
+        <MediaControls
+          maxWidth={contentWidth}
+          maxHeight={widgetHeight / 4}
+          openApp={openApp}
+          isPlaying={props.isPlaying}
+          config={config}
+        />
+      </FlexWidget>
     </WidgetBaseLayout>
   );
 }

--- a/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
@@ -127,15 +127,20 @@ function MediaControls({
         style={{
           paddingHorizontal: paddingX,
           paddingVertical: paddingY,
-          backgroundColor:
-            config[props.isPlaying ? "inactiveColor" : "activeColor"],
+          backgroundColor: config.transparent
+            ? Styles.color.transparent
+            : config[props.isPlaying ? "inactiveColor" : "activeColor"],
           borderRadius: 999,
         }}
       >
         <WidgetSVG
           name={props.isPlaying ? "pause" : "play"}
           size={svgSize}
-          color={config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]}
+          color={
+            config.transparent
+              ? config.textColor
+              : config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]
+          }
         />
       </FlexWidget>
       <WidgetSVG

--- a/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
@@ -18,7 +18,7 @@ import type {
 
 type WidgetProps = WidgetDefinition<PlayerWidgetData>;
 
-export function ResizableNowPlayingWidget(props: WidgetProps) {
+export function ResizableNowPlayingWidget({ config, ...props }: WidgetProps) {
   const canUseFullArea = props.width - props.height > 2 * props.height;
   let widgetHeight = props.height;
 
@@ -42,19 +42,17 @@ export function ResizableNowPlayingWidget(props: WidgetProps) {
 
   const openApp = props.openApp || props.track === undefined;
 
-  const clrs = props.config;
-
   return (
     <WidgetBaseLayout
       clickAction={Action.Open}
       height={widgetHeight}
-      config={clrs}
+      config={config}
     >
       <OverlapWidget>
         <WidgetCell
           size={widgetHeight}
-          bgColor={clrs.inactiveColor}
-          style={{ borderRadius: clrs.transparent ? Styles.radius : 0 }}
+          bgColor={config.inactiveColor}
+          style={{ borderRadius: config.transparent ? Styles.radius : 0 }}
         >
           <WidgetArtwork
             size={widgetHeight}
@@ -72,12 +70,12 @@ export function ResizableNowPlayingWidget(props: WidgetProps) {
           <WidgetText
             text={props.track?.title}
             maxLines={2}
-            color={clrs.textColor}
+            color={config.textColor}
             fontSize={textFontSize}
           />
           <WidgetText
             text={props.track?.artist}
-            color={clrs.mutedTextColor}
+            color={config.mutedTextColor}
             fontSize={textFontSize}
             style={{ paddingBottom: contentPadding }}
           />
@@ -86,7 +84,7 @@ export function ResizableNowPlayingWidget(props: WidgetProps) {
             maxHeight={widgetHeight / 4}
             openApp={openApp}
             isPlaying={props.isPlaying}
-            stylingConfig={clrs}
+            config={config}
           />
         </FlexWidget>
       </OverlapWidget>
@@ -95,18 +93,19 @@ export function ResizableNowPlayingWidget(props: WidgetProps) {
 }
 
 //#region Layout Helpers
-function MediaControls(props: {
+function MediaControls({
+  config,
+  ...props
+}: {
   maxWidth: number;
   maxHeight: number;
   openApp: boolean;
   isPlaying: boolean;
-  stylingConfig: WidgetConfig;
+  config: WidgetConfig;
 }) {
   const svgSize = Math.min(props.maxWidth / 7, (props.maxHeight * 2) / 3);
   const paddingY = svgSize / 9;
   const paddingX = paddingY * 5;
-
-  const clrs = props.stylingConfig;
 
   return (
     <FlexWidget
@@ -121,7 +120,7 @@ function MediaControls(props: {
         clickAction={withAction(Action.Prev, props.openApp)}
         name="prev"
         size={svgSize}
-        color={clrs.textColor}
+        color={config.textColor}
       />
       <FlexWidget
         clickAction={withAction(Action.PlayPause, props.openApp)}
@@ -129,21 +128,21 @@ function MediaControls(props: {
           paddingHorizontal: paddingX,
           paddingVertical: paddingY,
           backgroundColor:
-            clrs[props.isPlaying ? "inactiveColor" : "activeColor"],
+            config[props.isPlaying ? "inactiveColor" : "activeColor"],
           borderRadius: 999,
         }}
       >
         <WidgetSVG
           name={props.isPlaying ? "pause" : "play"}
           size={svgSize}
-          color={clrs[props.isPlaying ? "onInactiveColor" : "onActiveColor"]}
+          color={config[props.isPlaying ? "onInactiveColor" : "onActiveColor"]}
         />
       </FlexWidget>
       <WidgetSVG
         clickAction={withAction(Action.Next, props.openApp)}
         name="next"
         size={svgSize}
-        color={clrs.textColor}
+        color={config.textColor}
       />
     </FlexWidget>
   );

--- a/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/ResizableNowPlayingWidget.tsx
@@ -42,13 +42,13 @@ export function ResizableNowPlayingWidget(props: WidgetProps) {
 
   const openApp = props.openApp || props.track === undefined;
 
-  const clrs = props.stylingConfig;
+  const clrs = props.config;
 
   return (
     <WidgetBaseLayout
       clickAction={Action.Open}
       height={widgetHeight}
-      stylingConfig={clrs}
+      config={clrs}
     >
       <OverlapWidget>
         <WidgetCell

--- a/mobile/src/modules/widget/impl/SkinnyNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/SkinnyNowPlayingWidget.tsx
@@ -15,7 +15,7 @@ type WidgetProps = WidgetDefinition<PlayerWidgetData>;
 const SMALL_GAP = 8;
 const FULL_ROUNDED = 999;
 
-export function SkinnyNowPlayingWidget(props: WidgetProps) {
+export function SkinnyNowPlayingWidget({ config, ...props }: WidgetProps) {
   const showAdditionalActions = props.width > props.height * 2.5;
 
   // Calculate height of widget if we only support showing the play/pause action.
@@ -36,11 +36,9 @@ export function SkinnyNowPlayingWidget(props: WidgetProps) {
 
   const openApp = props.openApp || props.track === undefined;
 
-  const clrs = props.config;
-
   return (
     <WidgetBaseLayout
-      config={clrs}
+      config={config}
       height={widgetHeight}
       style={{
         flexDirection: "row",
@@ -51,7 +49,7 @@ export function SkinnyNowPlayingWidget(props: WidgetProps) {
       <WidgetCell
         clickAction={Action.Open}
         size={widgetHeight}
-        bgColor={clrs.inactiveColor}
+        bgColor={config.inactiveColor}
         style={{ borderRadius: FULL_ROUNDED }}
       >
         <WidgetArtwork
@@ -75,21 +73,21 @@ export function SkinnyNowPlayingWidget(props: WidgetProps) {
             clickAction={withAction(Action.Prev, openApp)}
             name="prev"
             size={svgSize}
-            color={clrs.textColor}
+            color={config.textColor}
           />
         ) : null}
         <WidgetSVG
           clickAction={withAction(Action.PlayPause, openApp)}
           name={props.isPlaying ? "pause" : "play"}
           size={svgSize}
-          color={clrs.textColor}
+          color={config.textColor}
         />
         {showAdditionalActions ? (
           <WidgetSVG
             clickAction={withAction(Action.Next, openApp)}
             name="next"
             size={svgSize}
-            color={clrs.textColor}
+            color={config.textColor}
           />
         ) : null}
       </FlexWidget>

--- a/mobile/src/modules/widget/impl/SkinnyNowPlayingWidget.tsx
+++ b/mobile/src/modules/widget/impl/SkinnyNowPlayingWidget.tsx
@@ -36,11 +36,11 @@ export function SkinnyNowPlayingWidget(props: WidgetProps) {
 
   const openApp = props.openApp || props.track === undefined;
 
-  const clrs = props.stylingConfig;
+  const clrs = props.config;
 
   return (
     <WidgetBaseLayout
-      stylingConfig={clrs}
+      config={clrs}
       height={widgetHeight}
       style={{
         flexDirection: "row",

--- a/mobile/src/modules/widget/types.ts
+++ b/mobile/src/modules/widget/types.ts
@@ -34,3 +34,9 @@ export interface WidgetConfig {
   inactiveColor: HexColor;
   onInactiveColor: HexColor;
 }
+
+type ExtractColorKeys<T> = {
+  [K in keyof T]: K extends `${string}Color` ? K : never;
+}[keyof T];
+
+export type WidgetConfigColors = ExtractColorKeys<WidgetConfig>;

--- a/mobile/src/modules/widget/types.ts
+++ b/mobile/src/modules/widget/types.ts
@@ -19,7 +19,7 @@ export type PlayerWidgetData = {
 export type WidgetDefinition<T> = T & {
   height: number;
   width: number;
-  stylingConfig: WidgetConfig;
+  config: WidgetConfig;
 };
 
 export interface WidgetConfig {

--- a/mobile/src/modules/widget/utils/customize.core.ts
+++ b/mobile/src/modules/widget/utils/customize.core.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Storage from "expo-sqlite/kv-store";
+import { createStore } from "zustand/vanilla";
+
+import { isRecord } from "~/utils/validation";
+import { isWidgetConfigSupported } from "./customize";
+import { DEFAULT_WIDGET_CONFIG } from "../constants/Config";
+import type { WidgetConfig } from "../types";
+
+/** Local cache of widget configs so we don't overload calling the database. */
+export const widgetConfigCache = createStore<Record<string, WidgetConfig>>()(
+  () => ({}),
+);
+
+export async function getWidgetConfig(
+  widgetConfigKey: string,
+): Promise<WidgetConfig> {
+  const baseConfig = { ...DEFAULT_WIDGET_CONFIG };
+  if (!isWidgetConfigSupported(widgetConfigKey)) return baseConfig;
+
+  // First check to see if it's cached.
+  const cachedConfig = widgetConfigCache.getState()[widgetConfigKey];
+  if (cachedConfig) return cachedConfig;
+
+  const config = await Storage.getItemAsync(widgetConfigKey);
+  if (config) {
+    try {
+      const storedConfig = JSON.parse(config);
+      // Verify we're storing an object.
+      if (isRecord<WidgetConfig>(storedConfig)) {
+        const formattedConfig = { ...baseConfig, ...storedConfig };
+        widgetConfigCache.setState({ [widgetConfigKey]: formattedConfig });
+        return formattedConfig;
+      }
+    } catch {}
+  }
+
+  widgetConfigCache.setState({ [widgetConfigKey]: baseConfig });
+  return baseConfig;
+}
+
+export async function deleteWidgetConfig(widgetConfigKey: string) {
+  if (!isWidgetConfigSupported(widgetConfigKey)) return;
+
+  //? We get the following error if we use the sync method:
+  //?   - "Error: Call to function 'NativeDatabase.prepareAsync' has been rejected."
+  //?
+  //? This method might get called on a previously deleted widget due to
+  //? weird behavior that appeared with New Architecture implementation.
+  await Storage.removeItemAsync(widgetConfigKey);
+}
+
+export async function updateWidgetConfig(
+  widgetConfigKey: string,
+  config: WidgetConfig,
+) {
+  if (!isWidgetConfigSupported(widgetConfigKey)) return;
+
+  try {
+    widgetConfigCache.setState({ [widgetConfigKey]: config });
+
+    const stringifiedConfig = JSON.stringify(config);
+    await Storage.setItemAsync(widgetConfigKey, stringifiedConfig);
+  } catch {}
+}

--- a/mobile/src/modules/widget/utils/customize.ts
+++ b/mobile/src/modules/widget/utils/customize.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { WidgetInfo } from "react-native-android-widget";
 
 import type { WidgetConfig, WidgetConfigColors } from "../types";

--- a/mobile/src/modules/widget/utils/customize.ts
+++ b/mobile/src/modules/widget/utils/customize.ts
@@ -1,15 +1,5 @@
-// Copyright (C) 2024 - present, MissingCore
-// SPDX-License-Identifier: AGPL-3.0-only
-
-import Storage from "expo-sqlite/kv-store";
 import type { WidgetInfo } from "react-native-android-widget";
-import { createStore } from "zustand/vanilla";
 
-import { isRecord } from "~/utils/validation";
-import { DEFAULT_WIDGET_CONFIG } from "../constants/Config";
-import type { WidgetConfig } from "../types";
-
-//#region Helpers
 export function getWidgetConfigKey(args: WidgetInfo) {
   return `WIDGET_${args.widgetName}_${args.widgetId}`;
 }
@@ -17,64 +7,3 @@ export function getWidgetConfigKey(args: WidgetInfo) {
 export function isWidgetConfigSupported(widgetConfigKey: string) {
   return !widgetConfigKey.startsWith("WIDGET_ArtworkPlayer");
 }
-//#endregion
-
-//#region Config Persistence
-
-/** Local cache of widget configs so we don't overload calling the database. */
-export const widgetConfigCache = createStore<Record<string, WidgetConfig>>()(
-  () => ({}),
-);
-
-export async function getWidgetConfig(
-  widgetConfigKey: string,
-): Promise<WidgetConfig> {
-  const baseConfig = { ...DEFAULT_WIDGET_CONFIG };
-  if (!isWidgetConfigSupported(widgetConfigKey)) return baseConfig;
-
-  // First check to see if it's cached.
-  const cachedConfig = widgetConfigCache.getState()[widgetConfigKey];
-  if (cachedConfig) return cachedConfig;
-
-  const config = await Storage.getItemAsync(widgetConfigKey);
-  if (config) {
-    try {
-      const storedConfig = JSON.parse(config);
-      // Verify we're storing an object.
-      if (isRecord<WidgetConfig>(storedConfig)) {
-        const formattedConfig = { ...baseConfig, ...storedConfig };
-        widgetConfigCache.setState({ [widgetConfigKey]: formattedConfig });
-        return formattedConfig;
-      }
-    } catch {}
-  }
-
-  widgetConfigCache.setState({ [widgetConfigKey]: baseConfig });
-  return baseConfig;
-}
-
-export async function deleteWidgetConfig(widgetConfigKey: string) {
-  if (!isWidgetConfigSupported(widgetConfigKey)) return;
-
-  //? We get the following error if we use the sync method:
-  //?   - "Error: Call to function 'NativeDatabase.prepareAsync' has been rejected."
-  //?
-  //? This method might get called on a previously deleted widget due to
-  //? weird behavior that appeared with New Architecture implementation.
-  await Storage.removeItemAsync(widgetConfigKey);
-}
-
-export async function updateWidgetConfig(
-  widgetConfigKey: string,
-  config: WidgetConfig,
-) {
-  if (!isWidgetConfigSupported(widgetConfigKey)) return;
-
-  try {
-    widgetConfigCache.setState({ [widgetConfigKey]: config });
-
-    const stringifiedConfig = JSON.stringify(config);
-    await Storage.setItemAsync(widgetConfigKey, stringifiedConfig);
-  } catch {}
-}
-//#endregion

--- a/mobile/src/modules/widget/utils/customize.ts
+++ b/mobile/src/modules/widget/utils/customize.ts
@@ -1,9 +1,31 @@
 import type { WidgetInfo } from "react-native-android-widget";
 
+import type { WidgetConfig, WidgetConfigColors } from "../types";
+
 export function getWidgetConfigKey(args: WidgetInfo) {
   return `WIDGET_${args.widgetName}_${args.widgetId}`;
 }
 
 export function isWidgetConfigSupported(widgetConfigKey: string) {
   return !widgetConfigKey.startsWith("WIDGET_ArtworkPlayer");
+}
+
+export function applyColor(
+  config: WidgetConfig,
+  color: WidgetConfigColors,
+  overrideIsTransparent = false,
+) {
+  const isTransparent = overrideIsTransparent || config.transparent;
+  //? Can't pass `transparent` to `backgroundColor`, so use hex color.
+  return isTransparent ? "#00000000" : config[color];
+}
+
+/** Applies specified color over background. */
+export function applyTextColor(
+  config: WidgetConfig,
+  color: WidgetConfigColors,
+  overrideIsTransparent = false,
+) {
+  const isTransparent = overrideIsTransparent || config.transparent;
+  return isTransparent ? config.textColor : config[color];
 }

--- a/mobile/src/modules/widget/utils/update.tsx
+++ b/mobile/src/modules/widget/utils/update.tsx
@@ -3,7 +3,8 @@
 
 import { requestWidgetUpdate } from "react-native-android-widget";
 
-import { getWidgetConfig, getWidgetConfigKey } from "./customize.core";
+import { getWidgetConfigKey } from "./customize";
+import { getWidgetConfig } from "./customize.core";
 import type { WidgetName } from "../impl";
 import { nameToWidget } from "../impl";
 import type { PlayerWidgetData } from "../types";

--- a/mobile/src/modules/widget/utils/update.tsx
+++ b/mobile/src/modules/widget/utils/update.tsx
@@ -31,9 +31,7 @@ export async function updateWidgets({
           const configStyle = await getWidgetConfig(
             getWidgetConfigKey(widgetInfo),
           );
-          return (
-            <Widget {...widgetInfo} stylingConfig={configStyle} {...args} />
-          );
+          return <Widget {...widgetInfo} config={configStyle} {...args} />;
         },
       }),
     ),

--- a/mobile/src/modules/widget/utils/update.tsx
+++ b/mobile/src/modules/widget/utils/update.tsx
@@ -3,7 +3,7 @@
 
 import { requestWidgetUpdate } from "react-native-android-widget";
 
-import { getWidgetConfig, getWidgetConfigKey } from "./customize";
+import { getWidgetConfig, getWidgetConfigKey } from "./customize.core";
 import type { WidgetName } from "../impl";
 import { nameToWidget } from "../impl";
 import type { PlayerWidgetData } from "../types";


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR applies the `transparent` widget config to additional locations (specifically the media control buttons on the `2×2` & `4×2` widgets).

### Other Changes

- Created helpers to determining which color to apply based on the `transparent` config.
- Simplified layout of widgets (don't use `OverlapWidget` when it's not necessary).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] New files have the SPDX license identifier at the top of the file.
- [x] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced widget styling with consistent background and icon colors, including correct transparency handling.
  * Improved Now Playing widget layout and playback-control appearance for more reliable color application.
  * Faster widget configuration loading via in-memory caching.

* **Documentation**
  * Updated widget docs to explicitly state horizontal resizing support for Now Playing widgets.
  * Removed an outdated customization limitation note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->