### PR TITLE
refactor: Use translation key trick

### DIFF
--- a/mobile/src/components/List/index.tsx
+++ b/mobile/src/components/List/index.tsx
@@ -1,11 +1,12 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { ParseKeys } from "i18next";
 import { memo, useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import type { StyleProp, TextStyle, ViewStyle } from "react-native";
 import { View } from "react-native";
+
+import type { TranslationKeyOrString } from "~/modules/i18n/core";
+import { useMaybeT } from "~/modules/i18n/core";
 
 import { cn } from "~/lib/style";
 import type { VariantColor } from "~/modules/customization/theme/core/constants";
@@ -41,7 +42,7 @@ export const ListItem = memo(function StandardListItem(props: ListItemProps) {
 //#region List Item Slots
 interface ListItemSlotsProps {
   /** Will be larger if `Leading` is provided & `supportingText` is omitted. */
-  labelText: ParseKeys | (string & {});
+  labelText: TranslationKeyOrString;
   supportingText?: string;
 
   Leading?: React.ReactNode;
@@ -56,7 +57,7 @@ interface ListItemSlotsProps {
 }
 
 const ListItemSlots = memo(function ListItemSlots(props: ListItemSlotsProps) {
-  const { t } = useTranslation();
+  const t = useMaybeT();
   const theme = useTheme();
 
   const lineCount = props._overflow ? undefined : 1;
@@ -77,7 +78,6 @@ const ListItemSlots = memo(function ListItemSlots(props: ListItemSlotsProps) {
             props._labelTextClassName,
           )}
         >
-          {/* @ts-expect-error - If the key doesn't exist, then the string is outputted. */}
           {t(props.labelText)}
         </StyledText>
         {props.supportingText ? (

--- a/mobile/src/components/Modal.tsx
+++ b/mobile/src/components/Modal.tsx
@@ -5,6 +5,8 @@ import type { ParseKeys } from "i18next";
 import { useState } from "react";
 import { Modal as RNModal, View } from "react-native";
 
+import type { TranslationKeyOrString } from "~/modules/i18n/core";
+
 import { cn } from "~/lib/style";
 import { GestureHandlerRootView } from "./Base/GestureHandlerRootView";
 import type { RipplePressProps } from "./Base/Pressable";
@@ -79,7 +81,8 @@ export function ConfirmableAction<
   Component: TComponent;
   componentProps: React.ComponentProps<TComponent> & { onPress: VoidFunction };
   disableModal?: boolean;
-  modalMessage: [ParseKeys] | [ParseKeys, ParseKeys];
+  modalMessage:
+    [TranslationKeyOrString] | [TranslationKeyOrString, TranslationKeyOrString];
 }) {
   const [visible, setVisible] = useState(false);
   return (
@@ -93,6 +96,7 @@ export function ConfirmableAction<
       />
       <Modal visible={visible}>
         {props.modalMessage.map((msg) => (
+          // @ts-expect-error - If the key doesn't exist, then the string is outputted.
           <TStyledText key={msg} textKey={msg} style={{ fontSize: 18 }} />
         ))}
         <ModalActions

--- a/mobile/src/modules/customization/font/screens/CreateView.tsx
+++ b/mobile/src/modules/customization/font/screens/CreateView.tsx
@@ -72,7 +72,7 @@ function FontForm() {
 
   return (
     <KeyboardAwareScrollView contentContainerClassName="gap-6 p-4">
-      <FormInput labelKey="feat.trackMetadata.extra.name" field="name" />
+      <FormInput label="feat.trackMetadata.extra.name" field="name" />
       {!data.uri ? (
         <ExtendedTButton
           textKey="feat.backup.extra.import"

--- a/mobile/src/modules/customization/theme/components/ModifyViewBase.tsx
+++ b/mobile/src/modules/customization/theme/components/ModifyViewBase.tsx
@@ -80,7 +80,7 @@ function ThemeForm({ bottomOffset }: { bottomOffset: number }) {
       contentContainerStyle={{ paddingBottom: bottomOffset }}
       contentContainerClassName="gap-6 p-4"
     >
-      <FormInput labelKey="feat.trackMetadata.extra.name" field="name" />
+      <FormInput label="feat.trackMetadata.extra.name" field="name" />
       <SheetLabelAction
         labelKey="feat.theme.extra.dark"
         Trailing={

--- a/mobile/src/modules/form/FormState/FormInput.tsx
+++ b/mobile/src/modules/form/FormState/FormInput.tsx
@@ -1,10 +1,10 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { ParseKeys } from "i18next";
-import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
+import type { TranslationKeyOrString } from "~/modules/i18n/core";
+import { useMaybeT } from "~/modules/i18n/core";
 import { useFormStateContext } from ".";
 
 import { cn } from "~/lib/style";
@@ -13,21 +13,17 @@ import { FlatList } from "~/components/Base/List";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { TextInput } from "~/components/Form/Input";
 import { RemovableItem } from "~/components/List/RemovableItem";
-import { Em, TEm } from "~/components/Typography/StyledText";
+import { Em } from "~/components/Typography/StyledText";
 
 //#region Label
 export function InputLabel(props: {
-  labelKey?: ParseKeys;
-  label?: string;
+  label: TranslationKeyOrString;
   Trailing?: React.ReactNode;
 }) {
+  const t = useMaybeT();
   return (
     <View className="mb-1 min-h-8 flex-row items-center justify-between gap-4">
-      {props.labelKey ? (
-        <TEm textKey={props.labelKey} />
-      ) : (
-        <Em>{props.label}</Em>
-      )}
+      <Em>{t(props.label)}</Em>
       {props.Trailing}
     </View>
   );
@@ -37,8 +33,7 @@ export function InputLabel(props: {
 //#region Text/Numeric Input
 export function FormInputImpl<TData extends Record<string, any>>() {
   return function FormInput(props: {
-    labelKey?: ParseKeys;
-    label?: string;
+    label: TranslationKeyOrString;
     field: KeysOfValue<TData, string | number | null>;
     numeric?: boolean;
   }) {
@@ -59,7 +54,7 @@ export function FormInputImpl<TData extends Record<string, any>>() {
 
     return (
       <View className="flex-1">
-        <InputLabel labelKey={props.labelKey} label={props.label} />
+        <InputLabel label={props.label} />
         <TextInput
           inputMode={props.numeric ? "numeric" : undefined}
           editable={!isSubmitting}
@@ -76,11 +71,10 @@ export function FormInputImpl<TData extends Record<string, any>>() {
 //#region Array Input
 export function ArrayFormInputImpl<TData extends Record<string, any>>() {
   return function ArrayFormInput(props: {
-    labelKey?: ParseKeys;
-    label?: string;
+    label: TranslationKeyOrString;
     field: KeysOfValue<TData, string[]>;
   }) {
-    const { t } = useTranslation();
+    const t = useMaybeT();
     const { data, setField, isSubmitting } = useFormState<TData>();
 
     const field = props.field;
@@ -89,13 +83,12 @@ export function ArrayFormInputImpl<TData extends Record<string, any>>() {
     return (
       <View>
         <InputLabel
-          labelKey={props.labelKey}
           label={props.label}
           Trailing={
             <IconButton
               icon="add"
               accessibilityLabel={t("template.entryAdd", {
-                name: props.labelKey ? t(props.labelKey) : props.label,
+                name: t(props.label),
               })}
               onPress={() =>
                 setField((prev) => ({ ...prev, [field]: [...prev[field], ""] }))
@@ -148,15 +141,14 @@ export function ArrayFormInputImpl<TData extends Record<string, any>>() {
 //#region Textarea
 export function TextareaImpl<TData extends Record<string, any>>() {
   return function Textarea(props: {
-    labelKey?: ParseKeys;
-    label?: string;
+    label: TranslationKeyOrString;
     field: KeysOfValue<TData, string>;
     oneLine?: boolean;
   }) {
     const { data, setField, isSubmitting } = useFormState<TData>();
     return (
       <View className="flex-1">
-        <InputLabel labelKey={props.labelKey} label={props.label} />
+        <InputLabel label={props.label} />
         <TextInput
           editable={!isSubmitting}
           value={data[props.field]}

--- a/mobile/src/modules/i18n/core.ts
+++ b/mobile/src/modules/i18n/core.ts
@@ -6,10 +6,10 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 /**
- * Suports regular strings & translation keys. Translation keys will auto-complete.
+ * Supports regular strings & translation keys. Translation keys will auto-complete.
  *
  * To check for removed translation keys, we can temporarily remove `string & {}`
- * and then run the typecheck script.
+ * and then run the `typecheck` script.
  */
 export type TranslationKeyOrString = ParseKeys | (string & {});
 

--- a/mobile/src/modules/i18n/core.ts
+++ b/mobile/src/modules/i18n/core.ts
@@ -5,7 +5,12 @@ import type { ParseKeys, TOptions } from "i18next";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
-/** Suports regular strings & translation keys. Translation keys will auto-complete. */
+/**
+ * Suports regular strings & translation keys. Translation keys will auto-complete.
+ *
+ * To check for removed translation keys, we can temporarily remove `string & {}`
+ * and then run the typecheck script.
+ */
 export type TranslationKeyOrString = ParseKeys | (string & {});
 
 export function useMaybeT() {

--- a/mobile/src/modules/i18n/core.ts
+++ b/mobile/src/modules/i18n/core.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { ParseKeys } from "i18next";
+import type { ParseKeys, TOptions } from "i18next";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -11,8 +11,9 @@ export type TranslationKeyOrString = ParseKeys | (string & {});
 export function useMaybeT() {
   const { t } = useTranslation();
   return useCallback(
-    // @ts-expect-error - If the key doesn't exist, then the string is outputted.
-    (keyOrString: TranslationKeyOrString): string => t(keyOrString),
+    (keyOrString: TranslationKeyOrString, options?: TOptions): string =>
+      // @ts-expect-error - If the key doesn't exist, then the string is outputted.
+      t(keyOrString, options),
     [t],
   );
 }

--- a/mobile/src/modules/i18n/core.ts
+++ b/mobile/src/modules/i18n/core.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { ParseKeys } from "i18next";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+/** Suports regular strings & translation keys. Translation keys will auto-complete. */
+export type TranslationKeyOrString = ParseKeys | (string & {});
+
+export function useMaybeT() {
+  const { t } = useTranslation();
+  return useCallback(
+    // @ts-expect-error - If the key doesn't exist, then the string is outputted.
+    (keyOrString: TranslationKeyOrString): string => t(keyOrString),
+    [t],
+  );
+}

--- a/mobile/src/modules/lyric/components/ModifyProviderViewBase.tsx
+++ b/mobile/src/modules/lyric/components/ModifyProviderViewBase.tsx
@@ -67,7 +67,7 @@ function LyricProviderForm({ bottomOffset }: { bottomOffset: number }) {
       contentContainerStyle={{ paddingBottom: bottomOffset }}
       contentContainerClassName="gap-6 p-4"
     >
-      <FormInput labelKey="feat.trackMetadata.extra.name" field="name" />
+      <FormInput label="feat.trackMetadata.extra.name" field="name" />
       <Textarea label="Endpoint" field="endpoint" oneLine />
       <ArrayFormInput label="Traversed Fields" field="traversedFields" />
       <SheetLabelAction

--- a/mobile/src/modules/lyric/components/ModifyViewBase.tsx
+++ b/mobile/src/modules/lyric/components/ModifyViewBase.tsx
@@ -49,8 +49,8 @@ function LyricForm({ bottomOffset }: { bottomOffset: number }) {
       contentContainerStyle={{ paddingBottom: bottomOffset }}
       contentContainerClassName="gap-6 p-4"
     >
-      <FormInput labelKey="feat.trackMetadata.extra.name" field="name" />
-      <Textarea labelKey="feat.lyrics.title" field="lyrics" />
+      <FormInput label="feat.trackMetadata.extra.name" field="name" />
+      <Textarea label="feat.lyrics.title" field="lyrics" />
     </KeyboardAwareScrollView>
   );
 }

--- a/mobile/src/modules/media/multiSelect/components/TrackMultiSelectListeners.tsx
+++ b/mobile/src/modules/media/multiSelect/components/TrackMultiSelectListeners.tsx
@@ -157,7 +157,6 @@ function MultiSelectActions(props: {
             accessibilityLabel: t("template.entryRemove", { name: trackTerm }),
             onPress: () => removeSelectedFromPlaylist(playlistRouteId),
           }}
-          // @ts-expect-error - If we use a non-translation key, it'll be rendered as a string.
           modalMessage={[t("template.entryRemove", { name: trackCount })]}
         />
       ) : (
@@ -181,7 +180,6 @@ function MultiSelectActions(props: {
           accessibilityLabel: t("template.entryHide", { name: trackTerm }),
           onPress: hideSelected,
         }}
-        // @ts-expect-error - If we use a non-translation key, it'll be rendered as a string.
         modalMessage={[t("template.entryHide", { name: trackCount })]}
       />
     </View>

--- a/mobile/src/navigation/screens/playlists/components/ModifyViewBase.tsx
+++ b/mobile/src/navigation/screens/playlists/components/ModifyViewBase.tsx
@@ -221,13 +221,13 @@ function PlaylistNameField({ isFavoritesList }: { isFavoritesList?: boolean }) {
     <View className="gap-1">
       {isFavoritesList ? (
         <View>
-          <InputLabel labelKey="feat.trackMetadata.extra.name" />
+          <InputLabel label="feat.trackMetadata.extra.name" />
           <View className="min-h-12 w-full justify-center rounded-sm border border-outline p-2 opacity-25">
             <TStyledText textKey="term.favoriteTracks" numberOfLines={1} />
           </View>
         </View>
       ) : (
-        <FormInput labelKey="feat.trackMetadata.extra.name" field="name" />
+        <FormInput label="feat.trackMetadata.extra.name" field="name" />
       )}
       <View className="shrink flex-row items-center gap-0.5">
         <Icon
@@ -257,7 +257,7 @@ function ListHeaderComponent(props: {
     <View className="gap-6">
       <PlaylistNameField isFavoritesList={props.isFavoritesList} />
       <InputLabel
-        labelKey="term.tracks"
+        label="term.tracks"
         Trailing={
           <IconButton
             icon="add"

--- a/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
+++ b/mobile/src/navigation/screens/settings/ExperimentalSettingsView.tsx
@@ -80,9 +80,7 @@ export default function ExperimentalSettings() {
             onPress: deleteAllUnhashedImages,
           }}
           modalMessage={[
-            // @ts-expect-error - If we use a non-translation key, it'll be rendered as a string.
             "Re-launching the app is necessary after confirming this action.",
-            // @ts-expect-error - If we use a non-translation key, it'll be rendered as a string.
             "You will need to re-add any images you manually assigned to albums/artists/genres/playlists/tracks.",
           ]}
         />

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -183,11 +183,11 @@ function MetadataForm({ bottomOffset }: { bottomOffset: number }) {
           </StyledText>
         </View>
 
-        <FormInput labelKey="feat.trackMetadata.extra.name" field="name" />
-        <ArrayFormInput labelKey="term.artists" field="artists" />
+        <FormInput label="feat.trackMetadata.extra.name" field="name" />
+        <ArrayFormInput label="term.artists" field="artists" />
         <View className="flex-1">
           <InputLabel
-            labelKey="term.album"
+            label="term.album"
             Trailing={
               <IconButton
                 icon="color-wand"
@@ -208,27 +208,23 @@ function MetadataForm({ bottomOffset }: { bottomOffset: number }) {
           />
         </View>
         <ArrayFormInput
-          labelKey="feat.trackMetadata.extra.albumArtists"
+          label="feat.trackMetadata.extra.albumArtists"
           field="albumArtists"
         />
         <View className="flex-row items-end gap-4">
           <FormInput
-            labelKey="feat.trackMetadata.extra.disc"
+            label="feat.trackMetadata.extra.disc"
             field="disc"
             numeric
           />
           <FormInput
-            labelKey="feat.trackMetadata.extra.trackNumber"
+            label="feat.trackMetadata.extra.trackNumber"
             field="track"
             numeric
           />
         </View>
-        <FormInput
-          labelKey="feat.trackMetadata.extra.year"
-          field="year"
-          numeric
-        />
-        <ArrayFormInput labelKey="term.genres" field="genres" />
+        <FormInput label="feat.trackMetadata.extra.year" field="year" numeric />
+        <ArrayFormInput label="term.genres" field="genres" />
       </KeyboardAwareScrollView>
     </>
   );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR uses the translation key trick (`ParseKey | (string & {})`), which we did in #551, to have a prop that supports auto-completing translation keys & regular strings. We don't do this everywhere in case of re-rendering concerns, but theoretically, we could do this everywhere.

If we ever remove a translation key, we can simply check to see if we're using an outdated value by temporarily removing the `(string & {})` portion of the `TranslationKeyOrString` type, then run the `typecheck` script and go through the errors and see if any contain any strings that look like translation keys.
- Creating & reusing this type wherever we want to do this makes this easy.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] New files have the SPDX license identifier at the top of the file.
- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form labels and confirmation modal messages can now use either translation keys or plain strings.
  * Added i18n fallback behavior to display the provided text when a translation isn’t available.

* **Improvements**
  * Updated track, playlist, lyric, theme, font, and settings screens to use the unified label handling for better consistency.
  * Refreshed list and modal rendering to remove unnecessary type workarounds, keeping accessibility and messaging unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->