### PR TITLE
feat: Album editing capabilities

### DIFF
--- a/mobile/src/data/album/api.ts
+++ b/mobile/src/data/album/api.ts
@@ -17,7 +17,7 @@ import {
 import { db } from "~/db";
 import { albums, albumsToArtists, artists, tracks } from "~/db/schema";
 
-import { getExcludedColumns, iAsc, throwIfNoResults } from "~/lib/drizzle";
+import { iAsc, throwIfNoResults } from "~/lib/drizzle";
 import { omitKeys } from "~/utils/object";
 import type { AlbumSummary, AlbumTrack } from "./types";
 import { AlbumArtistsKey } from "./utils";
@@ -152,10 +152,7 @@ export async function updateAlbum(id: string, values: Partial<InsertedAlbum>) {
 
 //#region PUT Methods
 /** Create/update album entries and its relations. Returns the created albums. */
-export function upsertAlbums(
-  entries: InsertedAlbum[],
-  overrideModifiable = false,
-) {
+export function upsertAlbums(entries: InsertedAlbum[]) {
   return db.transaction(async (tx) => {
     const results = await tx
       .insert(albums)
@@ -164,10 +161,7 @@ export function upsertAlbums(
         target: [albums.name, albums.artistsKey],
         // Replace `name` with passed name to allow `.returning()` to return
         // a value if a conflict occurs.
-        set: getExcludedColumns([
-          "name",
-          ...(overrideModifiable ? ["embeddedArtwork", "isEP"] : []),
-        ]),
+        set: { name: sql`excluded.name` },
       })
       .returning();
 

--- a/mobile/src/data/track/types.ts
+++ b/mobile/src/data/track/types.ts
@@ -15,7 +15,6 @@ export type Track = Prettify<
   TRACK_INTERNAL & {
     albumName: string | null;
     albumArtistsKey: string | null;
-    isAlbumEP: boolean | null;
     artists: string[] | null;
   }
 >;

--- a/mobile/src/data/views.ts
+++ b/mobile/src/data/views.ts
@@ -35,7 +35,6 @@ export const structuredTracksView = db
     //? For some weird reason, using `albums.name` directly returns `tracks.name`.
     albumName: sql<string | null>`${albums.name}`.as("album_name"),
     albumArtistsKey: albums.artistsKey,
-    isAlbumEP: albums.isEP,
     artistsName: sql<
       string | null
     >`GROUP_CONCAT(${orderedTrackArtistsView.artistName}, ', ')`.as(

--- a/mobile/src/modules/i18n/translations/en.json
+++ b/mobile/src/modules/i18n/translations/en.json
@@ -449,7 +449,9 @@
         "disc": "Disc",
         "name": "Name",
         "trackNumber": "Track Number",
-        "year": "Year"
+        "year": "Year",
+
+        "overrideFields": "Providing a value to the following fields will override the assigned values on all tracks in the album."
       }
     },
 

--- a/mobile/src/navigation/routes.tsx
+++ b/mobile/src/navigation/routes.tsx
@@ -21,6 +21,7 @@ import { BackHandler } from "react-native";
 
 import Home from "./screens/HomeView";
 import Album from "./screens/albums/CurrentView";
+import ModifyAlbum from "./screens/albums/ModifyView";
 import Albums from "./screens/albums/View";
 import Artist from "./screens/artists/CurrentView";
 import Artists from "./screens/artists/View";
@@ -293,6 +294,10 @@ export const RootStack = createNativeStackNavigator({
     Font: FontScreenGroup,
     Form: {
       screens: {
+        ModifyAlbum: {
+          screen: ModifyAlbum,
+          options: { title: "form.edit" },
+        },
         CreatePlaylist: {
           screen: CreatePlaylist,
           options: { title: "form.create" },

--- a/mobile/src/navigation/screens/albums/CurrentView.tsx
+++ b/mobile/src/navigation/screens/albums/CurrentView.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import type { StaticScreenProps } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
@@ -16,6 +17,7 @@ import {
 } from "~/navigation/layouts/CurrentListLayout";
 import { AlbumArtworkSheet } from "~/navigation/sheets/ArtworkSheet";
 import { useBottomActionsOffset } from "~/navigation/components/BottomActions/useBottomActions";
+import type { MenuAction } from "~/navigation/components/CurrentListMenu";
 import { CurrentListMenu } from "~/navigation/components/CurrentListMenu";
 
 import { mutateGuard } from "~/lib/react-query";
@@ -39,6 +41,7 @@ export default function Album({
   },
 }: Props) {
   const { t } = useTranslation();
+  const navigation = useNavigation();
   const listLayout = useListLayoutConfig(ColumnLayoutConfig);
   const bottomOffset = useBottomActionsOffset();
   const { isPending, error, data } = useAlbumForScreen(albumId);
@@ -47,6 +50,17 @@ export default function Album({
 
   const trackSource = { type: "album", id: albumId } as const;
   const listData = useTrackListPlayingIndication(trackSource, data?.tracks);
+
+  const menuActions = useMemo<MenuAction[]>(
+    () => [
+      {
+        icon: "edit",
+        labelKey: "form.edit",
+        onPress: () => navigation.navigate("ModifyAlbum", { id: albumId }),
+      },
+    ],
+    [navigation, albumId],
+  );
 
   const formattedData = useMemo(() => {
     if (!listData) return [];
@@ -92,6 +106,7 @@ export default function Album({
                 onPress={() => mutateGuard(favoriteAlbum, !data.isFavorite)}
               />
               <CurrentListMenu
+                actions={menuActions}
                 name={data.name}
                 trackIds={data.tracks.map(({ id }) => id)}
                 presentArtworkSheet={() => artworkSheetRef.current?.present()}

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -3,21 +3,17 @@
 
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
-import { eq } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
-import { tracksToArtists, tracksToGenres } from "~/db/schema";
+import { tracks, tracksToGenres } from "~/db/schema";
 
 import { upsertAlbums } from "~/data/album/api";
 import { useAlbum } from "~/data/album/queries";
 import { AlbumArtistsKey } from "~/data/album/utils";
-import { createArtists } from "~/data/artist/api";
 import { createGenres } from "~/data/genre/api";
-import { updateTrack } from "~/data/track/api";
 import { Resynchronize } from "~/stores/Playback/actions";
-import { preferenceStore } from "~/stores/Preference/store";
-import { getArtworkHash } from "~/modules/startup/scanning/core/artwork";
 import { AppCleanUp } from "~/modules/startup/scanning/core/cleanup";
 
 import { router } from "~/navigation/utils/router";
@@ -25,6 +21,7 @@ import { PagePlaceholder } from "~/navigation/components/Placeholder";
 
 import { clearAllQueries } from "~/lib/react-query";
 import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
+import { Divider } from "~/components/Divider";
 import { SwitchInput } from "~/components/Form/Switch";
 import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
 import { ZSchema } from "~/modules/form/utils";
@@ -51,6 +48,7 @@ export default function ModifyAlbum({
       schema={AlbumMetadataSchema}
       initData={{
         id: data.id,
+        trackIds: data.tracks.map((t) => t.id),
         name: data.name,
         artists: AlbumArtistsKey.deconstruct(data.artistsKey),
         isEP: data.isEP,
@@ -58,6 +56,7 @@ export default function ModifyAlbum({
         genres: [],
       }}
       onSubmit={onEditAlbum}
+      //? Prevent duplicates.
       onConstraints={({ artists, genres }) =>
         artists.length ===
           new Set(artists.map((artist) => artist.trim())).size &&
@@ -89,6 +88,7 @@ function MetadataForm() {
           />
         }
       />
+      <Divider />
       <FormInput label="feat.trackMetadata.extra.year" field="year" numeric />
       <ArrayFormInput label="term.genres" field="genres" />
     </KeyboardAwareScrollView>
@@ -100,9 +100,10 @@ function MetadataForm() {
 const AlbumMetadataSchema = z.object({
   // Additional context:
   id: z.string(),
+  trackIds: z.array(ZSchema.NonEmptyString),
   // Actual form fields:
   name: ZSchema.NonEmptyString,
-  artists: z.array(ZSchema.NonEmptyString),
+  artists: z.array(ZSchema.NonEmptyString).check(z.minLength(1)),
   isEP: z.boolean(),
   // Fields applied to current tracks:
   year: ZSchema.NullableRealNumber,
@@ -119,6 +120,52 @@ function useFormState() {
 //#region Submit Handler
 async function onEditAlbum(data: AlbumMetadata) {
   try {
+    const { id: albumId, trackIds, year, genres, ...albumBase } = data;
+
+    //? First update year & genres on tracks if specified (as we don't
+    //? want to override unrelated tracks if the album gets changed).
+    if (trackIds.length > 0) {
+      if (year !== null) {
+        await db
+          .update(tracks)
+          .set({ year })
+          .where(inArray(tracks.id, trackIds));
+      }
+
+      if (genres.length > 0) {
+        const genreEntries = genres.flatMap((genreName) =>
+          trackIds.map((trackId) => ({ trackId, genreName })),
+        );
+        await createGenres(genres.map((name) => ({ name })));
+        await db.transaction(async (tx) => {
+          await tx
+            .delete(tracksToGenres)
+            .where(inArray(tracksToGenres.trackId, trackIds));
+          await tx.insert(tracksToGenres).values(genreEntries);
+        });
+      }
+    }
+
+    //? If we change `name` & `artistsKey` to an album that already exists,
+    //? we replace this album with that album.
+    const [updatedAlbum] = await upsertAlbums([
+      {
+        name: albumBase.name,
+        artistsKey: AlbumArtistsKey.from(albumBase.artists)!,
+        isEP: albumBase.isEP,
+      },
+    ]);
+
+    if (trackIds.length > 0 && updatedAlbum && updatedAlbum.id !== albumId) {
+      await db
+        .update(tracks)
+        .set({ albumId: updatedAlbum.id })
+        .where(inArray(tracks.id, trackIds));
+    }
+
+    // Revalidate `activeTrack` in Playback store if needed.
+    await Resynchronize.onActiveTrack({ type: "album", id: albumId });
+    await AppCleanUp.media();
     clearAllQueries();
     router.back();
   } catch {

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -4,12 +4,14 @@
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
 import { eq, inArray } from "drizzle-orm";
+import { View } from "react-native";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
 import type { albums } from "~/db/schema";
 import { albumsToArtists, tracks, tracksToGenres } from "~/db/schema";
 
+import { Icon } from "~/resources/icons";
 import { updateAlbum, upsertAlbums } from "~/data/album/api";
 import { useAlbum } from "~/data/album/queries";
 import { AlbumArtistsKey } from "~/data/album/utils";
@@ -26,6 +28,7 @@ import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
 import { Divider } from "~/components/Divider";
 import { SwitchInput } from "~/components/Form/Switch";
 import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
+import { TStyledText } from "~/components/Typography/StyledText";
 import { ZSchema } from "~/modules/form/utils";
 import {
   FormStateProvider,
@@ -97,6 +100,14 @@ function MetadataForm() {
         }
       />
       <Divider />
+      <View className="flex-row gap-2 rounded-md bg-surfaceContainerLowest p-4 pl-2">
+        <Icon name="info" size={20} color="onSurfaceVariant" />
+        <TStyledText
+          textKey="feat.trackMetadata.extra.overrideFields"
+          dim
+          className="shrink grow text-sm"
+        />
+      </View>
       <FormInput label="feat.trackMetadata.extra.year" field="year" numeric />
       <ArrayFormInput label="term.genres" field="genres" />
     </KeyboardAwareScrollView>

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -199,7 +199,12 @@ async function onEditAlbum(data: AlbumMetadata) {
             );
           });
         }
-      } catch {
+      } catch (err) {
+        //? If we don't get a constraint error, then propagate the error.
+        const constraintErrMsg =
+          "UNIQUE constraint failed: albums.name, albums.artists_key";
+        if (!(err as Error).message.includes(constraintErrMsg)) throw err;
+
         //? If we crash, then an album with the changed `name` or `artistsKey`
         //? already exists. In that case, we use that album's id.
         const upsertContent = { ...ctx, ...albumContent };
@@ -215,7 +220,7 @@ async function onEditAlbum(data: AlbumMetadata) {
       }
     }
 
-    // Revalidate `activeTrack` in Playback store if needed.
+    //? 3. Revalidate `activeTrack` in Playback store if needed.
     await Resynchronize.onActiveTrack({ type: "album", id: albumId });
     await AppCleanUp.media();
     clearAllQueries();

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -90,7 +90,7 @@ function MetadataForm() {
       <FormInput label="feat.trackMetadata.extra.name" field="name" />
       <ArrayFormInput label="term.artists" field="artists" />
       <SheetLabelAction
-        label="isAlbumEP"
+        label="isEP"
         Trailing={
           <SwitchInput
             enabled={data.isEP}

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -1,0 +1,128 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { toast } from "@missingcore/ui/toast";
+import type { StaticScreenProps } from "@react-navigation/native";
+import { eq } from "drizzle-orm";
+import { z } from "zod/mini";
+
+import { db } from "~/db";
+import { tracksToArtists, tracksToGenres } from "~/db/schema";
+
+import { upsertAlbums } from "~/data/album/api";
+import { useAlbum } from "~/data/album/queries";
+import { AlbumArtistsKey } from "~/data/album/utils";
+import { createArtists } from "~/data/artist/api";
+import { createGenres } from "~/data/genre/api";
+import { updateTrack } from "~/data/track/api";
+import { Resynchronize } from "~/stores/Playback/actions";
+import { preferenceStore } from "~/stores/Preference/store";
+import { getArtworkHash } from "~/modules/startup/scanning/core/artwork";
+import { AppCleanUp } from "~/modules/startup/scanning/core/cleanup";
+
+import { router } from "~/navigation/utils/router";
+import { PagePlaceholder } from "~/navigation/components/Placeholder";
+
+import { clearAllQueries } from "~/lib/react-query";
+import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
+import { SwitchInput } from "~/components/Form/Switch";
+import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
+import { ZSchema } from "~/modules/form/utils";
+import {
+  FormStateProvider,
+  useFormStateContext,
+} from "~/modules/form/FormState";
+import {
+  ArrayFormInputImpl,
+  FormInputImpl,
+} from "~/modules/form/FormState/FormInput";
+
+type Props = StaticScreenProps<{ id: string }>;
+
+export default function ModifyAlbum({
+  route: {
+    params: { id },
+  },
+}: Props) {
+  const { isPending, data, error } = useAlbum(id);
+  if (isPending || error) return <PagePlaceholder isPending={isPending} />;
+  return (
+    <FormStateProvider
+      schema={AlbumMetadataSchema}
+      initData={{
+        id: data.id,
+        name: data.name,
+        artists: AlbumArtistsKey.deconstruct(data.artistsKey),
+        isEP: data.isEP,
+        year: null,
+        genres: [],
+      }}
+      onSubmit={onEditAlbum}
+      onConstraints={({ artists, genres }) =>
+        artists.length ===
+          new Set(artists.map((artist) => artist.trim())).size &&
+        genres.length === new Set(genres.map((genre) => genre.trim())).size
+      }
+    >
+      <MetadataForm />
+    </FormStateProvider>
+  );
+}
+
+//#region Metadata Form
+const FormInput = FormInputImpl<AlbumMetadata>();
+const ArrayFormInput = ArrayFormInputImpl<AlbumMetadata>();
+
+function MetadataForm() {
+  const { data, setFields, isSubmitting } = useFormState();
+  return (
+    <KeyboardAwareScrollView contentContainerClassName="bottom-safe-offset-4 gap-4 p-4">
+      <FormInput label="feat.trackMetadata.extra.name" field="name" />
+      <ArrayFormInput label="term.artists" field="artists" />
+      <SheetLabelAction
+        label="isAlbumEP"
+        Trailing={
+          <SwitchInput
+            enabled={data.isEP}
+            onPress={() => setFields((prev) => ({ isEP: !prev.isEP }))}
+            disabled={isSubmitting}
+          />
+        }
+      />
+      <FormInput label="feat.trackMetadata.extra.year" field="year" numeric />
+      <ArrayFormInput label="term.genres" field="genres" />
+    </KeyboardAwareScrollView>
+  );
+}
+//#endregion
+
+//#region Schema
+const AlbumMetadataSchema = z.object({
+  // Additional context:
+  id: z.string(),
+  // Actual form fields:
+  name: ZSchema.NonEmptyString,
+  artists: z.array(ZSchema.NonEmptyString),
+  isEP: z.boolean(),
+  // Fields applied to current tracks:
+  year: ZSchema.NullableRealNumber,
+  genres: z.array(ZSchema.NonEmptyString),
+});
+
+type AlbumMetadata = z.infer<typeof AlbumMetadataSchema>;
+
+function useFormState() {
+  return useFormStateContext<AlbumMetadata>();
+}
+//#endregion
+
+//#region Submit Handler
+async function onEditAlbum(data: AlbumMetadata) {
+  try {
+    clearAllQueries();
+    router.back();
+  } catch {
+    toast.tError("err.flow.generic.title");
+  }
+}
+//#endregion

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -3,15 +3,17 @@
 
 import { toast } from "@missingcore/ui/toast";
 import type { StaticScreenProps } from "@react-navigation/native";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { z } from "zod/mini";
 
 import { db } from "~/db";
-import { tracks, tracksToGenres } from "~/db/schema";
+import type { albums } from "~/db/schema";
+import { albumsToArtists, tracks, tracksToGenres } from "~/db/schema";
 
-import { upsertAlbums } from "~/data/album/api";
+import { updateAlbum, upsertAlbums } from "~/data/album/api";
 import { useAlbum } from "~/data/album/queries";
 import { AlbumArtistsKey } from "~/data/album/utils";
+import { createArtists } from "~/data/artist/api";
 import { createGenres } from "~/data/genre/api";
 import { Resynchronize } from "~/stores/Playback/actions";
 import { AppCleanUp } from "~/modules/startup/scanning/core/cleanup";
@@ -47,8 +49,13 @@ export default function ModifyAlbum({
     <FormStateProvider
       schema={AlbumMetadataSchema}
       initData={{
-        id: data.id,
-        trackIds: data.tracks.map((t) => t.id),
+        albumContext: {
+          id: data.id,
+          name: data.name,
+          artistsKey: data.artistsKey,
+          isEP: data.isEP,
+          trackIds: data.tracks.map((t) => t.id),
+        },
         name: data.name,
         artists: AlbumArtistsKey.deconstruct(data.artistsKey),
         isEP: data.isEP,
@@ -56,6 +63,7 @@ export default function ModifyAlbum({
         genres: [],
       }}
       onSubmit={onEditAlbum}
+      omittedFields={["albumContext"]}
       //? Prevent duplicates.
       onConstraints={({ artists, genres }) =>
         artists.length ===
@@ -99,8 +107,13 @@ function MetadataForm() {
 //#region Schema
 const AlbumMetadataSchema = z.object({
   // Additional context:
-  id: z.string(),
-  trackIds: z.array(ZSchema.NonEmptyString),
+  albumContext: z.object({
+    id: z.string(),
+    name: z.string(),
+    artistsKey: z.string(),
+    isEP: z.boolean(),
+    trackIds: z.array(ZSchema.NonEmptyString),
+  }),
   // Actual form fields:
   name: ZSchema.NonEmptyString,
   artists: z.array(ZSchema.NonEmptyString).check(z.minLength(1)),
@@ -120,47 +133,75 @@ function useFormState() {
 //#region Submit Handler
 async function onEditAlbum(data: AlbumMetadata) {
   try {
-    const { id: albumId, trackIds, year, genres, ...albumBase } = data;
+    const {
+      albumContext: { id: albumId, trackIds, ...ctx },
+      year,
+      genres,
+      ...albumBase
+    } = data;
 
-    //? First update year & genres on tracks if specified (as we don't
+    //? We shouldn't be able to edit an album if it has no tracks.
+    if (trackIds.length === 0) return router.back();
+
+    //? 1. First update year & genres on tracks if specified (as we don't
     //? want to override unrelated tracks if the album gets changed).
-    if (trackIds.length > 0) {
-      if (year !== null) {
-        await db
-          .update(tracks)
-          .set({ year })
-          .where(inArray(tracks.id, trackIds));
-      }
-
-      if (genres.length > 0) {
-        const genreEntries = genres.flatMap((genreName) =>
-          trackIds.map((trackId) => ({ trackId, genreName })),
-        );
-        await createGenres(genres.map((name) => ({ name })));
-        await db.transaction(async (tx) => {
-          await tx
-            .delete(tracksToGenres)
-            .where(inArray(tracksToGenres.trackId, trackIds));
-          await tx.insert(tracksToGenres).values(genreEntries);
-        });
-      }
+    if (year !== null) {
+      await db.update(tracks).set({ year }).where(inArray(tracks.id, trackIds));
     }
 
-    //? If we change `name` & `artistsKey` to an album that already exists,
-    //? we replace this album with that album.
-    const [updatedAlbum] = await upsertAlbums([
-      {
-        name: albumBase.name,
-        artistsKey: AlbumArtistsKey.from(albumBase.artists)!,
-        isEP: albumBase.isEP,
-      },
-    ]);
+    if (genres.length > 0) {
+      const genreEntries = genres.flatMap((genreName) =>
+        trackIds.map((trackId) => ({ trackId, genreName })),
+      );
+      await createGenres(genres.map((name) => ({ name })));
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(tracksToGenres)
+          .where(inArray(tracksToGenres.trackId, trackIds));
+        await tx.insert(tracksToGenres).values(genreEntries);
+      });
+    }
 
-    if (trackIds.length > 0 && updatedAlbum && updatedAlbum.id !== albumId) {
-      await db
-        .update(tracks)
-        .set({ albumId: updatedAlbum.id })
-        .where(inArray(tracks.id, trackIds));
+    //? 2. Update the album entry.
+    const albumContent: Partial<typeof albums.$inferInsert> = {};
+    if (ctx.name !== albumBase.name) albumContent.name = albumBase.name;
+    const artistsKey = AlbumArtistsKey.from(albumBase.artists)!;
+    if (ctx.artistsKey !== artistsKey) albumContent.artistsKey = artistsKey;
+    if (ctx.isEP !== albumBase.isEP) albumContent.isEP = albumBase.isEP;
+
+    let returnedAlbumId: string | undefined = albumId;
+    if (Object.keys(albumContent).length > 0) {
+      try {
+        await updateAlbum(albumId, albumContent);
+        //? If we're updating `artistsKey`, we need to re-create those relations.
+        if (albumContent.artistsKey) {
+          await createArtists(albumBase.artists.map((name) => ({ name })));
+          await db.transaction(async (tx) => {
+            await tx
+              .delete(albumsToArtists)
+              .where(eq(albumsToArtists.albumId, albumId));
+            await tx.insert(albumsToArtists).values(
+              albumBase.artists.map((artistName) => ({
+                albumId,
+                artistName,
+              })),
+            );
+          });
+        }
+      } catch {
+        //? If we crash, then an album with the changed `name` or `artistsKey`
+        //? already exists. In that case, we use that album's id.
+        const upsertContent = { ...ctx, ...albumContent };
+        const [updatedAlbum] = await upsertAlbums([upsertContent]);
+        //? This should be defined.
+        returnedAlbumId = updatedAlbum?.id;
+
+        if (returnedAlbumId)
+          await db
+            .update(tracks)
+            .set({ albumId: returnedAlbumId })
+            .where(inArray(tracks.id, trackIds));
+      }
     }
 
     // Revalidate `activeTrack` in Playback store if needed.
@@ -168,6 +209,7 @@ async function onEditAlbum(data: AlbumMetadata) {
     await AppCleanUp.media();
     clearAllQueries();
     router.back();
+    router.navigate("Album", { id: returnedAlbumId ?? albumId });
   } catch {
     toast.tError("err.flow.generic.title");
   }

--- a/mobile/src/navigation/screens/albums/ModifyView.tsx
+++ b/mobile/src/navigation/screens/albums/ModifyView.tsx
@@ -161,22 +161,26 @@ async function onEditAlbum(data: AlbumMetadata) {
     }
 
     if (genres.length > 0) {
-      const genreEntries = genres.flatMap((genreName) =>
-        trackIds.map((trackId) => ({ trackId, genreName })),
-      );
       await createGenres(genres.map((name) => ({ name })));
       await db.transaction(async (tx) => {
         await tx
           .delete(tracksToGenres)
           .where(inArray(tracksToGenres.trackId, trackIds));
-        await tx.insert(tracksToGenres).values(genreEntries);
+        await tx
+          .insert(tracksToGenres)
+          .values(
+            genres.flatMap((genreName) =>
+              trackIds.map((trackId) => ({ trackId, genreName })),
+            ),
+          );
       });
     }
 
     //? 2. Update the album entry.
     const albumContent: Partial<typeof albums.$inferInsert> = {};
     if (ctx.name !== albumBase.name) albumContent.name = albumBase.name;
-    const artistsKey = AlbumArtistsKey.from(albumBase.artists)!;
+    const artistsKey = AlbumArtistsKey.from(albumBase.artists);
+    if (!artistsKey) throw new Error("`artistsKey` somehow not generated.");
     if (ctx.artistsKey !== artistsKey) albumContent.artistsKey = artistsKey;
     if (ctx.isEP !== albumBase.isEP) albumContent.isEP = albumBase.isEP;
 

--- a/mobile/src/navigation/screens/tracks/ModifyView.tsx
+++ b/mobile/src/navigation/screens/tracks/ModifyView.tsx
@@ -39,8 +39,6 @@ import { splitOn } from "~/utils/string";
 import { KeyboardAwareScrollView } from "~/components/Base/ScrollView";
 import { IconButton } from "~/components/Form/Button/Icon";
 import { TextInput } from "~/components/Form/Input";
-import { SwitchInput } from "~/components/Form/Switch";
-import { SheetLabelAction } from "~/components/Sheet/SheetLabelAction";
 import { useSheetRef } from "~/components/Sheet/useSheetRef";
 import { StyledText } from "~/components/Typography/StyledText";
 import { ZSchema } from "~/modules/form/utils";
@@ -99,7 +97,6 @@ export default function ModifyTrack({
         albumArtists: trackQuery.data.albumArtistsKey
           ? AlbumArtistsKey.deconstruct(trackQuery.data.albumArtistsKey)
           : [],
-        isEP: trackQuery.data.isAlbumEP ?? false,
         year: trackQuery.data.year,
         disc: trackQuery.data.disc,
         track: trackQuery.data.track,
@@ -214,16 +211,6 @@ function MetadataForm({ bottomOffset }: { bottomOffset: number }) {
           label="feat.trackMetadata.extra.albumArtists"
           field="albumArtists"
         />
-        <SheetLabelAction
-          label="isAlbumEP"
-          Trailing={
-            <SwitchInput
-              enabled={data.isEP}
-              onPress={() => setFields((prev) => ({ isEP: !prev.isEP }))}
-              disabled={isSubmitting}
-            />
-          }
-        />
         <View className="flex-row items-end gap-4">
           <FormInput
             label="feat.trackMetadata.extra.disc"
@@ -254,7 +241,6 @@ const TrackMetadataSchema = z.object({
   artists: z.array(ZSchema.NonEmptyString),
   album: ZSchema.NullableString,
   albumArtists: z.array(ZSchema.NonEmptyString),
-  isEP: z.boolean(),
   year: ZSchema.NullableRealNumber,
   disc: ZSchema.NullableRealNumber,
   track: ZSchema.NullableRealNumber,
@@ -271,16 +257,8 @@ function useFormState() {
 //#region Submit Handler
 async function onEditTrack(data: TrackMetadata) {
   try {
-    const {
-      id,
-      uri,
-      album,
-      albumArtists,
-      isEP,
-      artists,
-      genres,
-      ...trackBase
-    } = data;
+    const { id, uri, album, albumArtists, artists, genres, ...trackBase } =
+      data;
 
     const updatedTrack = {
       ...trackBase,
@@ -291,7 +269,6 @@ async function onEditTrack(data: TrackMetadata) {
     const updatedAlbum = {
       name: album,
       artistsKey: AlbumArtistsKey.from(albumArtists),
-      isEP,
     };
 
     // Add new artists & genres to the database.
@@ -310,17 +287,13 @@ async function onEditTrack(data: TrackMetadata) {
     // Add new album to the database.
     let albumId: string | null = null;
     if (updatedAlbum.name && updatedAlbum.artistsKey) {
-      const [newAlbum] = await upsertAlbums(
-        [
-          {
-            name: updatedAlbum.name,
-            artistsKey: updatedAlbum.artistsKey,
-            embeddedArtwork: artworkHash,
-            isEP: updatedAlbum.isEP,
-          },
-        ],
-        true,
-      );
+      const [newAlbum] = await upsertAlbums([
+        {
+          name: updatedAlbum.name,
+          artistsKey: updatedAlbum.artistsKey,
+          embeddedArtwork: artworkHash,
+        },
+      ]);
       if (newAlbum) albumId = newAlbum.id;
     }
     if (!albumId || !preferenceStore.getState().optimizedImageSave) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds album editing capabilities, specifically the album name, album artists, and EP status. In addition, you can bulk apply a year & genres on all tracks in the album (**_setting these values in the form will override the values on all tracks in the album_**).
- With this change, we removed the `isEP` field in the "Edit Track" form (reverting some changes from #587).

The "Edit Album" form allows merging of albums if you changed the album name & album artists to be one that another album is already using.
- One caveat of this is that the `isEP` status in the current "Edit Album" form won't be brought over.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] New files have the SPDX license identifier at the top of the file.
- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added album editing from the album screen.
  * Album metadata can now be updated, including name, artists, EP status, release year, and genres.
  * Added support for overriding assigned album-track metadata values.

* **Changes**
  * Removed the “Is EP” option from track editing; EP status is managed at the album level.
  * Improved handling of album edits that conflict with existing album information.
  * Updated track and album metadata behavior to keep album-level details consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->