### PR TITLE
feat: Support TTML lyrics (to a certain extent)

### DIFF
--- a/docs/lyrics.md
+++ b/docs/lyrics.md
@@ -68,7 +68,7 @@ Given you have a license to an API that distributes lyrics which can be displaye
 
 ## Supported Lyric Formats
 
-Unless we support the provided lyrics format, they will be rendered as a static string.
+Unless we support the provided lyrics format, they will be rendered as a static string. In addition, if the lyrics are identified as synchronized, clicking on a line will **seek to the start of the line (we do not support seeking to a specific word)**.
 
 <table>
   <thead>

--- a/docs/lyrics.md
+++ b/docs/lyrics.md
@@ -92,7 +92,7 @@ Unless we support the provided lyrics format, they will be rendered as a static 
       <td>
         <b>In addition to the <code>LRC</code> notes:</b>
         <ul>
-          <li>We support word/syllable timestamps with square or angle branckets (ie: <code>[mm:ss.ms]</code>, <code>&lt;mm:ss.ms&gt;</code>).</li>
+          <li>We support word/syllable timestamps with square or angle brackets (ie: <code>[mm:ss.ms]</code>, <code>&lt;mm:ss.ms&gt;</code>).</li>
         </ul>
       </td>
     </tr>

--- a/docs/lyrics.md
+++ b/docs/lyrics.md
@@ -68,8 +68,42 @@ Given you have a license to an API that distributes lyrics which can be displaye
 
 ## Supported Lyric Formats
 
-Lyrics will be rendered as a static string, unless it's identified as synchronized by the following conditions:
+Unless we support the provided lyrics format, they will be rendered as a static string.
 
-- Every line starts with `[mm:ss.ms]` or `[mm:ss]`.
-  - Tags at the start of the lyrics that follow a similar format (ie: `[ti:]`) will be ignored.
-- Word-by-word lyrics (using either square or angle brackets) are also supported (ie: `[mm:ss.ms]`, `<mm:ss.ms>`).
+<table>
+  <thead>
+    <tr>
+      <th>Format</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>LRC</code></td>
+      <td>
+        <ul>
+          <li>Every line starts with <code>[mm:ss.ms]</code> or <code>[mm:ss]</code>.</li>
+          <li>Tags at the start of the lyrics that follow a similar format (ie: <code>[ti:]</code>) will be ignored.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>LRC A2</code></td>
+      <td>
+        <b>In addition to the <code>LRC</code> notes:</b>
+        <ul>
+          <li>We support word/syllable timestamps with square or angle branckets (ie: <code>[mm:ss.ms]</code>, <code>&lt;mm:ss.ms&gt;</code>).</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>TTML</code></td>
+      <td>
+        <ul>
+          <li>We do not support/take advantage of every feature provided by the <code>TTML</code> lyrics format.</li>
+          <li>For example, inline assistant content (ie: background vocals) will be rendered as a separate line.</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/mobile/src/modules/lyric/components/LyricsOverlay.tsx
+++ b/mobile/src/modules/lyric/components/LyricsOverlay.tsx
@@ -13,6 +13,7 @@ import { PlaybackControls } from "~/stores/Playback/actions";
 
 import { cn } from "~/lib/style";
 import { bgWait } from "~/utils/promise";
+import { isString } from "~/utils/validation";
 import type { FlatListProps, FlatListRef } from "~/components/Base/List";
 import { FlatList, useFlatListRef } from "~/components/Base/List";
 import { Pressable } from "~/components/Base/Pressable";
@@ -24,6 +25,8 @@ import { useIsAtmosphereActive } from "~/modules/customization/atmosphere/store"
 import { useTheme } from "~/modules/customization/theme/hooks";
 import { autoDiscoverLyrics } from "../helpers/autoDiscoverLyrics";
 import { removeSynchronizedLyricsJunk } from "../helpers/cleanUpLyricsJunk";
+import { parseLyrics } from "../helpers/parser";
+import type { SynchronizedLine } from "../helpers/parser/utils";
 
 const SCROLL_OFFSET = 64;
 const LINE_GAP = 16;
