### PR TITLE
feat: Support filtering Singles & EPs on "Albums" screen

### DIFF
--- a/mobile/src/components/Form/Switch.tsx
+++ b/mobile/src/components/Form/Switch.tsx
@@ -41,7 +41,7 @@ export function SwitchInput(props: {
       accessibilityState={{ checked: props.enabled, disabled: props.disabled }}
       onPress={props.onPress}
       disabled={props.disabled}
-      className="h-8 justify-center"
+      className="h-8 justify-center disabled:opacity-25"
     >
       <Switch enabled={props.enabled} />
     </Pressable>

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -152,7 +152,10 @@ export async function updateAlbum(id: string, values: Partial<InsertedAlbum>) {
 
 //#region PUT Methods
 /** Create/update album entries and its relations. Returns the created albums. */
-export function upsertAlbums(entries: InsertedAlbum[], overrideIsEP = false) {
+export function upsertAlbums(
+  entries: InsertedAlbum[],
+  overrideModifiable = false,
+) {
   return db.transaction(async (tx) => {
     const results = await tx
       .insert(albums)
@@ -163,8 +166,7 @@ export function upsertAlbums(entries: InsertedAlbum[], overrideIsEP = false) {
         // a value if a conflict occurs.
         set: getExcludedColumns([
           "name",
-          "embeddedArtwork",
-          ...(overrideIsEP ? ["isEP"] : []),
+          ...(overrideModifiable ? ["embeddedArtwork", "isEP"] : []),
         ]),
       })
       .returning();

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -152,7 +152,7 @@ export async function updateAlbum(id: string, values: Partial<InsertedAlbum>) {
 
 //#region PUT Methods
 /** Create/update album entries and its relations. Returns the created albums. */
-export function upsertAlbums(entries: InsertedAlbum[]) {
+export function upsertAlbums(entries: InsertedAlbum[], overrideIsEP = false) {
   return db.transaction(async (tx) => {
     const results = await tx
       .insert(albums)
@@ -161,7 +161,11 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
         target: [albums.name, albums.artistsKey],
         // Replace `name` with passed name to allow `.returning()` to return
         // a value if a conflict occurs.
-        set: UpsertFields,
+        set: getExcludedColumns([
+          "name",
+          "embeddedArtwork",
+          ...(overrideIsEP ? ["isEP"] : []),
+        ]),
       })
       .returning();
 
@@ -192,8 +196,6 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
 //#endregion
 
 //#region Internal Utils
-const UpsertFields = getExcludedColumns(["name", "embeddedArtwork", "isEP"]);
-
 function parseAlbumTracks(tracks?: string) {
   if (!tracks) return [];
   let results: CommonTrack[] = [];

--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -17,7 +17,7 @@ import {
 import { db } from "~/db";
 import { albums, albumsToArtists, artists, tracks } from "~/db/schema";
 
-import { iAsc, throwIfNoResults } from "~/lib/drizzle";
+import { getExcludedColumns, iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { omitKeys } from "~/utils/object";
 import type { AlbumSummary, AlbumTrack } from "./types";
 import { AlbumArtistsKey } from "./utils";
@@ -161,7 +161,7 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
         target: [albums.name, albums.artistsKey],
         // Replace `name` with passed name to allow `.returning()` to return
         // a value if a conflict occurs.
-        set: { name: sql`excluded.name` },
+        set: UpsertFields,
       })
       .returning();
 
@@ -192,6 +192,8 @@ export function upsertAlbums(entries: InsertedAlbum[]) {
 //#endregion
 
 //#region Internal Utils
+const UpsertFields = getExcludedColumns(["name", "embeddedArtwork", "isEP"]);
+
 function parseAlbumTracks(tracks?: string) {
   if (!tracks) return [];
   let results: CommonTrack[] = [];

--- a/mobile/src/data/album/types.ts
+++ b/mobile/src/data/album/types.ts
@@ -19,4 +19,5 @@ export type AlbumSummary = {
   artwork: string | null;
   duration: number;
   trackCount: number;
+  isEP: boolean;
 };

--- a/mobile/src/data/track/types.ts
+++ b/mobile/src/data/track/types.ts
@@ -15,6 +15,7 @@ export type Track = Prettify<
   TRACK_INTERNAL & {
     albumName: string | null;
     albumArtistsKey: string | null;
+    isAlbumEP: boolean | null;
     artists: string[] | null;
   }
 >;

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -35,6 +35,7 @@ export const structuredTracksView = db
     //? For some weird reason, using `albums.name` directly returns `tracks.name`.
     albumName: sql<string | null>`${albums.name}`.as("album_name"),
     albumArtistsKey: albums.artistsKey,
+    isAlbumEP: albums.isEP,
     artistsName: sql<
       string | null
     >`GROUP_CONCAT(${orderedTrackArtistsView.artistName}, ', ')`.as(

--- a/mobile/src/db/drizzle/0018_young_dexter_bennett.sql
+++ b/mobile/src/db/drizzle/0018_young_dexter_bennett.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `albums` ADD `is_ep` integer DEFAULT false NOT NULL;

--- a/mobile/src/db/drizzle/meta/0018_snapshot.json
+++ b/mobile/src/db/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1244 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a0cecba5-176f-4382-9856-7f388774302d",
+  "prevId": "c69fd35d-cf16-47d1-8881-f5ae11d4d995",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artists_key": {
+          "name": "artists_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(coalesce(\"alt_artwork\", \"embedded_artwork\"))",
+            "type": "virtual"
+          }
+        },
+        "embedded_artwork": {
+          "name": "embedded_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_ep": {
+          "name": "is_ep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "albums_name_artistsKey_unique": {
+          "name": "albums_name_artistsKey_unique",
+          "columns": [
+            "name",
+            "artists_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "albums_to_artists": {
+      "name": "albums_to_artists",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "albums_to_artists_album_id_albums_id_fk": {
+          "name": "albums_to_artists_album_id_albums_id_fk",
+          "tableFrom": "albums_to_artists",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "albums_to_artists_artist_name_artists_name_fk": {
+          "name": "albums_to_artists_artist_name_artists_name_fk",
+          "tableFrom": "albums_to_artists",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "albums_to_artists_album_id_artist_name_pk": {
+          "columns": [
+            "album_id",
+            "artist_name"
+          ],
+          "name": "albums_to_artists_album_id_artist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_fonts": {
+      "name": "custom_fonts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_themes": {
+      "name": "custom_themes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'light'"
+        },
+        "primary": {
+          "name": "primary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_dim": {
+          "name": "primary_dim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_primary": {
+          "name": "on_primary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_primary_variant": {
+          "name": "on_primary_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secondary": {
+          "name": "secondary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secondary_dim": {
+          "name": "secondary_dim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_secondary": {
+          "name": "on_secondary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_secondary_variant": {
+          "name": "on_secondary_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_dim": {
+          "name": "error_dim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_error": {
+          "name": "on_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_error_variant": {
+          "name": "on_error_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_dim": {
+          "name": "surface_dim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_bright": {
+          "name": "surface_bright",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_container_lowest": {
+          "name": "surface_container_lowest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_container_low": {
+          "name": "surface_container_low",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_container": {
+          "name": "surface_container",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_container_high": {
+          "name": "surface_container_high",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface_container_highest": {
+          "name": "surface_container_highest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_surface": {
+          "name": "on_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_surface_variant": {
+          "name": "on_surface_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outline": {
+          "name": "outline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outline_variant": {
+          "name": "outline_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse_surface": {
+          "name": "inverse_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inverse_on_surface": {
+          "name": "inverse_on_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFFFFF'"
+        },
+        "android_navbar": {
+          "name": "android_navbar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FFFFFF00'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_node": {
+      "name": "file_node",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_node_parent_path_file_node_path_fk": {
+          "name": "file_node_parent_path_file_node_path_fk",
+          "tableFrom": "file_node",
+          "tableTo": "file_node",
+          "columnsFrom": [
+            "parent_path"
+          ],
+          "columnsTo": [
+            "path"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genres": {
+      "name": "genres",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hashed_images": {
+      "name": "hashed_images",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hidden_tracks": {
+      "name": "hidden_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invalid_tracks": {
+      "name": "invalid_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lyrics": {
+      "name": "lyrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lyrics": {
+          "name": "lyrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "played_media_list": {
+      "name": "played_media_list",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "played_media_list_id_type_pk": {
+          "columns": [
+            "id",
+            "type"
+          ],
+          "name": "played_media_list_id_type_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks": {
+      "name": "tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_artist_name": {
+          "name": "raw_artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disc": {
+          "name": "disc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_rate": {
+          "name": "sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modification_time": {
+          "name": "modification_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discover_time": {
+          "name": "discover_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(coalesce(\"alt_artwork\", \"embedded_artwork\"))",
+            "type": "virtual"
+          }
+        },
+        "embedded_artwork": {
+          "name": "embedded_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_artwork": {
+          "name": "alt_artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fetched_art": {
+          "name": "fetched_art",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "edited_metadata": {
+          "name": "edited_metadata",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_folder": {
+          "name": "parent_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(rtrim(\"uri\", replace(\"uri\", '/', '')))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_album_id_albums_id_fk": {
+          "name": "tracks_album_id_albums_id_fk",
+          "tableFrom": "tracks",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_play_events": {
+      "name": "tracks_play_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "play_time": {
+          "name": "play_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_play_events_track_id_tracks_id_fk": {
+          "name": "tracks_play_events_track_id_tracks_id_fk",
+          "tableFrom": "tracks_play_events",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_artists": {
+      "name": "tracks_to_artists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_artists_track_id_tracks_id_fk": {
+          "name": "tracks_to_artists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_artists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracks_to_artists_artist_name_artists_name_fk": {
+          "name": "tracks_to_artists_artist_name_artists_name_fk",
+          "tableFrom": "tracks_to_artists",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_artists_track_id_artist_name_pk": {
+          "columns": [
+            "track_id",
+            "artist_name"
+          ],
+          "name": "tracks_to_artists_track_id_artist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_genres": {
+      "name": "tracks_to_genres",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_genres_track_id_tracks_id_fk": {
+          "name": "tracks_to_genres_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_genres",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracks_to_genres_genre_name_genres_name_fk": {
+          "name": "tracks_to_genres_genre_name_genres_name_fk",
+          "tableFrom": "tracks_to_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_genres_track_id_genre_name_pk": {
+          "columns": [
+            "track_id",
+            "genre_name"
+          ],
+          "name": "tracks_to_genres_track_id_genre_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_lyrics": {
+      "name": "tracks_to_lyrics",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lyric_id": {
+          "name": "lyric_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_lyrics_track_id_tracks_id_fk": {
+          "name": "tracks_to_lyrics_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_lyrics",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracks_to_lyrics_lyric_id_lyrics_id_fk": {
+          "name": "tracks_to_lyrics_lyric_id_lyrics_id_fk",
+          "tableFrom": "tracks_to_lyrics",
+          "tableTo": "lyrics",
+          "columnsFrom": [
+            "lyric_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracks_to_playlists": {
+      "name": "tracks_to_playlists",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": -1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracks_to_playlists_track_id_tracks_id_fk": {
+          "name": "tracks_to_playlists_track_id_tracks_id_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tracks_to_playlists_playlist_name_playlists_name_fk": {
+          "name": "tracks_to_playlists_playlist_name_playlists_name_fk",
+          "tableFrom": "tracks_to_playlists",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tracks_to_playlists_track_id_playlist_name_pk": {
+          "columns": [
+            "track_id",
+            "playlist_name"
+          ],
+          "name": "tracks_to_playlists_track_id_playlist_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "waveform_sample": {
+      "name": "waveform_sample",
+      "columns": {
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "samples": {
+          "name": "samples",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_array())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "waveform_sample_track_id_tracks_id_fk": {
+          "name": "waveform_sample_track_id_tracks_id_fk",
+          "tableFrom": "waveform_sample",
+          "tableTo": "tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/mobile/src/db/drizzle/meta/_journal.json
+++ b/mobile/src/db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1786564026359,
       "tag": "0017_noisy_loners",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1788383938940,
+      "tag": "0018_young_dexter_bennett",
+      "breakpoints": true
     }
   ]
 }

--- a/mobile/src/db/drizzle/migrations.js
+++ b/mobile/src/db/drizzle/migrations.js
@@ -19,6 +19,7 @@ import m0014 from "./0014_cold_the_executioner.sql";
 import m0015 from "./0015_melted_maddog.sql";
 import m0016 from "./0016_friendly_tenebrous.sql";
 import m0017 from "./0017_noisy_loners.sql";
+import m0018 from "./0018_young_dexter_bennett.sql";
 
 export default {
   journal,
@@ -41,5 +42,6 @@ export default {
     m0015,
     m0016,
     m0017,
+    m0018,
   },
 };

--- a/mobile/src/db/schema.ts
+++ b/mobile/src/db/schema.ts
@@ -46,6 +46,7 @@ export const albums = sqliteTable(
     embeddedArtwork: text(),
     altArtwork: text(),
     isFavorite: integer({ mode: "boolean" }).notNull().default(false),
+    isEP: integer({ mode: "boolean" }).notNull().default(false),
   },
   (t) => [unique().on(t.name, t.artistsKey)],
 );

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -37,7 +37,9 @@
 
     "instructions": "Instructions",
 
-    "disc": "Disc {{count}}"
+    "disc": "Disc {{count}}",
+    "eps": "EPs",
+    "singles": "Singles"
   },
 
   "template": {

--- a/mobile/src/navigation/screens/albums/View.tsx
+++ b/mobile/src/navigation/screens/albums/View.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 
 import { useAlbums } from "~/data/album/queries";
 import { usePreferenceStore } from "~/stores/Preference/store";
+import { useSessionStore } from "~/stores/Session/store";
 import { useViewLayout } from "~/stores/ViewPreference/hooks/useViewLayout";
 import { useViewOrder } from "~/stores/ViewPreference/hooks/useViewOrder";
 
@@ -17,10 +18,20 @@ import type { ExtractQueryData } from "~/lib/react-query";
 export default function Albums() {
   const { isPending, data } = useAlbums();
   const minAlbumLength = usePreferenceStore((s) => s.minAlbumLength);
+  const showSingles = useSessionStore((s) => s.showSingles);
+  const showEPs = useSessionStore((s) => s.showEPs);
+  const showAlbums = useSessionStore((s) => s.showAlbums);
 
   const filteredData = useMemo(
-    () => data?.filter(({ trackCount }) => trackCount >= minAlbumLength),
-    [data, minAlbumLength],
+    () =>
+      data?.filter(({ isEP, trackCount }) => {
+        let condition = trackCount >= minAlbumLength;
+        if (!showSingles) condition &&= trackCount > 1;
+        if (!showEPs) condition &&= !isEP;
+        if (!showAlbums) condition &&= trackCount === 1 || isEP;
+        return condition;
+      }),
+    [data, minAlbumLength, showSingles, showEPs, showAlbums],
   );
 
   const sortedData = useViewOrder("album", filteredData);

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -310,14 +310,17 @@ async function onEditTrack(data: TrackMetadata) {
     // Add new album to the database.
     let albumId: string | null = null;
     if (updatedAlbum.name && updatedAlbum.artistsKey) {
-      const [newAlbum] = await upsertAlbums([
-        {
-          name: updatedAlbum.name,
-          artistsKey: updatedAlbum.artistsKey,
-          embeddedArtwork: artworkHash,
-          isEP: updatedAlbum.isEP,
-        },
-      ]);
+      const [newAlbum] = await upsertAlbums(
+        [
+          {
+            name: updatedAlbum.name,
+            artistsKey: updatedAlbum.artistsKey,
+            embeddedArtwork: artworkHash,
+            isEP: updatedAlbum.isEP,
+          },
+        ],
+        true,
+      );
       if (newAlbum) albumId = newAlbum.id;
     }
     if (!albumId || !preferenceStore.getState().optimizedImageSave) {

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -39,6 +39,8 @@ import { splitOn } from "~/utils/string";
 import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { TextInput } from "~/components/Form/Input";
+import { SwitchInput } from "~/components/Form/Switch";
+import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
 import { useSheetRef } from "~/components/Sheet/useSheetRef";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ZSchema } from "~/modules/form/utils";
@@ -97,6 +99,7 @@ export default function ModifyTrack({
         albumArtists: trackQuery.data.albumArtistsKey
           ? AlbumArtistsKey.deconstruct(trackQuery.data.albumArtistsKey)
           : [],
+        isEP: trackQuery.data.isAlbumEP ?? false,
         year: trackQuery.data.year,
         disc: trackQuery.data.disc,
         track: trackQuery.data.track,
@@ -211,6 +214,16 @@ function MetadataForm({ bottomOffset }: { bottomOffset: number }) {
           label="feat.trackMetadata.extra.albumArtists"
           field="albumArtists"
         />
+        <SheetLabelAction
+          label="isAlbumEP"
+          Trailing={
+            <SwitchInput
+              enabled={data.isEP}
+              onPress={() => setFields((prev) => ({ isEP: !prev.isEP }))}
+              disabled={isSubmitting}
+            />
+          }
+        />
         <View className="flex-row items-end gap-4">
           <FormInput
             label="feat.trackMetadata.extra.disc"
@@ -241,6 +254,7 @@ const TrackMetadataSchema = z.object({
   artists: z.array(ZSchema.NonEmptyString),
   album: ZSchema.NullableString,
   albumArtists: z.array(ZSchema.NonEmptyString),
+  isEP: z.boolean(),
   year: ZSchema.NullableRealNumber,
   disc: ZSchema.NullableRealNumber,
   track: ZSchema.NullableRealNumber,
@@ -257,8 +271,16 @@ function useFormState() {
 //#region Submit Handler
 async function onEditTrack(data: TrackMetadata) {
   try {
-    const { id, uri, album, albumArtists, artists, genres, ...trackBase } =
-      data;
+    const {
+      id,
+      uri,
+      album,
+      albumArtists,
+      isEP,
+      artists,
+      genres,
+      ...trackBase
+    } = data;
 
     const updatedTrack = {
       ...trackBase,
@@ -269,6 +291,7 @@ async function onEditTrack(data: TrackMetadata) {
     const updatedAlbum = {
       name: album,
       artistsKey: AlbumArtistsKey.from(albumArtists),
+      isEP,
     };
 
     // Add new artists & genres to the database.
@@ -292,6 +315,7 @@ async function onEditTrack(data: TrackMetadata) {
           name: updatedAlbum.name,
           artistsKey: updatedAlbum.artistsKey,
           embeddedArtwork: artworkHash,
+          isEP: updatedAlbum.isEP,
         },
       ]);
       if (newAlbum) albumId = newAlbum.id;

--- a/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
+++ b/mobile/src/navigation/sheets/ViewOptionsSheet.tsx
@@ -8,6 +8,8 @@ import { Icon } from "~/resources/icons";
 import { usePreferenceStore } from "~/stores/Preference/store";
 import { PreferenceSetters } from "~/stores/Preference/actions";
 import { MinAlbumLengthConfig } from "~/stores/Preference/utils";
+import { useSessionStore } from "~/stores/Session/store";
+import { toggleSessionKey } from "~/stores/Session/actions";
 import { useViewPreferenceStore } from "~/stores/ViewPreference/store";
 import { ViewPreferenceSetters } from "~/stores/ViewPreference/actions";
 
@@ -15,6 +17,7 @@ import { SortSheet } from "~/navigation/sheets/SortSheet";
 
 import { FilledIconButton } from "~/components/Form/Button/Icon";
 import { NumberStepper } from "~/components/Form/NumberStepper";
+import { SwitchInput } from "~/components/Form/Switch";
 import { SegmentedList } from "~/components/List/Segmented";
 import { DetachedSheet } from "~/components/Sheet";
 import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
@@ -25,7 +28,11 @@ import type { MutableViewLayout } from "~/stores/ViewPreference/types";
 
 //#region Albums
 export function AlbumsViewOptionsSheet(props: { ref: TrueSheetRef }) {
+  const { t } = useTranslation();
   const minAlbumLength = usePreferenceStore((s) => s.minAlbumLength);
+  const showSingles = useSessionStore((s) => s.showSingles);
+  const showEPs = useSessionStore((s) => s.showEPs);
+  const showAlbums = useSessionStore((s) => s.showAlbums);
   const sortOrderSheetRef = useSheetRef();
 
   return (
@@ -39,6 +46,34 @@ export function AlbumsViewOptionsSheet(props: { ref: TrueSheetRef }) {
               value={minAlbumLength}
               onChange={PreferenceSetters.updateMinAlbumLengthByDelta}
               {...MinAlbumLengthConfig.bound}
+            />
+          }
+        />
+
+        <SheetLabelAction
+          label={t("template.entryShow", { name: t("term.singles") })}
+          Trailing={
+            <SwitchInput
+              enabled={showSingles}
+              onPress={toggleSessionKey("showSingles")}
+            />
+          }
+        />
+        <SheetLabelAction
+          label={t("template.entryShow", { name: t("term.eps") })}
+          Trailing={
+            <SwitchInput
+              enabled={showEPs}
+              onPress={toggleSessionKey("showEPs")}
+            />
+          }
+        />
+        <SheetLabelAction
+          label={t("template.entryShow", { name: t("term.albums") })}
+          Trailing={
+            <SwitchInput
+              enabled={showAlbums}
+              onPress={toggleSessionKey("showAlbums")}
             />
           }
         />

--- a/mobile/src/stores/Session/actions.ts
+++ b/mobile/src/stores/Session/actions.ts
@@ -15,6 +15,14 @@ import type { PopStrategy } from "./types";
 import { iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { wait } from "~/utils/promise";
 
+type ToggleableKey = "showSingles" | "showEPs" | "showAlbums";
+
+export function toggleSessionKey(key: ToggleableKey) {
+  return () => {
+    sessionStore.setState((prev) => ({ [key]: !prev[key] }));
+  };
+}
+
 //#region Track Sheet
 /** Displays the global track sheet. */
 export async function presentTrackSheet(trackId: string) {

--- a/mobile/src/stores/Session/constants.ts
+++ b/mobile/src/stores/Session/constants.ts
@@ -30,5 +30,10 @@ export interface SessionStore {
 
   /** Waveform data for the active track. */
   activeWaveformContext: WaveformSample | null;
+
+  // Type of content shown on the "Albums" screen.
+  showSingles: boolean;
+  showEPs: boolean;
+  showAlbums: boolean;
 }
 //#endregion

--- a/mobile/src/stores/Session/store.ts
+++ b/mobile/src/stores/Session/store.ts
@@ -17,6 +17,10 @@ export const sessionStore = createStore<SessionStore>()(() => ({
   displayedArtists: null,
 
   activeWaveformContext: null,
+
+  showSingles: true,
+  showEPs: true,
+  showAlbums: true,
 }));
 
 export function useSessionStore<T>(selector: (state: SessionStore) => T): T {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds support for filtering Singles & EPs out on the "Albums" screen. We have 3 new options in the "View Options" sheet for the "Albums" screen:
- **Show Singles:** Shows albums with at least 1 track.
- **Show EPs:** Show albums which have the `isAlbumEP` flag enabled (toggleable via "Edit Track" screen).
- **Show Albums:** Show albums that aren't Singles or EPs.

> [!NOTE]
> The `isAlbumEP` flag will update the album database entry, so the change in one track will applied to the rest in the album.
>
> In addition, the `Minimum Album Length` feature will apply on top of the current selection (so if its greater than 1, singles will be hidden).

There are some things I want to change in the future, for example:
- Compressing the 3 options in the "View Options" sheet to take up less space.
- Consider removing the `Minimum Album Length` filter feature since it applies on top of these filters.
- Maybe having a dedicated "edit" flow for the "Current Album" screen instead of modifying the value in the "Edit Track" flow.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] New files have the SPDX license identifier at the top of the file.
- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Albums can now be categorized as albums, EPs, or singles.
* Added filters to show or hide albums, EPs, and singles.
* Added an option to mark an album as an EP when creating or editing it.
* Added translations for “EPs” and “Singles.”

## Bug Fixes
* Disabled switches now appear dimmed.
* Album updates preserve existing EP classifications unless explicitly overridden.
* EP classifications now remain available when viewing associated tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->