### PR TITLE
feat: Support controlling size of column used in "List" layout

### DIFF
--- a/mobile/src/hooks/useLayoutConfigs.ts
+++ b/mobile/src/hooks/useLayoutConfigs.ts
@@ -23,7 +23,7 @@ interface ColumnOptions extends ClampOptions {
 //#region Layout Config Hooks
 /** Get column configurations for "cards" in a compact grid. */
 export function useCompactGridLayoutConfig(args: ColumnOptions = {}) {
-  return useGetLayoutConfig({ compact: true, ...args, minCols: 3 });
+  return useGetLayoutConfig({ fallback: "compactGrid", ...args, minCols: 3 });
 }
 
 /** Get column configurations for "cards" in a grid. */
@@ -37,8 +37,8 @@ export function useHorizontalListLayoutConfig(args: ClampOptions = {}) {
 }
 
 /** Get column configurations for "items" in a list. */
-export function useListLayoutConfig(args?: ClampOptions) {
-  return useGetLayoutConfig({ ...args, minWidth: 272 });
+export function useListLayoutConfig(args: ClampOptions = {}) {
+  return useGetLayoutConfig({ fallback: "list", ...args });
 }
 //#endregion
 
@@ -54,14 +54,17 @@ function getColSize(width: number, cols: number, gap: number) {
 }
 
 /** Determine the width a column will take up based on parameters. */
-function useGetLayoutConfig(args: ColumnOptions & { compact?: boolean }) {
+function useGetLayoutConfig(
+  args: ColumnOptions & { fallback?: "compactGrid" | "grid" | "list" },
+) {
   const { width: screenWidth } = useWindowDimensions();
-  const compactGridSize = useViewPreferenceStore((s) => s.compactGridSize);
-  const gridSize = useViewPreferenceStore((s) => s.gridSize);
+  const fallbackWidth = useViewPreferenceStore(
+    (s) => s[`${args.fallback || "grid"}Size`],
+  );
 
   const width = screenWidth * (1 - (args.percentDeduction || 0));
   const minCols = args.minCols ?? 1;
-  const minWidth = args.minWidth ?? (args.compact ? compactGridSize : gridSize);
+  const minWidth = args.minWidth ?? fallbackWidth;
   const gap = args.gap ?? CONTENT_GAP;
 
   return useMemo(() => {

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -437,8 +437,9 @@
         "list": "List",
         "grid": "Grid",
         "compactGrid": "Compact Grid",
-        "gridColumnSize": "Grid Column Size",
-        "gridColumnCount": "Column Count: {{count}}",
+
+        "columnSize": "Column Size",
+        "columnCount": "Column Count: {{count}}",
 
         "sort": "Sort Order",
         "asc": "Ascending Order",

--- a/mobile/src/navigation/screens/settings/AppearanceSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/AppearanceSettingsView.tsx
@@ -108,7 +108,7 @@ function GridColumnSizeSetting() {
   return (
     <SegmentedList.CustomItem className="gap-6 p-4">
       <TStyledText
-        textKey="feat.modalViewPreference.extra.gridColumnSize"
+        textKey="feat.modalViewPreference.extra.columnSize"
         className="text-sm"
       />
       <Divider className="-my-2" />
@@ -147,7 +147,7 @@ function ColumnSizeSlider({ field }: { field: "grid" | "compactGrid" }) {
         displayedValue={String(_columnSize)}
       />
       <StyledText dim className="-mt-3">
-        {t("feat.modalViewPreference.extra.gridColumnCount", { count })}
+        {t("feat.modalViewPreference.extra.columnCount", { count })}
       </StyledText>
     </View>
   );

--- a/mobile/src/navigation/screens/settings/AppearanceSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/AppearanceSettingsView.tsx
@@ -12,10 +12,14 @@ import { usePreferenceStore } from "~/stores/Preference/store";
 import { PreferenceTogglers } from "~/stores/Preference/actions";
 import { useViewPreferenceStore } from "~/stores/ViewPreference/store";
 import { ViewPreferenceSetters } from "~/stores/ViewPreference/actions";
-import { GridColumnSizeConfig } from "~/stores/ViewPreference/utils";
+import {
+  GridColumnSizeConfig,
+  ListColumnSizeConfig,
+} from "~/stores/ViewPreference/utils";
 import {
   useCompactGridLayoutConfig,
   useGridLayoutConfig,
+  useListLayoutConfig,
 } from "~/hooks/useLayoutConfigs";
 
 import { ListLayout } from "~/navigation/layouts/ListLayout";
@@ -112,14 +116,24 @@ function GridColumnSizeSetting() {
         className="text-sm"
       />
       <Divider className="-my-2" />
+      <ColumnSizeSlider field="list" />
       <ColumnSizeSlider field="grid" />
       <ColumnSizeSlider field="compactGrid" />
     </SegmentedList.CustomItem>
   );
 }
 
-function ColumnSizeSlider({ field }: { field: "grid" | "compactGrid" }) {
-  const fieldName = `${field}Size` as const;
+const ColumnConfig = {
+  list: { bound: ListColumnSizeConfig.bound, hook: useListLayoutConfig },
+  grid: { bound: GridColumnSizeConfig.bound, hook: useGridLayoutConfig },
+  compactGrid: {
+    bound: GridColumnSizeConfig.bound,
+    hook: useCompactGridLayoutConfig,
+  },
+} as const;
+
+function ColumnSizeSlider(props: { field: keyof typeof ColumnConfig }) {
+  const fieldName = `${props.field}Size` as const;
 
   const { t } = useTranslation();
   const columnSize = useViewPreferenceStore((s) => s[fieldName]);
@@ -131,18 +145,18 @@ function ColumnSizeSlider({ field }: { field: "grid" | "compactGrid" }) {
     (currVal) => scheduleOnRN(_setColumnSize, currVal),
   );
 
+  const Config = ColumnConfig[props.field];
+
   //? Column calculation is different based on the grid layout.
-  const { count } = (
-    field === "grid" ? useGridLayoutConfig : useCompactGridLayoutConfig
-  )({ minWidth: _columnSize });
+  const { count } = Config.hook({ minWidth: _columnSize });
 
   return (
     <View className="gap-2">
-      <TEm textKey={`feat.modalViewPreference.extra.${field}`} />
+      <TEm textKey={`feat.modalViewPreference.extra.${props.field}`} />
       <LabeledSlider
         initValue={columnSize}
         liveValue={cachedValue}
-        {...GridColumnSizeConfig.bound}
+        {...Config.bound}
         onComplete={ViewPreferenceSetters.setColumnSize(fieldName)}
         displayedValue={String(_columnSize)}
       />

--- a/mobile/src/stores/ViewPreference/actions/setters.ts
+++ b/mobile/src/stores/ViewPreference/actions/setters.ts
@@ -4,13 +4,15 @@
 import { viewPreferenceStore } from "../store";
 import type { LayoutOption, ScreenSortOptions } from "../constants";
 import type { MutableViewLayout, MutableViewOrder } from "../types";
-import { GridColumnSizeConfig } from "../utils";
+import { GridColumnSizeConfig, ListColumnSizeConfig } from "../utils";
 
-export function setColumnSize(key: "gridSize" | "compactGridSize") {
+export function setColumnSize(
+  key: "listSize" | "gridSize" | "compactGridSize",
+) {
+  const ConfigProvider =
+    key === "listSize" ? ListColumnSizeConfig : GridColumnSizeConfig;
   return (columnSize: number) => {
-    viewPreferenceStore.setState({
-      [key]: GridColumnSizeConfig.clamp(columnSize),
-    });
+    viewPreferenceStore.setState({ [key]: ConfigProvider.clamp(columnSize) });
   };
 }
 

--- a/mobile/src/stores/ViewPreference/constants.ts
+++ b/mobile/src/stores/ViewPreference/constants.ts
@@ -77,6 +77,8 @@ export interface ViewPreferenceStore {
   /** Get a more accurate initial state. */
   _init: (state: ViewPreferenceStore) => Promise<void>;
 
+  /** Min width of columns in "List" layout. */
+  listSize: number;
   /** Min width of columns in "Grid" layout. */
   gridSize: number;
   /** Min width of columns in "Compact Grid" layout. */

--- a/mobile/src/stores/ViewPreference/store.ts
+++ b/mobile/src/stores/ViewPreference/store.ts
@@ -14,6 +14,7 @@ export const viewPreferenceStore = createPersistedStore<ViewPreferenceStore>(
       set({ _hasHydrated: true });
     },
 
+    listSize: 272,
     gridSize: 144,
     compactGridSize: 72,
 

--- a/mobile/src/stores/ViewPreference/utils.ts
+++ b/mobile/src/stores/ViewPreference/utils.ts
@@ -11,7 +11,7 @@ export const GridColumnSizeConfig = {
 };
 
 export const ListColumnSizeConfig = {
-  bound: { min: 100, max: 400 },
+  bound: { min: 150, max: 400 },
   clamp(value: number) {
     return clamp(this.bound.min, value, this.bound.max);
   },

--- a/mobile/src/stores/ViewPreference/utils.ts
+++ b/mobile/src/stores/ViewPreference/utils.ts
@@ -9,3 +9,10 @@ export const GridColumnSizeConfig = {
     return clamp(this.bound.min, value, this.bound.max);
   },
 };
+
+export const ListColumnSizeConfig = {
+  bound: { min: 100, max: 400 },
+  clamp(value: number) {
+    return clamp(this.bound.min, value, this.bound.max);
+  },
+};


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This does the same idea as in #549, but for the "List" layout. This has an added benefit of making it easier to test tablet layouts (ie: their different permutations).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] New files have the SPDX license identifier at the top of the file.
- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added column size controls for List, Grid, and Compact Grid layouts in Appearance settings.
  * List layout column width preferences are now saved and restored between sessions.
  * Column sizes are automatically constrained to supported limits for consistent display.
* **Improvements**
  * Updated column size labels and settings presentation for a clearer, more consistent experience across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->