### PR TITLE
fix: Some flaws with our listening session tracking

### DIFF
--- a/mobile/src/modules/insights/core/TrackListeningSession.ts
+++ b/mobile/src/modules/insights/core/TrackListeningSession.ts
@@ -38,13 +38,7 @@ function createTrackListeningSession() {
      * called when a new track is played.
      */
     start: async (uri: string) => {
-      //? In case AudioBrowser throws (ie: when it's not ready).
-      let isPlaying = false;
-      try {
-        isPlaying = AudioBrowser.getPlayingState().playing;
-      } catch {}
-
-      if (!isPlaying) return reset();
+      if (!AudioBrowser.getPlayingState().playing) return reset();
       const track = await db.query.tracks.findFirst({
         columns: { id: true },
         where: (fields, { eq }) => eq(fields.uri, uri),

--- a/mobile/src/modules/insights/core/TrackListeningSession.ts
+++ b/mobile/src/modules/insights/core/TrackListeningSession.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { sql } from "drizzle-orm";
+import AudioBrowser from "react-native-audio-browser";
 
 import { db } from "~/db";
 import { tracksPlayEvents } from "~/db/schema";
-
-import { playbackStore } from "~/stores/Playback/store";
 
 type ListeningSession = {
   trackId: string;
@@ -39,7 +38,7 @@ function createTrackListeningSession() {
      * called when a new track is played.
      */
     start: async (uri: string) => {
-      if (!playbackStore.getState().isPlaying) return reset();
+      if (!AudioBrowser.getPlayingState().playing) return reset();
       const track = await db.query.tracks.findFirst({
         columns: { id: true },
         where: (fields, { eq }) => eq(fields.uri, uri),
@@ -67,6 +66,14 @@ function createTrackListeningSession() {
     /** Take a snapshot of the playback of the current track. */
     finalize: async ({ paused = false }: { paused?: boolean } = {}) => {
       if (!session) return;
+
+      //? Handles edge case where the `finalize` called when the app is killed
+      //? when already in a paused state would incorrectly update the existing
+      //? session entry, resulting in an inflated value.
+      if (hasPaused) {
+        if (!paused) reset();
+        return;
+      }
 
       const { eventId, trackId, playedAt } = session;
       const { elapsedTime, nextTime } = derivePlayTimes(session);

--- a/mobile/src/modules/insights/core/TrackListeningSession.ts
+++ b/mobile/src/modules/insights/core/TrackListeningSession.ts
@@ -38,7 +38,13 @@ function createTrackListeningSession() {
      * called when a new track is played.
      */
     start: async (uri: string) => {
-      if (!AudioBrowser.getPlayingState().playing) return reset();
+      //? In case AudioBrowser throws (ie: when it's not ready).
+      let isPlaying = false;
+      try {
+        isPlaying = AudioBrowser.getPlayingState().playing;
+      } catch {}
+
+      if (!isPlaying) return reset();
       const track = await db.query.tracks.findFirst({
         columns: { id: true },
         where: (fields, { eq }) => eq(fields.uri, uri),

--- a/mobile/src/modules/insights/core/TrackListeningSession.ts
+++ b/mobile/src/modules/insights/core/TrackListeningSession.ts
@@ -93,6 +93,9 @@ function createTrackListeningSession() {
         reset();
       }
 
+      //? To help ensure we mutate the same session during a "pause" event.
+      const currentSession = session;
+
       if (nextTime > MIN_PLAY_TIME) {
         //? If `eventId` is defined, we just want to add the elapsed time
         //? to the existing value.
@@ -109,7 +112,9 @@ function createTrackListeningSession() {
             })
             .returning({ id: tracksPlayEvents.id });
 
-          if (paused && sessionEvent?.id) session.eventId = sessionEvent.id;
+          if (paused && session === currentSession && sessionEvent?.id) {
+            session.eventId = sessionEvent.id;
+          }
         } catch (err) {
           console.error("[TrackListeningSession] Failed to record event.", err);
         }

--- a/mobile/src/modules/startup/audioBrowser/registerEvents.ts
+++ b/mobile/src/modules/startup/audioBrowser/registerEvents.ts
@@ -70,7 +70,7 @@ export function registerEvents() {
   AudioBrowser.onPlaybackChanged.addListener(async (e) => {
     if (e.state === "paused" || e.state === "stopped") {
       playbackStore.setState({ isPlaying: false });
-      await TrackListeningSession.finalize({ paused: true });
+      await TrackListeningSession.finalize({ paused: e.state === "paused" });
     } else if (e.state === "loading") {
       const { repeat, activeTrack } = playbackStore.getState();
       if (repeat === "repeat-one" && activeTrack) {

--- a/mobile/src/modules/startup/migrations/constants.ts
+++ b/mobile/src/modules/startup/migrations/constants.ts
@@ -9,7 +9,8 @@ export type MigrationOption =
   | "onboarding-flow"
   | "clear-image-cache"
   | "waveform-slider"
-  | "geist-font";
+  | "geist-font"
+  | "insane-play-event-time";
 
 /**
  * History of data migrations due to "breaking" changes.
@@ -35,5 +36,8 @@ export const MigrationHistory: Record<
   },
   4: { version: "v3.4.0-rc.0", changes: ["clear-image-cache"] },
   5: { version: "v3.5.0-rc.0", changes: ["waveform-slider"] },
-  6: { version: "v3.6.0-rc.0", changes: ["geist-font"] },
+  6: {
+    version: "v3.6.0-rc.0",
+    changes: ["geist-font", "insane-play-event-time"],
+  },
 };

--- a/mobile/src/modules/startup/migrations/index.ts
+++ b/mobile/src/modules/startup/migrations/index.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 - present, MissingCore
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { inArray } from "drizzle-orm";
+import { gt, inArray } from "drizzle-orm";
 import { Image } from "expo-image";
 import AsyncStorage from "expo-sqlite/kv-store";
 
@@ -12,6 +12,7 @@ import {
   hiddenTracks,
   playlists,
   tracks,
+  tracksPlayEvents,
   tracksToArtists,
   tracksToPlaylists,
   waveformSamples,
@@ -228,5 +229,14 @@ const MigrationFunctionMap: Record<
     if (isString(primaryFont) && removedFonts.includes(primaryFont)) {
       preferenceStore.setState({ primaryFont: "Geist" });
     }
+  },
+  "insane-play-event-time": async () => {
+    //? Delete any `tracksPlayEvents` greater than 30 minutes due to a flaw
+    //? with the sleep timer completion not finalizing the session, resulting
+    //? in the possibility of a giant entry being added when we play a different
+    //? track of close the app.
+    await db
+      .delete(tracksPlayEvents)
+      .where(gt(tracksPlayEvents.playTime, 30 * 60));
   },
 };

--- a/mobile/src/stores/Playback/actions/playbackControls.ts
+++ b/mobile/src/stores/Playback/actions/playbackControls.ts
@@ -4,6 +4,7 @@
 import AudioBrowser from "react-native-audio-browser";
 
 import { preferenceStore } from "~/stores/Preference/store";
+import { TrackListeningSession } from "~/modules/insights/core/TrackListeningSession";
 import { playbackStore } from "../store";
 import { RepeatModes } from "../constants";
 import type { PlayFromSource } from "../types";
@@ -81,6 +82,8 @@ export async function stop() {
     _restoredTrackKey: playbackStore.getState().activeKey,
   });
   AudioBrowser.reset();
+  //? Finalize listening session here as it won't through the `onPlaybackChanged` event.
+  TrackListeningSession.finalize();
   revalidateWidgets({ openApp: true });
 }
 

--- a/mobile/src/stores/Playback/store.ts
+++ b/mobile/src/stores/Playback/store.ts
@@ -5,6 +5,7 @@ import AudioBrowser from "react-native-audio-browser";
 import { useStore } from "zustand";
 
 import { getTrack } from "~/data/track/api";
+import { TrackListeningSession } from "~/modules/insights/core/TrackListeningSession";
 
 import { createPersistedStore } from "~/lib/zustand";
 import { resetWidgets } from "~/modules/widget/utils/update";
@@ -45,6 +46,9 @@ export const playbackStore = createPersistedStore<PlaybackStore>(
       }
     },
     reset: async () => {
+      //? We should finalize whatever listening session is active currently.
+      await TrackListeningSession.finalize();
+
       set({
         _hasHydrated: true,
         _hasRestoredPosition: false,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

This PR addresses some issues that I've noticed after observed an inflated play count of tracks that I'm pretty sure I haven't played for the time indicated during developing.

I observed that we can inflate the playtime in 2 different scenarios:
1. We paused the current playing track, wait a while, then kill the app.
   - The time between pausing the playing track and when we killed the app will be added to the paused session due to calling `TrackListeningSession.finalize()` in the app killed event.
   - `TrackListeningSession.finalize()` didn't take into account of the playing state, so if called when the session is currently paused, it will add the time difference to the current session (which is paused).
2. We drag the miniplayer to reset the playback store, wait a while, then play a different track.
   - In this situation, the session for the previously playing track (before we reset the playback store) is still present.
   - When we call `TrackListeningSession.finalize()` when playing a new track, the prior session will finalize based on the current time.

In addition, we noticed that we weren't finalizing the session when the sleep timer finishes, which can lead to a giant playtime session being added for reasons similar to the above.
- We added a migration to remove any affected entries (ie: `tracksPlayEvents` with `play_time` greater than 30 minutes).

> [!NOTE]
> We do plan on adding a feature to "optimize" the database, which would collapse the rows for a track in a given month into a single entry, saving database space. This would probably enable us to simplify the `TrackListeningSession` to ignore the "paused" case.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] New files have the SPDX license identifier at the top of the file.
- [ ] Documentation is up to date to reflect these changes.
- [ ] Ensure dependency licenses are up-to-date by running `pnpm sync:licenses`.
- [x] This diff will work correctly for `pnpm android:prod`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved listening-time tracking when playback is paused, stopped, interrupted, or the app is closed.
  - Prevented listening sessions from recording excessive play time after sleep-timer completion or interrupted playback.
  - Ensured active listening sessions are finalized when playback is manually stopped or reset.
  - Corrected playback state handling so stopped playback is no longer recorded as paused.
  - Added a one-time cleanup for previously recorded listening events exceeding 30 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->