### PR TITLE
feat: parse comma-separated track artist credits

### DIFF
--- a/mobile/src/modules/scanning/helpers/audio.ts
+++ b/mobile/src/modules/scanning/helpers/audio.ts
@@ -334,7 +334,7 @@ class MediaStoreQuerier {
       /** @deprecated Do not use this field directly. */
       rawArtistName: trimmedArtistName,
       artistNames: trimmedArtistName
-        ? splitOn(trimmedArtistName, this.delimiters)
+        ? parseTrackArtistNames(trimmedArtistName, this.delimiters)
         : [],
       album: newAlbum,
       track: metadata.trackNumber,
@@ -445,7 +445,7 @@ class MetadataRetrieverQuerier {
       /** @deprecated Do not use this field directly. */
       rawArtistName: trimmedArtistName,
       artistNames: trimmedArtistName
-        ? splitOn(trimmedArtistName, this.delimiters)
+        ? parseTrackArtistNames(trimmedArtistName, this.delimiters)
         : [],
       album: newAlbum,
       track: t.trackNumber,
@@ -464,7 +464,19 @@ class MetadataRetrieverQuerier {
   }
 }
 //#endregion
-
+/**
+ * Split track artist credits on commas and user-configured separators.
+ */
+function parseTrackArtistNames(
+  artistName: string,
+  configuredSeparators: string[],
+) {
+  const separators = [
+    ",",
+    ...configuredSeparators.filter((separator) => separator !== ","),
+  ];
+  return splitOn(artistName, separators);
+}
 //#region Internal Helpers
 const UpsertInvalidTrackFields = getExcludedColumns([
   "uri",


### PR DESCRIPTION
Title: feat: parse comma-separated track artist credits

## Why

Track artist metadata containing comma-separated credits is currently treated as one artist unless the user manually configures a comma as a multi-value separator. For libraries that encode collaborations as `Artist A, Artist B`, this prevents the track from appearing under each credited artist.

## What changed

- Added a focused track-artist parser that always recognizes commas while preserving user-configured separators.
- Applied the parser to both the Android MediaStore and metadata-retriever scanning paths.
- Kept the raw embedded artist value unchanged.
- Left album-artist and genre parsing unchanged.

The existing `tracks_to_artists` relation writer continues to store one track with multiple artist links, so this does not create duplicate tracks or playlists.

## User impact

After a Deep Rescan, an unedited track credited to `Artist A, Artist B` appears on both artist pages. Tracks whose local metadata was manually edited remain protected from rescanning.

Because comma is now a built-in delimiter for track artist metadata, a legitimate single artist name containing a comma will also be split.

## Testing plan

- [x] `pnpm exec eslint src/modules/scanning/helpers/audio.ts`
- [x] `pnpm exec prettier --check src/modules/scanning/helpers/audio.ts`
- [x] `git diff --check`
- [x] Built and ran the Android development variant on a physical device.
- [x] Ran Deep Rescan and verified that one comma-credited track appears under each linked artist without duplicating the track.
- [x] Confirmed user-configured separators remain supported.

`pnpm typecheck` currently reports unrelated errors in existing navigation and insights files; this change does not modify those files.

## Checklist

- [x] No new files or dependencies were added.
- [x] Existing SPDX headers remain intact.
- [x] No database schema or native Android changes were required.
- [x] pnpm android:prod 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artist credit parsing during track scanning.
  * Artist names are now split consistently across scanning methods, including comma-separated credits and configured separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->