@@ -73,30 +76,22 @@ function LyricsContent(props: { trackId: string; offset: number }) {
   const { isPending, data, error } = useLyricForTrack(props.trackId);
   const cleanupInProgress = useRef<Set<string>>(new Set());
 
-  const lyricsLines = useMemo(() => {
-    if (!data?.lyrics) return [];
-    return data.lyrics.split("\n").map((line) => line.trim());
+  const formattedLyrics = useMemo(() => {
+    if (!data?.lyrics) return;
+    return parseLyrics(data.lyrics);
   }, [data?.lyrics]);
-
-  const isSynchronized = useMemo(
-    () =>
-      lyricsLines.every((line) =>
-        !line ? true : LRC_LINE_SYNC_TAG.test(line),
-      ),
-    [lyricsLines],
-  );
 
   //! TODO: Remove in `v4.0.0`.
   //! Temporary "hack" to clean up cached lyrics with "junk" in front, which
   //! was fixed in `v3.3.0`.
   useEffect(() => {
-    if (isSynchronized || !data?.id || lyricsLines.length === 0) return;
+    if (!isString(formattedLyrics) || !data?.id) return;
     if (cleanupInProgress.current.has(data.id)) return;
     cleanupInProgress.current.add(data.id);
     removeSynchronizedLyricsJunk(data.id)
       .catch((err) => console.log(`[LRC_CLEANUP_ERR]`, err))
       .finally(() => cleanupInProgress.current.delete(data.id));
-  }, [props.trackId, data?.id, lyricsLines, isSynchronized]);
+  }, [props.trackId, data?.id, formattedLyrics]);
 
   if (isPending) return null;
   else if (error || !data) {
@@ -105,15 +100,15 @@ function LyricsContent(props: { trackId: string; offset: number }) {
 
   return (
     <>
-      {isSynchronized ? (
+      {Array.isArray(formattedLyrics) ? (
         <SynchronizedLyrics
           key={props.trackId}
-          lines={lyricsLines}
+          parsedLines={formattedLyrics}
           offset={props.offset}
         />
       ) : (
         <FlatList
-          data={lyricsLines}
+          data={formattedLyrics?.split("\n")}
           keyExtractor={(_, index) => `${index}`}
           renderItem={({ item }) => <Em className="text-xl">{item}</Em>}
           nestedScrollEnabled
@@ -174,15 +169,19 @@ function LyricsNotFound(props: { trackId: string; offset: number }) {
 //#endregion
 
 //#region Synchronized Lyrics
-function SynchronizedLyrics(props: { lines: string[]; offset: number }) {
+function SynchronizedLyrics({
+  parsedLines,
+  offset,
+}: {
+  parsedLines: SynchronizedLine[];
+  offset: number;
+}) {
   // Use `usePolledProgress` as `Event.PlaybackProgressUpdated` fires once a second.
   const { position } = usePolledProgress(50, false);
   const listRef = useFlatListRef();
   const [activeLineIndex, setActiveLineIndex] = useState(-1);
   const prevActiveLineIndex = useRef(-1);
   const [inActiveWordStartIndex, setInActiveWordStartIndex] = useState(0);
-
-  const parsedLines = useMemo(() => parseLines(props.lines), [props.lines]);
 
   //#region Auto Scroll
   const autoScrollResumeTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
@@ -281,7 +280,7 @@ function SynchronizedLyrics(props: { lines: string[]; offset: number }) {
       initialNumToRender={renderedLines.length}
       onScrollBeginDrag={onPauseAutoScroll}
       onScrollEndDrag={debouncedResumeAutoScroll}
-      offset={props.offset}
+      offset={offset}
     />
   );
 }
@@ -337,76 +336,4 @@ const MemoLyricList = memo(
     JSON.stringify(prevProps.data) === JSON.stringify(nextProps.data) &&
     prevProps.offset === nextProps.offset,
 );
-//#endregion
-
-//#region Lyric Parsing
-const LRC_LINE_SYNC_TAG = /^\[.+:.+?\]/;
-const LRC_LINE_START_TIMESTAMP = /^\[[0-9]+:[0-9]+(?:\.[0-9]+)?\]/;
-/** Supports both square & angle bracket format. */
-const LRC_WORD_TIMESTAMP = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
-const LRC_TIMESTAMP = /[0-9]+/g;
-
-type Timestamp = [string, string, ...string[]];
-
-type SynchronizedWord = { timeMS: number; word: string };
-type SynchronizedLine = { timeMS: number; words: SynchronizedWord[] };
-
-function parseLines(lines: string[]): SynchronizedLine[] {
-  const results: SynchronizedLine[] = [];
-  for (const line of lines) {
-    if (!line) continue;
-    const lyricLineTimestampStr = line.match(LRC_LINE_START_TIMESTAMP);
-    if (!lyricLineTimestampStr || lyricLineTimestampStr.length === 0) continue;
-
-    // Get the time when the line will start.
-    const lineTimeMS = getTimestampInMS(lyricLineTimestampStr[0]);
-    const lyricLine = line.replace(LRC_LINE_START_TIMESTAMP, "").trim();
-
-    // See if this has word-by-word synchronization.
-    if (LRC_WORD_TIMESTAMP.test(lyricLine)) {
-      const wordTimestampStrs = lyricLine.match(LRC_WORD_TIMESTAMP);
-      if (!wordTimestampStrs || wordTimestampStrs.length === 0) continue;
-      // Get the words after each timestamp. In general, `wordTimestampStrs` &
-      // `words` should have the same length.
-      const [lineFirstWord, ...words] = lyricLine.split(LRC_WORD_TIMESTAMP);
-
-      const synchronizedWords: SynchronizedWord[] = wordTimestampStrs
-        .map((wordTimestamp, index) => {
-          const syncWord = words[index];
-          if (syncWord === undefined) return;
-          return {
-            timeMS: getTimestampInMS(wordTimestamp),
-            word: syncWord.trimStart(),
-          };
-        })
-        .filter((syncWord) => syncWord !== undefined);
-
-      // Assign the first word (could be an empty string) the line's timestamp.
-      if (typeof lineFirstWord === "string") {
-        synchronizedWords.unshift({ timeMS: lineTimeMS, word: lineFirstWord });
-      }
-
-      results.push({ timeMS: lineTimeMS, words: synchronizedWords });
-    } else {
-      results.push({
-        timeMS: lineTimeMS,
-        words: [{ timeMS: lineTimeMS, word: lyricLine }],
-      });
-    }
-  }
-
-  return results;
-}
-//#endregion
-
-//#region Helpers
-function getTimestampInMS(timeString: string) {
-  const [min, sec, ms = "0"] = timeString.match(LRC_TIMESTAMP) as Timestamp;
-  return (
-    Number.parseInt(min) * 60 * 1000 +
-    Number.parseInt(sec) * 1000 +
-    Number.parseInt(ms)
-  );
-}
-//#endregion
 //#endregion

--- a/mobile/src/modules/lyric/components/LyricsOverlay.tsx
+++ b/mobile/src/modules/lyric/components/LyricsOverlay.tsx
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { useNavigation } from "@react-navigation/native";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  memo,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { Text, View } from "react-native";
 import { usePolledProgress } from "react-native-audio-browser";
@@ -31,50 +40,57 @@ import type { SynchronizedLine } from "../helpers/parser/utils";
 const SCROLL_OFFSET = 64;
 const LINE_GAP = 16;
 
+const LyricOffsetContext = createContext({ offset: 0, extraTop: 0 });
+
 export function LyricsOverlay(props: { size: number; trackId: string }) {
   const { top } = useSafeAreaInsets();
   const { scheme } = useTheme();
   const hideBackground = useIsAtmosphereActive();
 
   // Estimated offset to get overlay to go behind the `TopAppBar`.
-  const lyricsOffset = top + SCROLL_OFFSET;
+  const scrollGradientHeight = top + SCROLL_OFFSET;
 
   return (
-    <View
-      style={{ top: -top, bottom: 0 }}
-      className={cn(
-        "absolute w-full items-center justify-center",
-        !hideBackground
-          ? cn("bg-surface/85", { "bg-surface/60": scheme === "dark" })
-          : undefined,
-      )}
+    <LyricOffsetContext
+      value={{ offset: props.size / 2, extraTop: scrollGradientHeight }}
     >
-      <View style={{ width: props.size }} className="px-2">
-        <LyricsContent trackId={props.trackId} offset={lyricsOffset} />
-      </View>
+      <View
+        style={{ top: -top, bottom: 0 }}
+        className={cn(
+          "absolute w-full items-center justify-center",
+          !hideBackground
+            ? cn("bg-surface/85", { "bg-surface/60": scheme === "dark" })
+            : undefined,
+        )}
+      >
+        <View style={{ width: props.size }} className="px-2">
+          <LyricsContent trackId={props.trackId} />
+        </View>
 
-      {!hideBackground ? (
-        <>
-          <TopDownGradient
-            height={lyricsOffset}
-            startFrom={top}
-            className="absolute top-0 left-0"
-          />
-          <TopDownGradient
-            height={SCROLL_OFFSET}
-            className="absolute bottom-0 left-0 rotate-180"
-          />
-        </>
-      ) : null}
-    </View>
+        {!hideBackground ? (
+          <>
+            <TopDownGradient
+              height={scrollGradientHeight}
+              startFrom={top}
+              className="absolute top-0 left-0"
+            />
+            <TopDownGradient
+              height={scrollGradientHeight}
+              className="absolute bottom-0 left-0 rotate-180"
+            />
+          </>
+        ) : null}
+      </View>
+    </LyricOffsetContext>
   );
 }
 
-function LyricsContent(props: { trackId: string; offset: number }) {
+function LyricsContent({ trackId }: { trackId: string }) {
   const { t } = useTranslation();
   const navigation = useNavigation();
-  const { isPending, data, error } = useLyricForTrack(props.trackId);
+  const { isPending, data, error } = useLyricForTrack(trackId);
   const cleanupInProgress = useRef<Set<string>>(new Set());
+  const { offset, extraTop } = use(LyricOffsetContext);
 
   const formattedLyrics = useMemo(() => {
     if (!data?.lyrics) return;
@@ -91,21 +107,16 @@ function LyricsContent(props: { trackId: string; offset: number }) {
     removeSynchronizedLyricsJunk(data.id)
       .catch((err) => console.log(`[LRC_CLEANUP_ERR]`, err))
       .finally(() => cleanupInProgress.current.delete(data.id));
-  }, [props.trackId, data?.id, formattedLyrics]);
+  }, [trackId, data?.id, formattedLyrics]);
 
   if (isPending) return null;
   else if (error || !data) {
-    return <LyricsNotFound key={props.trackId} {...props} />;
+    return <LyricsNotFound key={trackId} trackId={trackId} />;
   }
-
   return (
     <>
       {Array.isArray(formattedLyrics) ? (
-        <SynchronizedLyrics
-          key={props.trackId}
-          parsedLines={formattedLyrics}
-          offset={props.offset}
-        />
+        <SynchronizedLyrics key={trackId} parsedLines={formattedLyrics} />
       ) : (
         <FlatList
           data={formattedLyrics?.split("\n")}
@@ -113,8 +124,8 @@ function LyricsContent(props: { trackId: string; offset: number }) {
           renderItem={({ item }) => <Em className="text-xl">{item}</Em>}
           nestedScrollEnabled
           contentContainerStyle={{
-            paddingTop: props.offset,
-            paddingBottom: SCROLL_OFFSET,
+            paddingTop: offset + extraTop,
+            paddingBottom: offset,
             gap: LINE_GAP,
           }}
         />
@@ -132,10 +143,11 @@ function LyricsContent(props: { trackId: string; offset: number }) {
 }
 
 //#region Not Found
-function LyricsNotFound(props: { trackId: string; offset: number }) {
+function LyricsNotFound({ trackId }: { trackId: string }) {
   const { t } = useTranslation();
   const navigation = useNavigation();
   const [checkingEmbeddedLyrics, setCheckingEmbeddedLyrics] = useState(true);
+  const { extraTop } = use(LyricOffsetContext);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -150,15 +162,12 @@ function LyricsNotFound(props: { trackId: string; offset: number }) {
   }, []);
 
   return (
-    <View
-      style={{ paddingTop: props.offset }}
-      className="items-center gap-6 pb-4"
-    >
+    <View style={{ paddingTop: extraTop }} className="items-center gap-6 pb-4">
       <TEm textKey="err.msg.noLyrics" className="text-xl" />
       <ExtendedTButton
         // @ts-expect-error - Will display text if key doesn't exist.
         textKey={t("template.entryManage", { name: t("feat.lyrics.title") })}
-        onPress={() => navigation.navigate("Lyrics", { linkTo: props.trackId })}
+        onPress={() => navigation.navigate("Lyrics", { linkTo: trackId })}
         disabled={checkingEmbeddedLyrics}
         className="min-h-auto w-full max-w-48"
         textClassName="text-xs"
@@ -171,10 +180,8 @@ function LyricsNotFound(props: { trackId: string; offset: number }) {
 //#region Synchronized Lyrics
 function SynchronizedLyrics({
   parsedLines,
-  offset,
 }: {
   parsedLines: SynchronizedLine[];
-  offset: number;
 }) {
   // Use `usePolledProgress` as `Event.PlaybackProgressUpdated` fires once a second.
   const { position } = usePolledProgress(50, false);
@@ -280,7 +287,6 @@ function SynchronizedLyrics({
       initialNumToRender={renderedLines.length}
       onScrollBeginDrag={onPauseAutoScroll}
       onScrollEndDrag={debouncedResumeAutoScroll}
-      offset={offset}
     />
   );
 }
@@ -295,9 +301,9 @@ const MemoLyricList = memo(
   function MemoLyricList(
     props: Omit<FlatListProps<FormattedSynchronizedLine>, "renderItem"> & {
       ref: FlatListRef<FormattedSynchronizedLine>;
-      offset: number;
     },
   ) {
+    const { offset, extraTop } = use(LyricOffsetContext);
     return (
       <FlatList
         {...props}
@@ -324,16 +330,15 @@ const MemoLyricList = memo(
         // Suppresses error when `scrollToIndex` fails.
         onScrollToIndexFailed={() => {}}
         contentContainerStyle={{
-          paddingTop: props.offset,
-          paddingBottom: SCROLL_OFFSET,
+          paddingTop: offset + extraTop,
+          paddingBottom: offset,
           gap: LINE_GAP,
         }}
       />
     );
   },
-  // We should only re-render the list when `data` or `offset` changes.
+  // We should only re-render the list when `data` changes.
   (prevProps, nextProps) =>
-    JSON.stringify(prevProps.data) === JSON.stringify(nextProps.data) &&
-    prevProps.offset === nextProps.offset,
+    JSON.stringify(prevProps.data) === JSON.stringify(nextProps.data),
 );
 //#endregion

--- a/mobile/src/modules/lyric/helpers/parser/index.ts
+++ b/mobile/src/modules/lyric/helpers/parser/index.ts
@@ -7,7 +7,7 @@ import type { SynchronizedLine } from "./utils";
 
 /** Identifies and returns the lyrics we want to display. */
 export function parseLyrics(lyrics: string): string | SynchronizedLine[] {
-  if (lyrics.includes(`xmlns="http://www.w3.org/ns/ttml"`)) {
+  if (lyrics.includes("http://www.w3.org/ns/ttml")) {
     return parseTTML(lyrics);
   }
 

--- a/mobile/src/modules/lyric/helpers/parser/index.ts
+++ b/mobile/src/modules/lyric/helpers/parser/index.ts
@@ -1,0 +1,20 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { parseLRC } from "./parseLRC";
+import { parseTTML } from "./parseTTML";
+import type { SynchronizedLine } from "./utils";
+
+/** Identifies and returns the lyrics we want to display. */
+export function parseLyrics(lyrics: string): string | SynchronizedLine[] {
+  if (lyrics.includes(`xmlns="http://www.w3.org/ns/ttml"`)) {
+    return parseTTML(lyrics);
+  }
+
+  //* Current way of testing for `LRC` or `LRC A2` format is to run it
+  //* through the parser and see if it returns a result.
+  const results = parseLRC(lyrics);
+  if (results.length > 0) return results;
+
+  return lyrics;
+}

--- a/mobile/src/modules/lyric/helpers/parser/index.ts
+++ b/mobile/src/modules/lyric/helpers/parser/index.ts
@@ -8,7 +8,8 @@ import type { SynchronizedLine } from "./utils";
 /** Identifies and returns the lyrics we want to display. */
 export function parseLyrics(lyrics: string): string | SynchronizedLine[] {
   if (lyrics.includes("http://www.w3.org/ns/ttml")) {
-    return parseTTML(lyrics);
+    const results = parseTTML(lyrics);
+    if (results.length > 0) return parseTTML(lyrics);
   }
 
   //* Current way of testing for `LRC` or `LRC A2` format is to run it

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -1,11 +1,12 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { SynchronizedLine, SynchronizedWord } from "./types";
+import type { SynchronizedLine, SynchronizedWord } from "./utils";
+import { parseTimestampAsMS } from "./utils";
 
-/** Regex identifying the start of a lyric line (a timestamp). */
+/** Identifies the start of a lyric line (a timestamp). */
 const LRC_LINE_START = /^\[[0-9]+:[0-9]+(?:\.[0-9]+)?\]/;
-/** Regex identifying the timestamps in the LRC A2 format. */
+/** Identifies the timestamps in the LRC A2 format. */
 const LRC_A2_TIMESTAMP = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
 
 /**
@@ -60,19 +61,3 @@ export function parseLRC(lyrics: string): SynchronizedLine[] {
 
   return formattedLines;
 }
-
-//#region Helpers
-type Timestamp = [string, string, ...string[]];
-
-/** Regex to extract each timestamp segment. */
-const LRC_TIMESTAMP = /[0-9]+/g;
-
-function parseTimestampAsMS(timeStr: string) {
-  const [min, sec, ms = "0"] = timeStr.match(LRC_TIMESTAMP) as Timestamp;
-  return (
-    Number.parseInt(min) * 60 * 1000 +
-    Number.parseInt(sec) * 1000 +
-    Number.parseInt(ms)
-  );
-}
-//#endregion

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -5,9 +5,9 @@ import type { SynchronizedLine, SynchronizedWord } from "./utils";
 import { parseTimestampAsMS } from "./utils";
 
 /** Identifies the start of a lyric line (a timestamp). */
-const LRC_LINE_START = /^\[([0-9]+:[0-9]+(?:\.[0-9]+)?)\](.*)/;
+const LRCLineRegex = /^\[([0-9]+:[0-9]+(?:\.[0-9]+)?)\](.*)/;
 /** Identifies the timestamps in the LRC A2 format. */
-const LRC_A2_TIMESTAMP = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
+const A2TimestampRegex = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
 
 /**
  * Supports parsing the following formats:
@@ -21,7 +21,7 @@ export function parseLRC(lyrics: string): SynchronizedLine[] {
   const lines = lyrics
     .split("\n")
     .map((line) => {
-      const parsedLine = line.match(LRC_LINE_START);
+      const parsedLine = line.match(LRCLineRegex);
       if (!parsedLine || !parsedLine[1] || !parsedLine[2]) return undefined;
       return [parsedLine[1], parsedLine[2].trim()] as [string, string];
     })
@@ -31,11 +31,11 @@ export function parseLRC(lyrics: string): SynchronizedLine[] {
     const startMS = parseTimestampAsMS(timestamp);
 
     //? See if the lyrics are in A2 format.
-    const a2LRCTimestamps = lineContent.match(LRC_A2_TIMESTAMP);
+    const a2LRCTimestamps = lineContent.match(A2TimestampRegex);
     if (a2LRCTimestamps) {
       //? Get words after each timestamp. We expect `a2LRCTimestamps` &
       //? `words` to have the same length.
-      const [firstWord, ...words] = lineContent.split(LRC_A2_TIMESTAMP);
+      const [firstWord, ...words] = lineContent.split(A2TimestampRegex);
 
       const syncWords: SynchronizedWord[] = a2LRCTimestamps
         .map((timestamp, idx) => {

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { SynchronizedLine, SynchronizedWord } from "./types";
 
 /** Regex identifying the start of a lyric line (a timestamp). */

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -5,7 +5,7 @@ import type { SynchronizedLine, SynchronizedWord } from "./utils";
 import { parseTimestampAsMS } from "./utils";
 
 /** Identifies the start of a lyric line (a timestamp). */
-const LRC_LINE_START = /^\[[0-9]+:[0-9]+(?:\.[0-9]+)?\]/;
+const LRC_LINE_START = /^\[([0-9]+:[0-9]+(?:\.[0-9]+)?)\](.*)/;
 /** Identifies the timestamps in the LRC A2 format. */
 const LRC_A2_TIMESTAMP = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
 
@@ -17,35 +17,36 @@ const LRC_A2_TIMESTAMP = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
 export function parseLRC(lyrics: string): SynchronizedLine[] {
   const formattedLines: SynchronizedLine[] = [];
 
-  const lines = lyrics.split("\n").map((line) => line.trim());
-  for (const line of lines) {
-    //? Skip any non-LRC lines (ie: metadata, comments).
-    if (!line || !LRC_LINE_START.test(line)) continue;
+  //? Get tuple of timestamp & lyric line content.
+  const lines = lyrics
+    .split("\n")
+    .map((line) => {
+      const parsedLine = line.match(LRC_LINE_START);
+      if (!parsedLine || !parsedLine[1] || !parsedLine[2]) return undefined;
+      return [parsedLine[1], parsedLine[2].trim()] as [string, string];
+    })
+    .filter((line) => line !== undefined);
 
-    const startMS = parseTimestampAsMS(line.match(LRC_LINE_START)![0]);
-    const lineContent = line.replace(LRC_LINE_START, "").trim();
+  for (const [timestamp, lineContent] of lines) {
+    const startMS = parseTimestampAsMS(timestamp);
 
     //? See if the lyrics are in A2 format.
-    if (LRC_A2_TIMESTAMP.test(lineContent)) {
-      const timestampStrs = lineContent.match(LRC_A2_TIMESTAMP);
-      if (!timestampStrs || timestampStrs.length === 0) continue;
-
-      //? Get words after each timestamp. We expect `timestampStrs` & `words`
-      //? to have the same length.
+    const a2LRCTimestamps = lineContent.match(LRC_A2_TIMESTAMP);
+    if (a2LRCTimestamps) {
+      //? Get words after each timestamp. We expect `a2LRCTimestamps` &
+      //? `words` to have the same length.
       const [firstWord, ...words] = lineContent.split(LRC_A2_TIMESTAMP);
 
-      const syncWords: SynchronizedWord[] = timestampStrs
+      const syncWords: SynchronizedWord[] = a2LRCTimestamps
         .map((timestamp, idx) => {
           const word = words[idx];
           if (word === undefined) return;
-          return { timeMS: parseTimestampAsMS(timestamp), word: word.trim() };
+          return { timeMS: parseTimestampAsMS(timestamp), word };
         })
         .filter((word) => word !== undefined);
 
       //? Assign the first word (could be an empty string) the line's timestamp.
-      if (typeof firstWord === "string") {
-        syncWords.unshift({ timeMS: startMS, word: firstWord });
-      }
+      if (firstWord) syncWords.unshift({ timeMS: startMS, word: firstWord });
 
       formattedLines.push({ timeMS: startMS, words: syncWords });
     } else {

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -22,8 +22,8 @@ export function parseLRC(lyrics: string): SynchronizedLine[] {
     .split("\n")
     .map((line) => {
       const parsedLine = line.match(LRCLineRegex);
-      if (!parsedLine || !parsedLine[1] || !parsedLine[2]) return undefined;
-      return [parsedLine[1], parsedLine[2].trim()] as [string, string];
+      if (parsedLine?.[1] && parsedLine?.[2])
+        return [parsedLine[1], parsedLine[2].trim()] as const;
     })
     .filter((line) => line !== undefined);
 
@@ -40,12 +40,13 @@ export function parseLRC(lyrics: string): SynchronizedLine[] {
       const syncWords: SynchronizedWord[] = a2LRCTimestamps
         .map((timestamp, idx) => {
           const word = words[idx];
-          if (word === undefined) return;
-          return { timeMS: parseTimestampAsMS(timestamp), word };
+          if (word) return { timeMS: parseTimestampAsMS(timestamp), word };
         })
         .filter((word) => word !== undefined);
 
       //? Assign the first word (could be an empty string) the line's timestamp.
+      //? This situation would be if we got `[mm:ss.xxx]word` instead of
+      //? `[mm:ss.xxx]<mm:ss.xxx>word`.
       if (firstWord) syncWords.unshift({ timeMS: startMS, word: firstWord });
 
       formattedLines.push({ timeMS: startMS, words: syncWords });

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -1,0 +1,75 @@
+import type { SynchronizedLine, SynchronizedWord } from "./types";
+
+/** Regex identifying the start of a lyric line (a timestamp). */
+const LRC_LINE_START = /^\[[0-9]+:[0-9]+(?:\.[0-9]+)?\]/;
+/** Regex identifying the timestamps in the LRC A2 format. */
+const LRC_A2_TIMESTAMP = /(?:\[|<)[0-9]+:[0-9]+(?:\.[0-9]+)?(?:\]|>)/g;
+
+/**
+ * Supports parsing the following formats:
+ *  - **LRC:** `[mm:ss]`, `[mm:ss.xx]`, `[mm:ss.xxx]`
+ *  - **LRC A2:** `[mm:ss.xx] <mm:ss.xx>`, `[mm:ss.xx] [mm:ss.xx]`
+ */
+export function parseLRC(lyrics: string): SynchronizedLine[] {
+  const formattedLines: SynchronizedLine[] = [];
+
+  const lines = lyrics.split("\n").map((line) => line.trim());
+  for (const line of lines) {
+    //? Skip any non-LRC lines (ie: metadata, comments).
+    if (!line || !LRC_LINE_START.test(line)) continue;
+
+    const startMS = parseTimestampAsMS(line.match(LRC_LINE_START)![0]);
+    const lineContent = line.replace(LRC_LINE_START, "").trim();
+
+    //? See if the lyrics are in A2 format.
+    if (LRC_A2_TIMESTAMP.test(lineContent)) {
+      const timestampStrs = lineContent.match(LRC_A2_TIMESTAMP);
+      if (!timestampStrs || timestampStrs.length === 0) continue;
+
+      //? Get words after each timestamp. We expect `timestampStrs` & `words`
+      //? to have the same length.
+      const [firstWord, ...words] = lineContent.split(LRC_A2_TIMESTAMP);
+
+      const syncWords: SynchronizedWord[] = timestampStrs
+        .map((timestamp, idx) => {
+          const word = words[idx];
+          if (word === undefined) return;
+          return {
+            startMS: parseTimestampAsMS(timestamp),
+            content: word.trim(),
+          };
+        })
+        .filter((word) => word !== undefined);
+
+      //? Assign the first word (could be an empty string) the line's timestamp.
+      if (typeof firstWord === "string") {
+        syncWords.unshift({ startMS, content: firstWord });
+      }
+
+      formattedLines.push({ startMS, content: syncWords });
+    } else {
+      formattedLines.push({
+        startMS,
+        content: [{ startMS, content: lineContent }],
+      });
+    }
+  }
+
+  return formattedLines;
+}
+
+//#region Helpers
+type Timestamp = [string, string, ...string[]];
+
+/** Regex to extract each timestamp segment. */
+const LRC_TIMESTAMP = /[0-9]+/g;
+
+function parseTimestampAsMS(timeStr: string) {
+  const [min, sec, ms = "0"] = timeStr.match(LRC_TIMESTAMP) as Timestamp;
+  return (
+    Number.parseInt(min) * 60 * 1000 +
+    Number.parseInt(sec) * 1000 +
+    Number.parseInt(ms)
+  );
+}
+//#endregion

--- a/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseLRC.ts
@@ -38,23 +38,20 @@ export function parseLRC(lyrics: string): SynchronizedLine[] {
         .map((timestamp, idx) => {
           const word = words[idx];
           if (word === undefined) return;
-          return {
-            startMS: parseTimestampAsMS(timestamp),
-            content: word.trim(),
-          };
+          return { timeMS: parseTimestampAsMS(timestamp), word: word.trim() };
         })
         .filter((word) => word !== undefined);
 
       //? Assign the first word (could be an empty string) the line's timestamp.
       if (typeof firstWord === "string") {
-        syncWords.unshift({ startMS, content: firstWord });
+        syncWords.unshift({ timeMS: startMS, word: firstWord });
       }
 
-      formattedLines.push({ startMS, content: syncWords });
+      formattedLines.push({ timeMS: startMS, words: syncWords });
     } else {
       formattedLines.push({
-        startMS,
-        content: [{ startMS, content: lineContent }],
+        timeMS: startMS,
+        words: [{ timeMS: startMS, word: lineContent }],
       });
     }
   }

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -5,9 +5,9 @@ import type { SynchronizedLine, SynchronizedWord } from "./utils";
 import { parseTimestampAsMS } from "./utils";
 
 /** Identifies a lyric line, which may contain words in the form of `<span>`. */
-const PLineRegex = /<p\b([^>]*)>(.*?)<\/p>/g;
+const PLineRegex = /<p\b([^>]*)>([\s\S]*?)<\/p>/g;
 /** Identifies the representation of a word. */
-const SpanLineRegex = /<span\b([^>]*)>(.*?)<\/span>\s*/g;
+const SpanLineRegex = /<span\b([^>]*)>([\s\S]*?)<\/span>\s*/g;
 
 /** Identifies the HTML tag portion. */
 const HTMLTagRegex = /<[^>]*>/g;

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -13,7 +13,7 @@ const PLineRegex = /<p\b([^>]*)>([\s\S]*?)<\/p>/g;
 const SpanLineRegex =
   /<span\b([^>]*)>([\s\S]*?)(<\/span>\s*){2}|<span\b([^>]*)>([\s\S]*?)<\/span>\s*/g;
 /** Identifies inner span contents. */
-const SpanContentsRegex = /<span\b[^>]*>(.*)<\/span>\s*/;
+const SpanContentsRegex = /<span\b[^>]*>([\s\S]*)<\/span>\s*/;
 
 /** Identifies the HTML tag portion. */
 const HTMLTagRegex = /<[^>]*>/g;

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -6,8 +6,14 @@ import { parseTimestampAsMS } from "./utils";
 
 /** Identifies a lyric line, which may contain words in the form of `<span>`. */
 const PLineRegex = /<p\b([^>]*)>([\s\S]*?)<\/p>/g;
-/** Identifies the representation of a word. */
-const SpanLineRegex = /<span\b([^>]*)>([\s\S]*?)<\/span>\s*/g;
+/**
+ * Identifies the representation of a word (or group of words if we get a nested span).
+ * Since it's evaluated from left-to-right, we ensure nested span matches are returned first.
+ */
+const SpanLineRegex =
+  /<span\b([^>]*)>([\s\S]*?)(<\/span>\s*){2}|<span\b([^>]*)>([\s\S]*?)<\/span>\s*/g;
+/** Identifies inner span contents. */
+const SpanContentsRegex = /<span\b[^>]*>(.*)<\/span>(\s)*/;
 
 /** Identifies the HTML tag portion. */
 const HTMLTagRegex = /<[^>]*>/g;
@@ -19,6 +25,22 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
 
   const lines = Array.from(lyrics.match(PLineRegex) ?? []);
 
+  //? Helper for tracking what goes in a `SynchronizedLine`.
+  let lineWords: SynchronizedWord[] = [];
+  const parseAndPushWord = (wordLine: string) => {
+    const attributes = parseAttributes(wordLine);
+    if (!attributes.begin) return;
+    lineWords.push({
+      timeMS: parseTimestampAsMS(attributes.begin),
+      word: wordLine.replace(HTMLTagRegex, ""),
+    });
+  };
+  const pushLine = () => {
+    if (lineWords.length === 0) return;
+    formattedLines.push({ timeMS: lineWords[0]!.timeMS, words: lineWords });
+    lineWords = [];
+  };
+
   for (const line of lines) {
     const lineAttributes = parseAttributes(line);
     if (!lineAttributes.begin) continue;
@@ -27,18 +49,27 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
     const wordLines = line.match(SpanLineRegex);
 
     if (wordLines) {
-      const syncWords: SynchronizedWord[] = wordLines
-        .map((wordLine) => {
-          const attributes = parseAttributes(wordLine);
-          if (!attributes.begin) return;
-          return {
-            timeMS: parseTimestampAsMS(attributes.begin),
-            word: wordLine.replace(HTMLTagRegex, ""),
-          };
-        })
-        .filter((word) => word !== undefined);
+      for (const wordLine of wordLines) {
+        if (wordLine.split("</span>").length - 1 === 1) {
+          //? Typical case of no nested spans.
+          parseAndPushWord(wordLine);
+        } else {
+          //? Case with nested spans, in which we create a new line.
+          pushLine();
 
-      formattedLines.push({ timeMS: startMS, words: syncWords });
+          const newLine = wordLine.match(SpanContentsRegex);
+          if (!newLine) continue;
+          //? Trailing space we want to add to the last word of this new line.
+          const trailingSpace = newLine[2] ?? "";
+
+          newLine[1]?.match(SpanLineRegex)?.forEach(parseAndPushWord);
+          if (lineWords.at(-1)) lineWords.at(-1)!.word += trailingSpace;
+
+          pushLine();
+        }
+      }
+
+      pushLine();
     } else {
       formattedLines.push({
         timeMS: startMS,

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -4,27 +4,27 @@
 import type { SynchronizedLine, SynchronizedWord } from "./utils";
 import { parseTimestampAsMS } from "./utils";
 
-/** Identifies the start of a lyric line. */
-const P_LINE_START = /<p\b([^>]*)>(.*?)<\/p>/g;
-/** Identifies the start of a word. */
-const SPAN_LINE_START = /<span\b([^>]*)>(.*?)<\/span>\s*/g;
+/** Identifies a lyric line, which may contain words in the form of `<span>`. */
+const PLineRegex = /<p\b([^>]*)>(.*?)<\/p>/g;
+/** Identifies the representation of a word. */
+const SpanLineRegex = /<span\b([^>]*)>(.*?)<\/span>\s*/g;
 
-/** Identifies the attributes in a tag. */
-const ATTRIBUTE = /(\w+)="([^"]*)"/g;
 /** Identifies the HTML tag portion. */
-const TAG = /<[^>]*>/g;
+const HTMLTagRegex = /<[^>]*>/g;
+/** Identifies the attributes in a HTML tag. */
+const HTMLAttributeRegex = /(\w+)="([^"]*)"/g;
 
 export function parseTTML(lyrics: string): SynchronizedLine[] {
   const formattedLines: SynchronizedLine[] = [];
 
-  const lines = Array.from(lyrics.match(P_LINE_START) ?? []);
+  const lines = Array.from(lyrics.match(PLineRegex) ?? []);
 
   for (const line of lines) {
     const lineAttributes = parseAttributes(line);
     if (!lineAttributes.begin) continue;
 
     const startMS = parseTimestampAsMS(lineAttributes.begin);
-    const wordLines = line.match(SPAN_LINE_START);
+    const wordLines = line.match(SpanLineRegex);
 
     if (wordLines) {
       const syncWords: SynchronizedWord[] = wordLines
@@ -33,7 +33,7 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
           if (!attributes.begin) return;
           return {
             timeMS: parseTimestampAsMS(attributes.begin),
-            word: wordLine.replace(TAG, ""),
+            word: wordLine.replace(HTMLTagRegex, ""),
           };
         })
         .filter((word) => word !== undefined);
@@ -42,7 +42,7 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
     } else {
       formattedLines.push({
         timeMS: startMS,
-        words: [{ timeMS: startMS, word: line.replace(TAG, "") }],
+        words: [{ timeMS: startMS, word: line.replace(HTMLTagRegex, "") }],
       });
     }
   }
@@ -53,10 +53,13 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
 //#region Helpers
 /** Parse the "attributes" from the starting HTML tag in the segment. */
 function parseAttributes(segment: string): Record<string, string> {
-  const startingTag = segment.match(TAG)?.[0];
+  const startingTag = segment.match(HTMLTagRegex)?.[0];
   if (!startingTag) return {};
   return Object.fromEntries(
-    Array.from(startingTag.matchAll(ATTRIBUTE), ([_, key, val]) => [key, val]),
+    Array.from(startingTag.matchAll(HTMLAttributeRegex), ([_, key, val]) => [
+      key,
+      val,
+    ]),
   );
 }
 //#endregion

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -31,17 +31,17 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
           const attributes = parseAttributes(wordLine);
           if (!attributes.begin) return;
           return {
-            startMS: parseTimestampAsMS(attributes.begin),
-            content: wordLine.replace(TAG, ""),
+            timeMS: parseTimestampAsMS(attributes.begin),
+            word: wordLine.replace(TAG, "") + " ",
           };
         })
         .filter((word) => word !== undefined);
 
-      formattedLines.push({ startMS, content: syncWords });
+      formattedLines.push({ timeMS: startMS, words: syncWords });
     } else {
       formattedLines.push({
-        startMS,
-        content: [{ startMS, content: line.replace(TAG, "") }],
+        timeMS: startMS,
+        words: [{ timeMS: startMS, word: line.replace(TAG, "") }],
       });
     }
   }

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -13,7 +13,7 @@ const PLineRegex = /<p\b([^>]*)>([\s\S]*?)<\/p>/g;
 const SpanLineRegex =
   /<span\b([^>]*)>([\s\S]*?)(<\/span>\s*){2}|<span\b([^>]*)>([\s\S]*?)<\/span>\s*/g;
 /** Identifies inner span contents. */
-const SpanContentsRegex = /<span\b[^>]*>(.*)<\/span>(\s)*/;
+const SpanContentsRegex = /<span\b[^>]*>(.*)<\/span>\s*/;
 
 /** Identifies the HTML tag portion. */
 const HTMLTagRegex = /<[^>]*>/g;
@@ -56,15 +56,9 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
         } else {
           //? Case with nested spans, in which we create a new line.
           pushLine();
-
           const newLine = wordLine.match(SpanContentsRegex);
           if (!newLine) continue;
-          //? Trailing space we want to add to the last word of this new line.
-          const trailingSpace = newLine[2] ?? "";
-
           newLine[1]?.match(SpanLineRegex)?.forEach(parseAndPushWord);
-          if (lineWords.at(-1)) lineWords.at(-1)!.word += trailingSpace;
-
           pushLine();
         }
       }

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { SynchronizedLine, SynchronizedWord } from "./utils";
+import { parseTimestampAsMS } from "./utils";
+
+/** Identifies the start of a lyric line. */
+const P_LINE_START = /<p\b([^>]*)>(.*?)<\/p>/g;
+/** Identifies the start of a word. */
+const SPAN_LINE_START = /<span\b([^>]*)>(.*?)<\/span>/g;
+
+/** Identifies the attributes in a tag. */
+const ATTRIBUTE = /(\w+)="([^"]*)"/g;
+/** Identifies the HTML tag portion. */
+const TAG = /<[^>]*>/g;
+
+export function parseTTML(lyrics: string): SynchronizedLine[] {
+  const formattedLines: SynchronizedLine[] = [];
+
+  const lines = Array.from(lyrics.match(P_LINE_START) ?? []);
+  for (const line of lines) {
+    const lineAttributes = parseAttributes(line);
+    if (!lineAttributes.begin) continue;
+
+    const startMS = parseTimestampAsMS(lineAttributes.begin);
+    const wordLines = line.match(SPAN_LINE_START);
+
+    if (wordLines) {
+      const syncWords: SynchronizedWord[] = wordLines
+        .map((wordLine) => {
+          const attributes = parseAttributes(wordLine);
+          if (!attributes.begin) return;
+          return {
+            startMS: parseTimestampAsMS(attributes.begin),
+            content: wordLine.replace(TAG, ""),
+          };
+        })
+        .filter((word) => word !== undefined);
+
+      formattedLines.push({ startMS, content: syncWords });
+    } else {
+      formattedLines.push({
+        startMS,
+        content: [{ startMS, content: line.replace(TAG, "") }],
+      });
+    }
+  }
+
+  return formattedLines;
+}
+
+//#region Helpers
+/** Parse the "attributes" from the starting HTML tag in the segment. */
+function parseAttributes(segment: string): Record<string, string> {
+  const startingTag = segment.match(TAG)?.[0];
+  if (!startingTag) return {};
+  return Object.fromEntries(
+    Array.from(startingTag.matchAll(ATTRIBUTE), ([_, key, val]) => [key, val]),
+  );
+}
+//#endregion

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -7,7 +7,7 @@ import { parseTimestampAsMS } from "./utils";
 /** Identifies the start of a lyric line. */
 const P_LINE_START = /<p\b([^>]*)>(.*?)<\/p>/g;
 /** Identifies the start of a word. */
-const SPAN_LINE_START = /<span\b([^>]*)>(.*?)<\/span>/g;
+const SPAN_LINE_START = /<span\b([^>]*)>(.*?)<\/span>\s*/g;
 
 /** Identifies the attributes in a tag. */
 const ATTRIBUTE = /(\w+)="([^"]*)"/g;
@@ -18,6 +18,7 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
   const formattedLines: SynchronizedLine[] = [];
 
   const lines = Array.from(lyrics.match(P_LINE_START) ?? []);
+
   for (const line of lines) {
     const lineAttributes = parseAttributes(line);
     if (!lineAttributes.begin) continue;
@@ -32,7 +33,7 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
           if (!attributes.begin) return;
           return {
             timeMS: parseTimestampAsMS(attributes.begin),
-            word: wordLine.replace(TAG, "") + " ",
+            word: wordLine.replace(TAG, ""),
           };
         })
         .filter((word) => word !== undefined);

--- a/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
+++ b/mobile/src/modules/lyric/helpers/parser/parseTTML.ts
@@ -27,15 +27,15 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
 
   //? Helper for tracking what goes in a `SynchronizedLine`.
   let lineWords: SynchronizedWord[] = [];
-  const parseAndPushWord = (wordLine: string) => {
-    const attributes = parseAttributes(wordLine);
+  const parseAndPushWord = (wordSpan: string) => {
+    const attributes = parseAttributes(wordSpan);
     if (!attributes.begin) return;
     lineWords.push({
       timeMS: parseTimestampAsMS(attributes.begin),
-      word: wordLine.replace(HTMLTagRegex, ""),
+      word: wordSpan.replace(HTMLTagRegex, ""),
     });
   };
-  const pushLine = () => {
+  const pushWordsAsLine = () => {
     if (lineWords.length === 0) return;
     formattedLines.push({ timeMS: lineWords[0]!.timeMS, words: lineWords });
     lineWords = [];
@@ -46,24 +46,25 @@ export function parseTTML(lyrics: string): SynchronizedLine[] {
     if (!lineAttributes.begin) continue;
 
     const startMS = parseTimestampAsMS(lineAttributes.begin);
-    const wordLines = line.match(SpanLineRegex);
+    const wordSpans = line.match(SpanLineRegex);
 
-    if (wordLines) {
-      for (const wordLine of wordLines) {
-        if (wordLine.split("</span>").length - 1 === 1) {
+    //? Handle if line is made up of words/syllables.
+    if (wordSpans) {
+      for (const wordSpan of wordSpans) {
+        if (wordSpan.split("</span>").length - 1 === 1) {
           //? Typical case of no nested spans.
-          parseAndPushWord(wordLine);
+          parseAndPushWord(wordSpan);
         } else {
           //? Case with nested spans, in which we create a new line.
-          pushLine();
-          const newLine = wordLine.match(SpanContentsRegex);
+          pushWordsAsLine();
+          const newLine = wordSpan.match(SpanContentsRegex);
           if (!newLine) continue;
           newLine[1]?.match(SpanLineRegex)?.forEach(parseAndPushWord);
-          pushLine();
+          pushWordsAsLine();
         }
       }
 
-      pushLine();
+      pushWordsAsLine();
     } else {
       formattedLines.push({
         timeMS: startMS,

--- a/mobile/src/modules/lyric/helpers/parser/types.ts
+++ b/mobile/src/modules/lyric/helpers/parser/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export type SynchronizedWord = { startMS: number; content: string };
 
 export type SynchronizedLine = { startMS: number; content: SynchronizedWord[] };

--- a/mobile/src/modules/lyric/helpers/parser/types.ts
+++ b/mobile/src/modules/lyric/helpers/parser/types.ts
@@ -1,0 +1,3 @@
+export type SynchronizedWord = { startMS: number; content: string };
+
+export type SynchronizedLine = { startMS: number; content: SynchronizedWord[] };

--- a/mobile/src/modules/lyric/helpers/parser/types.ts
+++ b/mobile/src/modules/lyric/helpers/parser/types.ts
@@ -1,6 +1,0 @@
-// Copyright (C) 2024 - present, MissingCore
-// SPDX-License-Identifier: AGPL-3.0-only
-
-export type SynchronizedWord = { startMS: number; content: string };
-
-export type SynchronizedLine = { startMS: number; content: SynchronizedWord[] };

--- a/mobile/src/modules/lyric/helpers/parser/utils.ts
+++ b/mobile/src/modules/lyric/helpers/parser/utils.ts
@@ -1,0 +1,20 @@
+// Copyright (C) 2024 - present, MissingCore
+// SPDX-License-Identifier: AGPL-3.0-only
+
+export type SynchronizedWord = { startMS: number; content: string };
+
+export type SynchronizedLine = { startMS: number; content: SynchronizedWord[] };
+
+/** Parses out ms from time string, supporting `mm:ss.xxx` & `ss:xxx`. */
+export function parseTimestampAsMS(timeStr: string) {
+  const timeSegments = timeStr.match(/[0-9]+/g);
+  if (!timeSegments) return 0;
+  const ms = timeStr.includes(".") ? timeSegments.at(-1)! : "0";
+  const sec = timeStr.at(-2)!;
+  const min = timeStr.includes(":") ? timeSegments.at(-3)! : "0";
+  return (
+    Number.parseInt(min) * 60 * 1000 +
+    Number.parseInt(sec) * 1000 +
+    Number.parseInt(ms)
+  );
+}

--- a/mobile/src/modules/lyric/helpers/parser/utils.ts
+++ b/mobile/src/modules/lyric/helpers/parser/utils.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-export type SynchronizedWord = { startMS: number; content: string };
+export type SynchronizedWord = { timeMS: number; word: string };
 
-export type SynchronizedLine = { startMS: number; content: SynchronizedWord[] };
+export type SynchronizedLine = { timeMS: number; words: SynchronizedWord[] };
 
 /** Parses out ms from time string, supporting `mm:ss.xxx` & `ss:xxx`. */
 export function parseTimestampAsMS(timeStr: string) {

--- a/mobile/src/modules/lyric/helpers/parser/utils.ts
+++ b/mobile/src/modules/lyric/helpers/parser/utils.ts
@@ -10,7 +10,7 @@ export function parseTimestampAsMS(timeStr: string) {
   const timeSegments = timeStr.match(/[0-9]+/g);
   if (!timeSegments) return 0;
   const ms = timeStr.includes(".") ? timeSegments.at(-1)! : "0";
-  const sec = timeStr.at(-2)!;
+  const sec = timeSegments.at(-2)!;
   const min = timeStr.includes(":") ? timeSegments.at(-3)! : "0";
   return (
     Number.parseInt(min) * 60 * 1000 +

--- a/mobile/src/modules/lyric/helpers/parser/utils.ts
+++ b/mobile/src/modules/lyric/helpers/parser/utils.ts
@@ -5,13 +5,20 @@ export type SynchronizedWord = { timeMS: number; word: string };
 
 export type SynchronizedLine = { timeMS: number; words: SynchronizedWord[] };
 
-/** Parses out ms from time string, supporting `mm:ss.xxx` & `ss:xxx`. */
+/** Parses out ms from time string, supporting `mm:ss.xxx` & `ss.xxx`. */
 export function parseTimestampAsMS(timeStr: string) {
-  const timeSegments = timeStr.match(/[0-9]+/g);
-  if (!timeSegments) return 0;
-  const ms = timeStr.includes(".") ? timeSegments.at(-1)! : "0";
-  const sec = timeSegments.at(-2)!;
-  const min = timeStr.includes(":") ? timeSegments.at(-3)! : "0";
+  const [_nonMSSegments, _msSegment = "000"] = timeStr.split(".");
+
+  //? Extract numeric portions in case we have other characters (ie: brackets).
+  const nonMSSegments = _nonMSSegments?.match(/[0-9]+/g);
+  const msSegment = _msSegment.match(/[0-9]+/g);
+
+  if (!nonMSSegments) return 0;
+  //? We need to pad the end of `ms` to 3 digits.
+  const ms = (msSegment?.[0] ?? "000").padEnd(3, "0").slice(0, 3);
+  const sec = nonMSSegments.at(-1) ?? "0";
+  const min = nonMSSegments.at(-2) ?? "0";
+
   return (
     Number.parseInt(min) * 60 * 1000 +
     Number.parseInt(sec) * 1000 +


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR adds support for TTML lyrics, rendering it as synchronized lines instead of a static XML string.

The hardest part really with this is figuring out how we want to handle nested `<span>`s, which are typically used to indicate background vocals. Our current strategy is that when encountered, we add a new line. This way, it's compatible with our existing lyrics rendered.
- In the future, we should maybe handle it better (ie: render it underneath the actual line and highlight it first before the actual words), which will probably call for a redesign on how we return the parsed lyric data.
- I encountered this with [`"Hard Times" by Paramore`](https://lyrics-api-docs.boidu.dev/playground/?s=Hard+Times&a=Paramore&al=After+Laughter&d=182).

### Useful Docs

- https://en.wikipedia.org/wiki/LRC_(file_format)
- https://amll.dev/en/guides/lyric/formats
- https://amll.dev/en/guides/lyric/ttml

### Other Changes

- Fixed issue where we were parsing the `ms` value incorrectly if it had less digits.
- Move lyric parsers to a new `parser` folder. If we end up wanting to support more lyric format, we might as well switch to a different package, for example: [`@applemusic-like-lyrics/lyric`](https://github.com/amll-dev/applemusic-like-lyrics/tree/main/packages/lyric) to handle the parsing for us.
- Lyrics start & end "centered" on the allocated space.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] New files have the SPDX license identifier at the top of the file.
- [x] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for synchronized lyrics in LRC, LRC A2, and TTML formats.
  * Added word- and syllable-level timing where supported.
  * Unsupported lyric formats display as static text.
  * Clicking a synchronized lyric line seeks playback to its start.

* **Improvements**
  * Improved synchronized lyric rendering across supported formats.
  * TTML content, including background vocals, can render as separate lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->